### PR TITLE
Fix dependency for udevadm (#1424869)

### DIFF
--- a/packaging/udisks2.spec.in
+++ b/packaging/udisks2.spec.in
@@ -46,7 +46,7 @@ BuildRequires: libblockdev-swap-devel  >= %{libblockdev_version}
 # Needed to pull in the system bus daemon
 Requires: dbus >= %{dbus_version}
 # Needed to pull in the udev daemon
-Requires: systemd >= %{systemd_version}
+Requires: systemd-udev >= %{systemd_version}
 # We need at least this version for bugfixes/features etc.
 Requires: libatasmart >= %{libatasmart_version}
 # For mount, umount, mkswap


### PR DESCRIPTION
udevadm is now provided by 'systemd-udev', not by 'systemd'.