### PR TITLE
Fix permissions when mounting HFS+

### DIFF
--- a/src/udiskslinuxfilesystem.c
+++ b/src/udiskslinuxfilesystem.c
@@ -318,6 +318,13 @@ static const gchar *exfat_allow[] = { "dmask=", "errors=", "fmask=", "iocharset=
 static const gchar *exfat_allow_uid_self[] = { "uid=", NULL };
 static const gchar *exfat_allow_gid_self[] = { "gid=", NULL };
 
+/* ---------------------- hfs+ -------------------- */
+
+static const gchar *hfsplus_defaults[] = { "uid=", "gid=", "nls=utf8", NULL };
+static const gchar *hfsplus_allow[] = { "creator=", "type=", "umask=", "session=", "part=", "decompose", "nodecompose", "force", "nls=", NULL };
+static const gchar *hfsplus_allow_uid_self[] = { "uid=", NULL };
+static const gchar *hfsplus_allow_gid_self[] = { "gid=", NULL };
+
 /* ------------------------------------------------ */
 /* TODO: support context= */
 
@@ -330,6 +337,7 @@ static const FSMountOptions fs_mount_options[] =
     { "iso9660", iso9660_defaults, iso9660_allow, iso9660_allow_uid_self, iso9660_allow_gid_self },
     { "udf", udf_defaults, udf_allow, udf_allow_uid_self, udf_allow_gid_self },
     { "exfat", exfat_defaults, exfat_allow, exfat_allow_uid_self, exfat_allow_gid_self },
+    { "hfsplus", hfsplus_defaults, hfsplus_allow, hfsplus_allow_uid_self, hfsplus_allow_gid_self },
   };
 
 /* ------------------------------------------------ */


### PR DESCRIPTION
HFS+ supports "uid" and "gid" options for mounting (similarly to
VFAT or NTFS), so we should use these when mounting on behalf of
a non-root user.

--------------
This fixes #211

Before:
```
$ cat /proc/mounts
/dev/sdc1 /run/media/vtrefny/untitled hfsplus rw,nosuid,nodev,relatime,umask=22,uid=0,gid=0,nls=utf8 0 0
```

```
$ ls -la /run/media/vtrefny/untitled
total 0
drwxr-xr-x. 1 root root  3 Apr 12 12:11 .
```

After:
```
$ cat /proc/mounts
/dev/sdc1 /run/media/vtrefny/untitled hfsplus rw,nosuid,nodev,relatime,umask=22,uid=1001,gid=1001,nls=utf8 0 0
```

```
$ ls -la /run/media/vtrefny/untitled
total 0
drwxr-xr-x. 1 vtrefny vtrefny  3 Apr 12 11:51 .
```