### PR TITLE
Do not run MD RAID tests on Fedora 25

### DIFF
--- a/src/tests/dbus-tests/test_10_basic.py
+++ b/src/tests/dbus-tests/test_10_basic.py
@@ -11,11 +11,8 @@ class UdisksBaseTest(udiskstestcase.UdisksTestCase):
         self.manager_obj = self.get_object('/Manager')
 
     def _get_modules(self):
-        content = self.read_file('/etc/os-release')
-        release = {key: value for (key, value) in [line.split('=') for line in content.split('\n') if line]}
-        distro = release['ID'].replace('"', '')
-
-        if distro in ('redhat', 'centos'):
+        project, distro, version = self.distro
+        if ((project, distro) in (('redhat', 'enterprise_linux'), ('centos', 'centos')) and version.startswith("7")):
             return self.udisks_modules - {'Bcache'}
         else:
             return self.udisks_modules

--- a/src/tests/dbus-tests/test_mdraid.py
+++ b/src/tests/dbus-tests/test_mdraid.py
@@ -33,6 +33,15 @@ class RAIDLevel(udiskstestcase.UdisksTestCase):
     chunk_size = 0
 
     def setUp(self):
+        try:
+            with open("/etc/redhat-release", "r") as f:
+                if f.read().startswith("Fedora release 25"):
+                    self.skipTest("Skipping hanging MD RAID tests on Fedora 25")
+        except OSError:
+            # we tried our best, if the file doesn't exist or is unreadable,
+            # just move on
+            pass
+
         if len(self.vdevs) < self.min_members:
             raise ValueError('Not enough members for %s' % self.level)
 

--- a/src/tests/dbus-tests/test_mdraid.py
+++ b/src/tests/dbus-tests/test_mdraid.py
@@ -33,14 +33,8 @@ class RAIDLevel(udiskstestcase.UdisksTestCase):
     chunk_size = 0
 
     def setUp(self):
-        try:
-            with open("/etc/redhat-release", "r") as f:
-                if f.read().startswith("Fedora release 25"):
-                    self.skipTest("Skipping hanging MD RAID tests on Fedora 25")
-        except OSError:
-            # we tried our best, if the file doesn't exist or is unreadable,
-            # just move on
-            pass
+        if self.distro[1:] == ("fedora", "25"):
+            self.skipTest("Skipping hanging MD RAID tests on Fedora 25")
 
         if len(self.vdevs) < self.min_members:
             raise ValueError('Not enough members for %s' % self.level)

--- a/src/tests/dbus-tests/udiskstestcase.py
+++ b/src/tests/dbus-tests/udiskstestcase.py
@@ -130,6 +130,7 @@ class UdisksTestCase(unittest.TestCase):
     path_prefix = None
     bus = None
     vdevs = None
+    distro = (None, None, None)       # (project, distro_name, version)
     no_options = dbus.Dictionary(signature="sv")
 
 
@@ -138,6 +139,14 @@ class UdisksTestCase(unittest.TestCase):
         self.iface_prefix = 'org.freedesktop.UDisks2'
         self.path_prefix = '/org/freedesktop/UDisks2'
         self.bus = dbus.SystemBus()
+
+        # get information about the distribution from systemd (hostname1)
+        sys_info = self.bus.get_object("org.freedesktop.hostname1", "/org/freedesktop/hostname1")
+        cpe = str(sys_info.Get("org.freedesktop.hostname1", "OperatingSystemCPEName", dbus_interface=dbus.PROPERTIES_IFACE))
+
+        # 2nd to 4th fields from e.g. "cpe:/o:fedoraproject:fedora:25" or "cpe:/o:redhat:enterprise_linux:7.3:GA:server"
+        self.distro = tuple(cpe.split(":")[2:5])
+
         self._orig_call_async = self.bus.call_async
         self._orig_call_blocking = self.bus.call_blocking
         self.bus.call_async = get_call_long(self._orig_call_async)


### PR DESCRIPTION
They sometimes hang hard (in some syscall, cannot be killed). But if we disable
them, we can at least run all the other tests on a stable Fedora.