### PR TITLE
Use libblockdev for LUKS operations

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -532,6 +532,27 @@ if test "x$have_fs" = "xno"; then
   AC_MSG_ERROR([BLOCKDEV FS support requested but header or library not found])
 fi
 
+# libblockdev crypto
+SAVE_CFLAGS=$CFLAGS
+SAVE_LDFLAGS=$LDFLAGS
+
+CFLAGS="$GLIB_CFLAGS"
+LDFLAGS="$GLIB_LIBS"
+AC_MSG_CHECKING([libblockdev-crypto presence])
+AC_TRY_COMPILE([#include <blockdev/crypto.h>], [],
+               [AC_MSG_RESULT([yes])
+               have_crypto=yes],
+               [AC_MSG_RESULT([no])
+               have_crypto=no])
+
+CFLAGS=$SAVE_CFLAGS
+LDFLAGS=$SAVE_LDFLAGS
+
+if test "x$have_crypto" = "xno"; then
+  AC_MSG_ERROR([BLOCKDEV CRYPTO support requested but header or library not found])
+fi
+
+
 # Internationalization
 #
 

--- a/packaging/udisks2.spec.in
+++ b/packaging/udisks2.spec.in
@@ -7,7 +7,7 @@
 %global libblockdev_version             2.1
 %global with_gtk_doc                    1
 %global with_libblockdev_part           @have_libblockdev_part_spec@
-%global libblockdev_version             2.1
+%global libblockdev_version             2.4
 
 %define is_fedora                       0%{?rhel} == 0
 %define is_git                          %(git show > /dev/null 2>&1 && echo 1 || echo 0)
@@ -39,13 +39,14 @@ BuildRequires: chrpath
 BuildRequires: gtk-doc
 BuildRequires: intltool
 BuildRequires: redhat-rpm-config
-BuildRequires: libblockdev-devel  >= %{libblockdev_version}
-BuildRequires: libblockdev-part-devel  >= %{libblockdev_version}
-BuildRequires: libblockdev-btrfs-devel >= %{libblockdev_version}
-BuildRequires: libblockdev-kbd-devel   >= %{libblockdev_version}
-BuildRequires: libblockdev-swap-devel  >= %{libblockdev_version}
+BuildRequires: libblockdev-devel        >= %{libblockdev_version}
+BuildRequires: libblockdev-part-devel   >= %{libblockdev_version}
+BuildRequires: libblockdev-btrfs-devel  >= %{libblockdev_version}
+BuildRequires: libblockdev-kbd-devel    >= %{libblockdev_version}
+BuildRequires: libblockdev-swap-devel   >= %{libblockdev_version}
 BuildRequires: libblockdev-mdraid-devel >= %{libblockdev_version}
-BuildRequires: libblockdev-fs-devel  >= %{libblockdev_version}
+BuildRequires: libblockdev-fs-devel     >= %{libblockdev_version}
+BuildRequires: libblockdev-crypto-devel >= %{libblockdev_version}
 
 # Needed to pull in the system bus daemon
 Requires: dbus >= %{dbus_version}
@@ -62,8 +63,6 @@ Requires: xfsprogs
 # For mkfs.vfat
 Requires: dosfstools
 Requires: gdisk
-# For LUKS devices
-Requires: cryptsetup-luks
 # For ejecting removable disks
 Requires: eject
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -58,6 +58,7 @@ libudisks_daemon_la_SOURCES =                                                  \
 	udiskslinuxpartitiontable.h    udiskslinuxpartitiontable.c             \
 	udiskslinuxfilesystem.h        udiskslinuxfilesystem.c                 \
 	udiskslinuxencrypted.h         udiskslinuxencrypted.c                  \
+	udiskslinuxencryptedhelpers.h udiskslinuxencryptedhelpers.c            \
 	udiskslinuxswapspace.h         udiskslinuxswapspace.c                  \
 	udiskslinuxloop.h              udiskslinuxloop.c                       \
 	udiskslinuxdriveobject.h       udiskslinuxdriveobject.c                \

--- a/src/tests/integration-test
+++ b/src/tests/integration-test
@@ -1479,10 +1479,9 @@ class Luks(UDisksTestCase):
         encrypted.call_unlock_sync('', self.keyfile_options(KEYFILE), None)
         encrypted.call_lock_sync(no_options, None)
 
-        # Currently, we mimic cryptsetup which in passphrase-mode stops input
+        # We no longer mimic cryptsetup which in passphrase-mode stops input
         # at the first newline:
-        self.assertRaises(GLib.GError, encrypted.call_unlock_sync,
-                          KEYFILE.decode('utf-8'), no_options, None)
+        encrypted.call_unlock_sync(KEYFILE.decode('utf-8'), no_options, None)
 
 
 # ----------------------------------------------------------------------------

--- a/src/udisksdaemon.c
+++ b/src/udisksdaemon.c
@@ -252,13 +252,13 @@ udisks_daemon_constructed (GObject *object)
   BDPluginSpec swap_plugin = {BD_PLUGIN_SWAP, NULL};
   BDPluginSpec mdraid_plugin = {BD_PLUGIN_MDRAID, NULL};
   BDPluginSpec fs_plugin = {BD_PLUGIN_FS, NULL};
+  BDPluginSpec crypto_plugin = {BD_PLUGIN_CRYPTO, NULL};
 
-  /* the core daemon only needs the part, swap, mdraid and fs plugin, additional
-     plugins are required by various modules, but they make sure plugins are
-     loaded themselves */
+  /* The core daemon needs the part, swap, mdraid, fs and crypto plugins.
+     Additional plugins are required by various modules, but they make sure
+     plugins are loaded themselves. */
   BDPluginSpec *plugins[] = {&part_plugin, &swap_plugin, &mdraid_plugin,
-                             &fs_plugin, NULL};
-
+                             &fs_plugin, &crypto_plugin, NULL};
   error = NULL;
 
   ret = bd_ensure_init (plugins, NULL, &error);

--- a/src/udiskslinuxencryptedhelpers.c
+++ b/src/udiskslinuxencryptedhelpers.c
@@ -1,0 +1,74 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*-
+ *
+ * Copyright (C) 2017 Red Hat, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * Author: Vratislav Podzimek <vpodzime@redhat.com>
+ *
+ */
+
+#include <glib.h>
+#include <blockdev/crypto.h>
+
+#include "udisksthreadedjob.h"
+#include "udiskslinuxencryptedhelpers.h"
+
+gboolean luks_format_job_func (UDisksThreadedJob  *job,
+                      GCancellable       *cancellable,
+                      gpointer            user_data,
+                      GError            **error)
+{
+  LuksJobData *data = (LuksJobData*) user_data;
+
+  /* device, cipher, key_size, passphrase, key_file, min_entropy, error */
+  return bd_crypto_luks_format_blob (data->device, NULL, 0,
+                                     (const guint8*) data->passphrase->str, data->passphrase->len, 0,
+                                     error);
+}
+
+gboolean luks_open_job_func (UDisksThreadedJob  *job,
+                    GCancellable       *cancellable,
+                    gpointer            user_data,
+                    GError            **error)
+{
+  LuksJobData *data = (LuksJobData*) user_data;
+
+  /* device, name, passphrase, key_file, read_only, error */
+  return bd_crypto_luks_open_blob (data->device, data->map_name,
+                                   (const guint8*) data->passphrase->str, data->passphrase->len, data->read_only,
+                                   error);
+}
+
+gboolean luks_close_job_func (UDisksThreadedJob  *job,
+                    GCancellable       *cancellable,
+                    gpointer            user_data,
+                    GError            **error)
+{
+  LuksJobData *data = (LuksJobData*) user_data;
+  return bd_crypto_luks_close (data->map_name, error);
+}
+
+gboolean luks_change_key_job_func (UDisksThreadedJob  *job,
+                          GCancellable       *cancellable,
+                          gpointer            user_data,
+                          GError            **error)
+{
+  LuksJobData *data = (LuksJobData*) user_data;
+  return bd_crypto_luks_change_key_blob (data->device,
+                                         (const guint8*) data->passphrase->str, data->passphrase->len,
+                                         (const guint8*) data->new_passphrase->str, data->new_passphrase->len,
+                                         error);
+}

--- a/src/udiskslinuxencryptedhelpers.h
+++ b/src/udiskslinuxencryptedhelpers.h
@@ -1,0 +1,64 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*-
+ *
+ * Copyright (C) 2017 Red Hat, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * Author: Vratislav Podzimek <vpodzime@redhat.com>
+ *
+ */
+
+#ifndef __UDISKS_LINUX_ENCRYPTED_HELPERS_H__
+#define __UDISKS_LINUX_ENCRYPTED_HEPLERS_H__
+
+#include <glib.h>
+#include <blockdev/crypto.h>
+
+#include "udisksthreadedjob.h"
+
+G_BEGIN_DECLS
+
+typedef struct {
+  const gchar *device;
+  const gchar *map_name;
+  GString *passphrase;
+  GString *new_passphrase;
+  gboolean read_only;
+} LuksJobData;
+
+
+gboolean luks_format_job_func (UDisksThreadedJob  *job,
+                               GCancellable       *cancellable,
+                               gpointer            user_data,
+                               GError            **error);
+
+gboolean luks_open_job_func (UDisksThreadedJob  *job,
+                             GCancellable       *cancellable,
+                             gpointer            user_data,
+                             GError            **error);
+
+gboolean luks_close_job_func (UDisksThreadedJob  *job,
+                              GCancellable       *cancellable,
+                              gpointer            user_data,
+                              GError            **error);
+
+gboolean luks_change_key_job_func (UDisksThreadedJob  *job,
+                                   GCancellable       *cancellable,
+                                   gpointer            user_data,
+                                   GError            **error);
+
+G_END_DECLS
+
+#endif /* __UDISKS_LINUX_ENCRYPTED_HELPERS_H__ */


### PR DESCRIPTION
Please note that this PR builds on top of PR #194.

This needs three things to be done:
- [x] add support for synchronous threaded jobs
- [x] use *libblockdev* for LUKS operations with text/ASCII passphrases
- [x] use *libblockdev* for LUKS opeartions with binary passphrases (due to #184, requires a new function to be added to *libblockdev-crypto* first)