### PR TITLE
Fallback to crypttab passphrase only if none given

### DIFF
--- a/data/org.freedesktop.UDisks2.xml
+++ b/data/org.freedesktop.UDisks2.xml
@@ -1776,6 +1776,10 @@
         then name, options and passphrase (if available) is used from that
         file after requesting additional authorization.
 
+        If an empty passphrase should be used to unlock the device, it has to be
+        passed using the @keyfile_contents parameter. Empty string passed as
+        @passphrase means "Use the passphrase from the configuration file".
+
         If the device is removed without being locked (e.g. the user
         yanking the device or pulling the media out) the cleartext
         device will be cleaned up.

--- a/src/tests/dbus-tests/test_70_encrypted.py
+++ b/src/tests/dbus-tests/test_70_encrypted.py
@@ -106,6 +106,12 @@ class UdisksEncryptedTest(udiskstestcase.UdisksTestCase):
         objects = udisks.GetManagedObjects(dbus_interface='org.freedesktop.DBus.ObjectManager')
         self.assertNotIn(str(luks.object_path), objects.keys())
 
+        # no password
+        msg = 'org.freedesktop.UDisks2.Error.Failed: No key available.*'
+        with self.assertRaisesRegex(dbus.exceptions.DBusException, msg):
+            disk.Unlock("", self.no_options,
+                        dbus_interface=self.iface_prefix + '.Encrypted')
+
         # wrong password
         msg = 'org.freedesktop.UDisks2.Error.Failed: Error unlocking %s *' % self.vdevs[0]
         with self.assertRaisesRegex(dbus.exceptions.DBusException, msg):


### PR DESCRIPTION
If given a passphrase explicitly, we should use it instead of trying to dig
something up from /etc/crypttab. If we are given no passphrase, we should report
an error. But since there's no way to pass None/NULL as a value for argument of
type "s" over DBus, we have to treat an empty string as no passphrase. However,
an empty string is a valid LUKS passphrase so we still need to provide a way to
pass it. This is now possible with the new 'keyfile_contents' optional argument
we just need to mention the trick in the documentation.

Please note that there's no change in behavior here because an empty string
passed as a value for the 'passphrase' argument hasn't (ever?) been working
before this change.