### PR TITLE
Use smaller scsi_debug devices for integration tests

### DIFF
--- a/src/tests/integration-test
+++ b/src/tests/integration-test
@@ -69,7 +69,7 @@ sys.path.insert(0, os.path.dirname(__file__))
 import test_polkitd
 
 # GI_TYPELIB_PATH=udisks LD_LIBRARY_PATH=udisks/.libs
-VDEV_SIZE = 300000000  # size of virtual test device
+VDEV_SIZE = 64000000  # size of virtual test device
 
 # Those file systems are known to have a broken handling of permissions, in
 # particular the executable bit


### PR DESCRIPTION
scsi_debug devices are allocated/backed in RAM and for some reason (don't wanna
waste time on this) they can have very limitted size on the i686
architecture. But we don't need the device(s) to be 300 MB big for any test,
64 MB works just fine.