### PR TITLE
Remove the deprecated --no-debug from the udisks2.service file

### DIFF
--- a/data/udisks2.service.in
+++ b/data/udisks2.service.in
@@ -5,7 +5,7 @@ Documentation=man:udisks(8)
 [Service]
 Type=dbus
 BusName=org.freedesktop.UDisks2
-ExecStart=@udisksdprivdir@/udisksd --no-debug
+ExecStart=@udisksdprivdir@/udisksd
 KillSignal=SIGINT
 
 [Install]


### PR DESCRIPTION
Commit 52367c11f4edac673cf749d230707b04706395b2 removed the --no-debug flag from
org.freedesktop.UDisks2.service.in but udisks2.service still carries the --no-debug
flag and issues to following warning when started:

udisksd[2261]: The --no-debug option is deprecated and ignored. See '--help'.