### PR TITLE
Support keyfiles

### DIFF
--- a/data/org.freedesktop.UDisks2.xml
+++ b/data/org.freedesktop.UDisks2.xml
@@ -1226,7 +1226,7 @@
     <!--
         Format:
         @type: The type of file system, partition table or other content to format the device with.
-        @options: Options - known options (in addition to <link linkend="udisks-std-options">standard options</link>) includes <parameter>label</parameter> (of type 's'), <parameter>take-ownership</parameter> (of type 'b'), <parameter>encrypt.passphrase</parameter> (of type 's'), <parameter>erase</parameter> (of type 's'), <parameter>no-block</parameter> (of type 'b') and <parameter>update-partition-type</parameter> (of type 'b').
+        @options: Options - known options (in addition to <link linkend="udisks-std-options">standard options</link>) includes <parameter>label</parameter> (of type 's'), <parameter>take-ownership</parameter> (of type 'b'), <parameter>encrypt.passphrase</parameter> (of type 's' or 'ay'), <parameter>erase</parameter> (of type 's'), <parameter>no-block</parameter> (of type 'b') and <parameter>update-partition-type</parameter> (of type 'b').
 
         Formats the device with a file system, partition table or
         other well-known content.
@@ -1254,7 +1254,9 @@
         If the option <parameter>encrypt.passphrase</parameter> is
         given then a LUKS device is created with the given passphrase
         and the file system is created on the unlocked device. The
-        unlocked device will be left open.
+        unlocked device will be left open. This parameter can be used
+        to supply the binary contents of an arbitrary keyfile by passing
+        a value of type <quote>ay</quote>.
 
         If the option <parameter>erase</parameter> is used then the
         underlying device will be erased. Valid values include

--- a/data/org.freedesktop.UDisks2.xml
+++ b/data/org.freedesktop.UDisks2.xml
@@ -1764,7 +1764,7 @@
     <!--
         Unlock:
         @passphrase: The passphrase to use.
-        @options: Options (currently unused except for <link linkend="udisks-std-options">standard options</link>).
+        @options: Options - known options (in addition to <link linkend="udisks-std-options">standard options</link>) includes <parameter>keyfile_contents</parameter> (of type 'ay') which is preferred over @passphrase if specified.
         @cleartext_device: An object path to the unlocked object implementing the #org.freedesktop.UDisks2.Block interface.
 
         Tries to unlock the encrypted device using @passphrase.

--- a/doc/man/udisksctl.xml.in
+++ b/doc/man/udisksctl.xml.in
@@ -70,6 +70,7 @@
         <arg choice="plain">--block-device <replaceable>DEVICE</replaceable></arg>
       </group>
       <arg choice="opt">--no-user-interaction</arg>
+      <arg choice="opt">--key-file <replaceable>PATH</replaceable></arg>
     </cmdsynopsis>
 
     <cmdsynopsis>

--- a/src/tests/integration-test
+++ b/src/tests/integration-test
@@ -1451,6 +1451,38 @@ class Luks(UDisksTestCase):
 
         # correct password
         encrypted.call_unlock_sync('', self.keyfile_options(KEYFILE), None)
+        encrypted.call_lock_sync(no_options, None)
+
+    def test_ascii_keyfile_newline(self):
+
+        KEYFILE = b'ascii string\nwith newline\n'
+
+        # setup crypto device
+        self.fs_create(None, 'ext4', GLib.Variant('a{sv}', {
+            'encrypt.passphrase': GLib.Variant('ay', KEYFILE),
+            'label': GLib.Variant('s', 'treasure')}))
+        crypt_obj = self.client.get_object(self.udisks_block().get_object_path())
+        encrypted = crypt_obj.get_property('encrypted')
+        encrypted.call_lock_sync(no_options, None)
+
+        # wrong password
+        missing_byte = self.keyfile_options(KEYFILE[:-1])
+        extra_bytes = self.keyfile_options(KEYFILE+b'\0X')
+        self.assertRaises(GLib.GError, encrypted.call_unlock_sync,
+                          'h4ckpassword', no_options, None)
+        self.assertRaises(GLib.GError, encrypted.call_unlock_sync,
+                          '', missing_byte, None)
+        self.assertRaises(GLib.GError, encrypted.call_unlock_sync,
+                          '', extra_bytes, None)
+
+        # correct password
+        encrypted.call_unlock_sync('', self.keyfile_options(KEYFILE), None)
+        encrypted.call_lock_sync(no_options, None)
+
+        # Currently, we mimic cryptsetup which in passphrase-mode stops input
+        # at the first newline:
+        self.assertRaises(GLib.GError, encrypted.call_unlock_sync,
+                          KEYFILE.decode('utf-8'), no_options, None)
 
 
 # ----------------------------------------------------------------------------

--- a/src/tests/integration-test
+++ b/src/tests/integration-test
@@ -1392,7 +1392,7 @@ class Luks(UDisksTestCase):
     def test_keyfile_equivalent(self):
         '''Setup device using passphrase, unlock using keyfile.'''
         encrypted = self.setup_crypto_device()
-        # wrong password, has bytes after a trailing NUL
+        # wrong password, has bytes after a trailing '\0'
         self.assertRaises(GLib.GError, encrypted.call_unlock_sync,
                           '', self.keyfile_options(b's3kr1t\0X'), None)
         self.assertRaises(GLib.GError, encrypted.call_unlock_sync,

--- a/src/tests/integration-test
+++ b/src/tests/integration-test
@@ -1206,6 +1206,20 @@ class Smart(UDisksTestCase):
 class Luks(UDisksTestCase):
     '''Check LUKS.'''
 
+    def setup_crypto_device(self):
+        self.fs_create(None, 'ext4', GLib.Variant('a{sv}', {
+            'encrypt.passphrase': GLib.Variant('s', 's3kr1t'),
+            'label': GLib.Variant('s', 'treasure')}))
+        self.client.settle()
+        crypt_obj = self.client.get_object(self.udisks_block().get_object_path())
+        encrypted = crypt_obj.get_property('encrypted')
+        encrypted.call_lock_sync(no_options, None)
+        return encrypted
+
+    def unlock_crypto_device(self, encrypted):
+        return encrypted.call_unlock_sync(
+            's3kr1t', no_options, None)
+
     def tearDown(self):
         '''clean up behind failed test cases'''
 
@@ -1223,18 +1237,16 @@ class Luks(UDisksTestCase):
     def test_0_create_teardown(self):
         '''LUKS create/teardown'''
 
-        self.fs_create(None, 'ext4', GLib.Variant('a{sv}', {
-            'encrypt.passphrase': GLib.Variant('s', 's3kr1t'),
-            'label': GLib.Variant('s', 'treasure')}))
-        self.client.settle()
+        encrypted = self.setup_crypto_device()
+
+        block = self.udisks_block()
+        obj = self.client.get_object(block.get_object_path())
+        self.assertEqual(obj.get_property('filesystem'), None)
+        encrypted = obj.get_property('encrypted')
+        self.assertNotEqual(encrypted, None)
+        clear_dev = None
 
         try:
-            block = self.udisks_block()
-            obj = self.client.get_object(block.get_object_path())
-            self.assertEqual(obj.get_property('filesystem'), None)
-            encrypted = obj.get_property('encrypted')
-            self.assertNotEqual(encrypted, None)
-
             # check crypted device info
             self.assertEqual(block.get_property('id-type'), 'crypto_LUKS')
             self.assertEqual(block.get_property('id-usage'), 'crypto')
@@ -1244,7 +1256,6 @@ class Luks(UDisksTestCase):
 
             # check whether we can lock/unlock; we also need this to get the
             # cleartext device
-            encrypted.call_lock_sync(no_options, None)
             self.assertRaises(GLib.GError, encrypted.call_lock_sync,
                               no_options, None)
 
@@ -1252,8 +1263,7 @@ class Luks(UDisksTestCase):
             self.assertRaises(GLib.GError, encrypted.call_unlock_sync,
                               'h4ckpassword', no_options, None)
             # right password
-            clear_path = encrypted.call_unlock_sync('s3kr1t',
-                                                    no_options, None)
+            clear_path = self.unlock_crypto_device(encrypted)
 
             # check cleartext device info
             clear_obj = self.client.get_object(clear_path)
@@ -1281,15 +1291,15 @@ class Luks(UDisksTestCase):
         finally:
             # tear down cleartext device
             encrypted.call_lock_sync(no_options, None)
-            self.assertFalse(os.path.exists(clear_dev))
+            if clear_dev is not None:
+                self.assertFalse(os.path.exists(clear_dev))
 
     def test_luks_mount(self):
         '''LUKS mount/unmount'''
 
-        crypt_obj = self.client.get_object(self.udisks_block().get_object_path())
-        encrypted = crypt_obj.get_property('encrypted')
+        encrypted = self.setup_crypto_device()
 
-        path = encrypted.call_unlock_sync('s3kr1t', no_options, None)
+        path = self.unlock_crypto_device(encrypted)
         self.client.settle()
         obj = self.client.get_object(path)
         fs = obj.get_property('filesystem')
@@ -1326,9 +1336,9 @@ class Luks(UDisksTestCase):
         '''LUKS forced removal'''
 
         # unlock and mount it
+        encrypted = self.setup_crypto_device()
         crypt_obj = self.client.get_object(self.udisks_block().get_object_path())
-        path = crypt_obj.get_property('encrypted').call_unlock_sync(
-            's3kr1t', no_options, None)
+        path = self.unlock_crypto_device(encrypted)
         try:
             fs = self.client.get_object(path).get_property('filesystem')
             mount_path = fs.call_mount_sync(no_options, None)
@@ -1355,9 +1365,7 @@ class Luks(UDisksTestCase):
                 self.readd_devices()
 
             # after putting it back, it should be mountable again
-            crypt_obj = self.client.get_object(self.udisks_block().get_object_path())
-            path = crypt_obj.get_property('encrypted').call_unlock_sync(
-                's3kr1t', no_options, None)
+            path = self.unlock_crypto_device(encrypted)
             self.client.settle()
             fs = self.client.get_object(path).get_property('filesystem')
             mount_path = fs.call_mount_sync(no_options, None)
@@ -1375,6 +1383,74 @@ class Luks(UDisksTestCase):
                 no_options, None)
             self.client.settle()
             self.assertEqual(self.client.get_object(path), None)
+
+    def keyfile_options(self, keyfile_contents):
+        return GLib.Variant('a{sv}', {
+            'keyfile_contents': GLib.Variant('ay', keyfile_contents)
+        })
+
+    def test_keyfile_equivalent(self):
+        '''Setup device using passphrase, unlock using keyfile.'''
+        encrypted = self.setup_crypto_device()
+        # wrong password, has bytes after a trailing NUL
+        self.assertRaises(GLib.GError, encrypted.call_unlock_sync,
+                          '', self.keyfile_options(b's3kr1t\0X'), None)
+        self.assertRaises(GLib.GError, encrypted.call_unlock_sync,
+                          '', self.keyfile_options(b's3kr1t\n'), None)
+        # correct password, specified as keyfile
+        encrypted.call_unlock_sync('', self.keyfile_options(b's3kr1t'), None)
+        encrypted.call_lock_sync(no_options, None)
+
+    def test_plaintext_keyfile(self):
+        '''Setup a device using a plaintext keyfile.'''
+        # Using a plaintext keyfile should be equivalent to passphrase
+        self.fs_create(None, 'ext4', GLib.Variant('a{sv}', {
+            'encrypt.passphrase': GLib.Variant('ay', b's3kr1t'),
+            'label': GLib.Variant('s', 'treasure')}))
+
+        crypt_obj = self.client.get_object(self.udisks_block().get_object_path())
+        encrypted = crypt_obj.get_property('encrypted')
+        encrypted.call_lock_sync(no_options, None)
+
+        # wrong password
+        self.assertRaises(GLib.GError, encrypted.call_unlock_sync,
+                          'h4ckpassword', no_options, None)
+        self.assertRaises(GLib.GError, encrypted.call_unlock_sync,
+                          '', self.keyfile_options(b's3kr1t\0X'), None)
+        self.assertRaises(GLib.GError, encrypted.call_unlock_sync,
+                          '', self.keyfile_options(b's3kr1t\n'), None)
+
+        # correct password
+        encrypted.call_unlock_sync('', self.keyfile_options(b's3kr1t'), None)
+        encrypted.call_lock_sync(no_options, None)
+
+        # correct password, specified as passphrase
+        encrypted.call_unlock_sync('s3kr1t', no_options, None)
+        encrypted.call_lock_sync(no_options, None)
+
+    def test_binary_keyfile(self):
+
+        KEYFILE = b's\0me \bina\ry \xda\ta\0\0\1\1\xff\xff'
+
+        self.fs_create(None, 'ext4', GLib.Variant('a{sv}', {
+            'encrypt.passphrase': GLib.Variant('ay', KEYFILE),
+            'label': GLib.Variant('s', 'treasure')}))
+        crypt_obj = self.client.get_object(self.udisks_block().get_object_path())
+        encrypted = crypt_obj.get_property('encrypted')
+        encrypted.call_lock_sync(no_options, None)
+
+        # wrong password
+        missing_byte = self.keyfile_options(KEYFILE[:-1])
+        extra_bytes = self.keyfile_options(KEYFILE+b'\0X')
+        self.assertRaises(GLib.GError, encrypted.call_unlock_sync,
+                          'h4ckpassword', no_options, None)
+        self.assertRaises(GLib.GError, encrypted.call_unlock_sync,
+                          '', missing_byte, None)
+        self.assertRaises(GLib.GError, encrypted.call_unlock_sync,
+                          '', extra_bytes, None)
+
+        # correct password
+        encrypted.call_unlock_sync('', self.keyfile_options(KEYFILE), None)
 
 
 # ----------------------------------------------------------------------------

--- a/src/udisksdaemon.c
+++ b/src/udisksdaemon.c
@@ -825,7 +825,7 @@ udisks_daemon_launch_spawned_job (UDisksDaemon    *daemon,
  *
  * This function is the same as udisks_daemon_launch_spawned_job, with
  * the only difference that it takes a GString and is therefore able to
- * handle binary inputs that contain NUL bytes.
+ * handle binary inputs that contain '\0' bytes.
  *
  * Returns: A #UDisksSpawnedJob object. Do not free, the object
  * belongs to @manager.
@@ -999,7 +999,7 @@ udisks_daemon_launch_spawned_job_sync (UDisksDaemon    *daemon,
  *
  * This function is the same as udisks_daemon_launch_spawned_job_sync, with
  * the only difference that it takes a GString and is therefore able to
- * handle binary inputs that contain NUL bytes.
+ * handle binary inputs that contain '\0' bytes.
  *
  * Returns: The @success parameter of the #UDisksJob::completed signal.
  */

--- a/src/udisksdaemonutil.c
+++ b/src/udisksdaemonutil.c
@@ -81,10 +81,10 @@ void udisks_string_wipe_and_free (GString *string)
  * Looks up binary data in a dictionary #GVariant and returns it as #GString.
  *
  * If the value is a bytestring ("ay"), it can contain arbitrary binary data
- * including NUL values. If the value is a string ("s"), @out_text does not
- * include the terminating NUL character.
+ * including '\0' values. If the value is a string ("s"), @out_text does not
+ * include the terminating '\0' character.
  *
- * Returns: %TRUE if @dict contains an item @name of type "ay" that was
+ * Returns: %TRUE if @dict contains an item @name of type "ay" or "s" that was
  * successfully stored in @out_text, and %FALSE otherwise.
  */
 gboolean
@@ -107,11 +107,11 @@ udisks_variant_lookup_binary (GVariant     *dict,
  * it as a #GString.
  *
  * If the value is a bytestring ("ay"), it can contain arbitrary binary data
- * including NUL values. If the value is a string ("s"), @out_text does not
- * include the terminating NUL character.
+ * including '\0' values. If the value is a string ("s"), @out_text does not
+ * include the terminating '\0' character.
  *
- * Returns: %TRUE if @value is a bytestring #GVariant and was successfully
- * stored in @out_text, and %FALSE otherwise.
+ * Returns: %TRUE if @value is a bytestring or string #GVariant and was
+ * successfully stored in @out_text, and %FALSE otherwise.
  */
 gboolean
 udisks_variant_get_binary (GVariant  *value,
@@ -122,7 +122,6 @@ udisks_variant_get_binary (GVariant  *value,
 
   if (g_variant_is_of_type (value, G_VARIANT_TYPE_STRING))
       str = g_variant_get_string (value, &size);
-
   else if (g_variant_is_of_type (value, G_VARIANT_TYPE_BYTESTRING))
       str = g_variant_get_fixed_array (value, &size, sizeof (guchar));
 

--- a/src/udisksdaemonutil.c
+++ b/src/udisksdaemonutil.c
@@ -73,6 +73,70 @@ void udisks_string_wipe_and_free (GString *string)
 }
 
 /**
+ * udisks_variant_lookup_binary:
+ * @dict: A dictionary #GVariant.
+ * @name: The name of the item to lookup.
+ * @out_text: (out): Return location for the binary text as #GString.
+ *
+ * Looks up binary data in a dictionary #GVariant and returns it as #GString.
+ *
+ * If the value is a bytestring ("ay"), it can contain arbitrary binary data
+ * including NUL values. If the value is a string ("s"), @out_text does not
+ * include the terminating NUL character.
+ *
+ * Returns: %TRUE if @dict contains an item @name of type "ay" that was
+ * successfully stored in @out_text, and %FALSE otherwise.
+ */
+gboolean
+udisks_variant_lookup_binary (GVariant     *dict,
+                              const gchar  *name,
+                              GString     **out_text)
+{
+  GVariant* item = g_variant_lookup_value (dict, name, NULL);
+  if (item)
+    return udisks_variant_get_binary (item, out_text);
+  return FALSE;
+}
+
+/**
+ * udisks_variant_get_binary:
+ * @value: A #GVariant of type "ay" or "s".
+ * @out_text: (out): Return location for the binary text as #GString.
+ *
+ * Gets binary data contained in a BYTEARRAY or STRING #GVariant and returns
+ * it as a #GString.
+ *
+ * If the value is a bytestring ("ay"), it can contain arbitrary binary data
+ * including NUL values. If the value is a string ("s"), @out_text does not
+ * include the terminating NUL character.
+ *
+ * Returns: %TRUE if @value is a bytestring #GVariant and was successfully
+ * stored in @out_text, and %FALSE otherwise.
+ */
+gboolean
+udisks_variant_get_binary (GVariant  *value,
+                           GString  **out_text)
+{
+  const gchar* str = NULL;
+  gsize size = 0;
+
+  if (g_variant_is_of_type (value, G_VARIANT_TYPE_STRING))
+      str = g_variant_get_string (value, &size);
+
+  else if (g_variant_is_of_type (value, G_VARIANT_TYPE_BYTESTRING))
+      str = g_variant_get_fixed_array (value, &size, sizeof (guchar));
+
+  if (str)
+    {
+      *out_text = g_string_new_len (str, size);
+      return TRUE;
+    }
+
+  return FALSE;
+}
+
+
+/**
  * udisks_decode_udev_string:
  * @str: An udev-encoded string or %NULL.
  *

--- a/src/udisksdaemonutil.h
+++ b/src/udisksdaemonutil.h
@@ -27,6 +27,13 @@ G_BEGIN_DECLS
 
 void udisks_string_wipe_and_free (GString*);
 
+gboolean udisks_variant_lookup_binary (GVariant     *dict,
+                                       const gchar  *name,
+                                       GString     **contents);
+
+gboolean udisks_variant_get_binary (GVariant  *variant,
+                                    GString  **contents);
+
 gchar *udisks_decode_udev_string (const gchar *str);
 
 void udisks_safe_append_to_object_path (GString      *str,

--- a/src/udiskslinuxencrypted.c
+++ b/src/udiskslinuxencrypted.c
@@ -247,32 +247,6 @@ has_option (const gchar *options,
 
 /* ---------------------------------------------------------------------------------------------------- */
 
-static gboolean
-lookup_binary_blob (GVariant     *dict,
-                    const gchar  *name,
-                    GString     **contents)
-{
-  GVariantIter *iter;
-  guchar byte;
-  gsize size = 0;
-  gsize index = 0;
-
-  if (!g_variant_lookup (dict, name, "ay", &iter))
-    return FALSE;
-
-  size = g_variant_iter_n_children (iter);
-  *contents = g_string_sized_new (size);
-  (*contents)->len = size;
-
-  while (g_variant_iter_loop (iter, "y", &byte))
-    {
-      (*contents)->str[index++] = byte;
-    }
-
-  g_variant_iter_free (iter);
-  return TRUE;
-}
-
 /* runs in thread dedicated to handling @invocation */
 static gboolean
 handle_unlock (UDisksEncrypted        *encrypted,
@@ -415,7 +389,7 @@ handle_unlock (UDisksEncrypted        *encrypted,
     name = g_strdup_printf ("luks-%s", udisks_block_get_id_uuid (block));
   escaped_name = udisks_daemon_util_escape_and_quote (name);
 
-  if (lookup_binary_blob (options, "keyfile_contents", &effective_passphrase))
+  if (udisks_variant_lookup_binary (options, "keyfile_contents", &effective_passphrase))
     {
       use_keyfile = TRUE;
     }


### PR DESCRIPTION
Dear storaged folks,

I'm trying to add support for unlocking LUKS devices using binary data as was suggested for udisks [here](https://lists.freedesktop.org/archives/devkit-devel/2012-September/001315.html). There is also a corresponding [udisks ticket](https://bugs.freedesktop.org/show_bug.cgi?id=54828) where I tried to get in the patch.

I am now turning to you in the hope that storaged is more actively maintained and because I have seen talk about merging with udisks anyway.

Some more remarks:

I had to replace the `gchar* input_string` argument for the spawn/launch functions by a `GString` to make them work with binary data. For the `udisks_spawned_job_new` function, I simply changed the parameter type, since this function is used in only one place. For the `udisks_daemon_launch_spawned_job*` functions, I created variants accepting a `GString` since they were used all over the code base. Although I feel that C strings should ultimately be replaced by the likes of `GString`, I didn't go the extra mile for this PR. Please tell me if you're unhappy with either of these choices.

(this is a rebased and slightly squashed version of the changeset listed [here](https://github.com/coldfix/udisks/pull/1))