### PR TITLE
Misc test fixes

### DIFF
--- a/src/tests/integration-test
+++ b/src/tests/integration-test
@@ -81,10 +81,10 @@ no_options = GLib.Variant('a{sv}', {})
 # ----------------------------------------------------------------------------
 
 class UDisksTestCase(unittest.TestCase):
-    '''Base class for udisks test cases.
+    """Base class for udisks test cases.
 
     This provides static functions which are useful for all test cases.
-    '''
+    """
     daemon = None
     daemon_path = None
     daemon_log = None
@@ -95,7 +95,7 @@ class UDisksTestCase(unittest.TestCase):
 
     @classmethod
     def init(klass, logfile=None):
-        '''start daemon and set up test environment'''
+        """start daemon and set up test environment"""
 
         if os.geteuid() != 0:
             print('this test suite needs to run as root', file=sys.stderr)
@@ -139,7 +139,7 @@ class UDisksTestCase(unittest.TestCase):
 
     @classmethod
     def cleanup(klass):
-        '''stop daemon again and clean up test environment'''
+        """stop daemon again and clean up test environment"""
 
         subprocess.call(['umount', klass.device], stderr=subprocess.PIPE)  # if a test failed
 
@@ -182,12 +182,12 @@ class UDisksTestCase(unittest.TestCase):
 
     @classmethod
     def sync(klass):
-        '''Wait until pending events finished processing.
+        """Wait until pending events finished processing.
 
         This should only be called for situations where we genuinely have an
         asynchronous response, like invoking a CLI program and waiting for
         udev/udisks to catch up on the change events.
-        '''
+        """
         subprocess.call(['udevadm', 'settle'])
         context = GLib.main_context_default()
         timeout = 100
@@ -208,10 +208,10 @@ class UDisksTestCase(unittest.TestCase):
 
     @classmethod
     def devname(klass, partition=None, cd=False):
-        '''Get name of test device or one of its partitions
+        """Get name of test device or one of its partitions
 
         If cd is True, return the CD device, otherwise the hard disk device.
-        '''
+        """
         if cd:
             dev = klass.cd_device
         else:
@@ -226,10 +226,10 @@ class UDisksTestCase(unittest.TestCase):
 
     @classmethod
     def udisks_block(klass, partition=None, cd=False):
-        '''Get UDisksBlock object for test device or partition
+        """Get UDisksBlock object for test device or partition
 
         If cd is True, return the CD device, otherwise the hard disk device.
-        '''
+        """
         assert klass.client
         devname = klass.devname(partition, cd)
         dev_t = os.stat(devname).st_rdev
@@ -239,18 +239,18 @@ class UDisksTestCase(unittest.TestCase):
 
     @classmethod
     def udisks_filesystem(klass, partition=None, cd=False):
-        '''Get UDisksFilesystem object for test device or partition
+        """Get UDisksFilesystem object for test device or partition
 
         Return None if there is no file system on that device.
 
         If cd is True, return the CD device, otherwise the hard disk device.
-        '''
+        """
         block = klass.udisks_block(partition, cd)
         return klass.client.get_object(block.get_object_path()).get_filesystem()
 
     @classmethod
     def blkid(klass, partition=None, device=None):
-        '''Call blkid and return dictionary of results.'''
+        """Call blkid and return dictionary of results."""
 
         if not device:
             device = klass.devname(partition)
@@ -264,13 +264,13 @@ class UDisksTestCase(unittest.TestCase):
 
     @classmethod
     def is_mountpoint(klass, path):
-        '''Check if given path is a mount point.'''
+        """Check if given path is a mount point."""
 
         return subprocess.call(['mountpoint', path], stdout=subprocess.PIPE) == 0
 
     @classmethod
     def mkfs(klass, type, label=None, partition=None):
-        '''Create file system using mkfs.'''
+        """Create file system using mkfs."""
 
         if type == 'minix':
             assert label is None, 'minix does not support labels'
@@ -313,14 +313,14 @@ class UDisksTestCase(unittest.TestCase):
 
     @classmethod
     def fs_create(klass, partition, type, options):
-        '''Create file system using udisks.'''
+        """Create file system using udisks."""
 
         block = klass.udisks_block(partition)
         block.call_format_sync(type, options, None)
 
     @classmethod
     def retry_busy(klass, fn, *args):
-        '''Call a function until it does not fail with "Busy".'''
+        """Call a function until it does not fail with "Busy"."""
 
         timeout = 10
         while timeout >= 0:
@@ -335,7 +335,7 @@ class UDisksTestCase(unittest.TestCase):
 
     @classmethod
     def check_build_tree_config(klass):
-        '''Check configuration of build tree'''
+        """Check configuration of build tree"""
 
         # read make variables
         make_vars = {}
@@ -369,12 +369,12 @@ class UDisksTestCase(unittest.TestCase):
 
     @classmethod
     def setup_vdev(klass):
-        '''create virtual test devices
+        """create virtual test devices
 
         It is zeroed out initially.
 
         Return a pair (writable HD device path, readonly CD device path).
-        '''
+        """
         # ensure that the scsi_debug module is loaded
         if os.path.isdir('/sys/module/scsi_debug'):
             sys.stderr.write('The scsi_debug module is already loaded; please '
@@ -442,14 +442,14 @@ class UDisksTestCase(unittest.TestCase):
 
     @classmethod
     def teardown_vdev(klass, device):
-        '''release and remove virtual test device'''
+        """release and remove virtual test device"""
 
         klass.remove_device(device)
         assert subprocess.call(['rmmod', 'scsi_debug']) == 0, 'Failure to rmmod scsi_debug'
 
     @classmethod
     def remove_device(klass, device):
-        '''remove virtual test device'''
+        """remove virtual test device"""
 
         device = device.split('/')[-1]
         if os.path.exists('/sys/block/' + device):
@@ -463,7 +463,7 @@ class UDisksTestCase(unittest.TestCase):
 
     @classmethod
     def readd_devices(klass):
-        '''re-add virtual test devices after removal'''
+        """re-add virtual test devices after removal"""
 
         scan_files = glob('/sys/bus/pseudo/devices/adapter*/host*/scsi_host/host*/scan')
         assert len(scan_files) > 0
@@ -478,11 +478,11 @@ class UDisksTestCase(unittest.TestCase):
         klass.sync()
 
     def assertEventually(self, fn, value):
-        '''Check that an function is eventually equal to value.
+        """Check that an function is eventually equal to value.
 
         This is mostly meant for checking object properties, as these are
         updated asynchronously. This retries up to 10 times.
-        '''
+        """
         retries = 10
         while retries > 0:
             if fn() == value:
@@ -497,13 +497,13 @@ class UDisksTestCase(unittest.TestCase):
             self.assertEqual(fn(), value)
 
     def assertProperty(self, obj, name, value):
-        '''Check that an object's property is eventually equal to value'''
+        """Check that an object's property is eventually equal to value"""
 
         self.assertEventually(lambda: obj.get_property(name), value)
 
     @classmethod
     def write_stderr(klass, msg):
-        '''Write to stderr without buffering'''
+        """Write to stderr without buffering"""
         sys.stderr.write(msg)
         sys.stderr.flush()
 
@@ -511,15 +511,15 @@ class UDisksTestCase(unittest.TestCase):
 # ----------------------------------------------------------------------------
 
 class Manager(UDisksTestCase):
-    '''UDisksManager operations'''
+    """UDisksManager operations"""
 
     def test_version(self):
-        '''daemon version'''
+        """daemon version"""
 
         self.assertTrue(self.manager.get_property('version')[0].isdigit())
 
     def test_loop_rw(self):
-        '''loop device R/W'''
+        """loop device R/W"""
 
         with tempfile.NamedTemporaryFile() as f:
             f.truncate(100000000)
@@ -554,7 +554,7 @@ class Manager(UDisksTestCase):
                 loop.call_delete_sync(no_options, None)
 
     def test_loop_ro(self):
-        '''loop device R/O'''
+        """loop device R/O"""
 
         with tempfile.NamedTemporaryFile() as f:
             f.truncate(100000000)
@@ -591,14 +591,14 @@ class Manager(UDisksTestCase):
 # ----------------------------------------------------------------------------
 
 class Drive(UDisksTestCase):
-    '''UDisksDrive'''
+    """UDisksDrive"""
 
     def setUp(self):
         self.drive = self.client.get_drive_for_block(self.udisks_block())
         self.assertNotEqual(self.drive, None)
 
     def test_properties(self):
-        '''properties of UDisksDrive object'''
+        """properties of UDisksDrive object"""
 
         self.assertEqual(self.drive.get_property('model'), 'scsi_debug')
         self.assertEqual(self.drive.get_property('vendor'), 'Linux')
@@ -613,7 +613,7 @@ class Drive(UDisksTestCase):
 # ----------------------------------------------------------------------------
 
 class FS(UDisksTestCase):
-    '''Test detection of all supported file systems'''
+    """Test detection of all supported file systems"""
 
     def setUp(self):
         self.workdir = tempfile.mkdtemp()
@@ -626,7 +626,7 @@ class FS(UDisksTestCase):
         shutil.rmtree(self.workdir)
 
     def test_zero(self):
-        '''properties of zeroed out device'''
+        """properties of zeroed out device"""
 
         self.zero_device()
         self.assertProperty(self.block, 'device', self.device)
@@ -643,15 +643,15 @@ class FS(UDisksTestCase):
         self.assertEqual(obj.get_property('partition-table'), None)
 
     def test_exfat(self):
-        '''fs: exFAT'''
+        """fs: exFAT"""
         self._do_fs_check('exfat')
 
     def test_ext4(self):
-        '''fs: ext4'''
+        """fs: ext4"""
         self._do_fs_check('ext4')
 
     def test_empty(self):
-        '''fs: empty'''
+        """fs: empty"""
 
         self.mkfs('ext4', 'foo')
         block = self.udisks_block()
@@ -668,7 +668,7 @@ class FS(UDisksTestCase):
         self.assertEqual(self.udisks_filesystem(), None)
 
     def test_create_fs_unknown_type(self):
-        '''Format() with unknown type'''
+        """Format() with unknown type"""
 
         try:
             self.fs_create(None, 'bogus', no_options)
@@ -678,7 +678,7 @@ class FS(UDisksTestCase):
             self.assertIn('type bogus', e.message)
 
     def test_create_fs_unsupported_label(self):
-        '''Format() with unsupported label'''
+        """Format() with unsupported label"""
 
         options = GLib.Variant('a{sv}', {'label': GLib.Variant('s', 'foo')})
         try:
@@ -688,7 +688,7 @@ class FS(UDisksTestCase):
             self.assertIn('UDisks2.Error.NotSupported', e.message)
 
     def test_force_removal(self):
-        '''fs: forced removal'''
+        """fs: forced removal"""
 
         # create a fs and mount it
         self.mkfs('ext4', 'udiskstest')
@@ -720,7 +720,7 @@ class FS(UDisksTestCase):
         self.assertProperty(fs, 'mount-points', [])
 
     def test_existing_manual_mount_point(self):
-        '''fs: does not reuse existing manual mount point'''
+        """fs: does not reuse existing manual mount point"""
 
         self.mkfs('ext4', 'udiskstest')
         fs = self.udisks_filesystem()
@@ -748,7 +748,7 @@ class FS(UDisksTestCase):
             os.rmdir(mount_path)
 
     def test_existing_udisks_mount_point(self):
-        '''fs: reuses existing udisks mount point'''
+        """fs: reuses existing udisks mount point"""
 
         self.mkfs('ext4', 'udiskstest')
         fs = self.udisks_filesystem()
@@ -774,7 +774,7 @@ class FS(UDisksTestCase):
         self.assertEqual(new_mount_path, mount_path)
 
     def _do_fs_check(self, type):
-        '''Run checks for a particular file system.'''
+        """Run checks for a particular file system."""
         if type == 'ntfs':
             mkfs = 'mkntfs'
         else:
@@ -816,7 +816,7 @@ class FS(UDisksTestCase):
             self._do_udisks_check(type, '')
 
     def _do_cli_check(self, type, label=None):
-        '''udisks correctly picks up file system changes from command line tools'''
+        """udisks correctly picks up file system changes from command line tools"""
 
         self.mkfs(type, label)
 
@@ -879,7 +879,7 @@ class FS(UDisksTestCase):
         self.assertProperty(fs, 'mount-points', [])
 
     def _do_udisks_check(self, type, label=None):
-        '''udisks API correctly changes file system'''
+        """udisks API correctly changes file system"""
 
         # create fs
         if label is not None:
@@ -1028,11 +1028,11 @@ class FS(UDisksTestCase):
                 self.assertProperty(cd_fs, 'mount-points', [])
 
     def _do_file_perms_checks(self, type, mount_point):
-        '''Check for permissions for data files and executables.
+        """Check for permissions for data files and executables.
 
         This particularly checks sane and useful permissions on non-Unix file
         systems like vfat.
-        '''
+        """
         if type in BROKEN_PERMISSIONS_FS:
             return
 
@@ -1065,7 +1065,7 @@ class FS(UDisksTestCase):
 # ----------------------------------------------------------------------------
 
 class Fstab(UDisksTestCase):
-    '''Test /etc/fstab custom options'''
+    """Test /etc/fstab custom options"""
 
     @classmethod
     def setUpClass(kls):
@@ -1108,7 +1108,7 @@ class Fstab(UDisksTestCase):
         self.retry_busy(self.fs.call_unmount_sync, no_options, None)
 
     def test_devname(self):
-        '''by device name'''
+        """by device name"""
 
         with open('/etc/fstab', 'a') as f:
             f.write('%s %s ext4 defaults,nosuid,noexec 0 0\n' %
@@ -1117,7 +1117,7 @@ class Fstab(UDisksTestCase):
         self.do_test()
 
     def test_label(self):
-        '''by label'''
+        """by label"""
 
         with open('/etc/fstab', 'a') as f:
             f.write('LABEL=udtestfst %s ext4 defaults,nosuid,noexec 0 0\n' %
@@ -1126,7 +1126,7 @@ class Fstab(UDisksTestCase):
         self.do_test()
 
     def test_partuuid(self):
-        '''by PARTUUID'''
+        """by PARTUUID"""
 
         with open('/etc/fstab', 'a') as f:
             f.write('PARTUUID=%s %s ext4 defaults,nosuid,noexec 0 0\n' %
@@ -1136,7 +1136,7 @@ class Fstab(UDisksTestCase):
         self.do_test()
 
     def test_partlabel(self):
-        '''by PARTLABEL'''
+        """by PARTLABEL"""
 
         with open('/etc/fstab', 'a') as f:
             f.write('PARTLABEL=%s %s ext4 defaults,nosuid,noexec 0 0\n' %
@@ -1146,7 +1146,7 @@ class Fstab(UDisksTestCase):
         self.do_test()
 
     def test_uuid(self):
-        '''by UUID'''
+        """by UUID"""
 
         with open('/etc/fstab', 'a') as f:
             f.write('UUID=%s %s ext4 defaults,nosuid,noexec 0 0\n' %
@@ -1172,13 +1172,13 @@ class Fstab(UDisksTestCase):
 # ----------------------------------------------------------------------------
 
 class Smart(UDisksTestCase):
-    '''Check SMART operation.'''
+    """Check SMART operation."""
 
     def test_sda(self):
-        '''SMART status of first internal hard disk
+        """SMART status of first internal hard disk
 
         This is a best-effort readonly test.
-        '''
+        """
         hd = '/dev/sda'
         has_smart = False
 
@@ -1224,7 +1224,7 @@ class Smart(UDisksTestCase):
 # ----------------------------------------------------------------------------
 
 class Luks(UDisksTestCase):
-    '''Check LUKS.'''
+    """Check LUKS."""
 
     def setup_crypto_device(self):
         self.fs_create(None, 'ext4', GLib.Variant('a{sv}', {
@@ -1241,7 +1241,7 @@ class Luks(UDisksTestCase):
             's3kr1t', no_options, None)
 
     def tearDown(self):
-        '''clean up behind failed test cases'''
+        """clean up behind failed test cases"""
 
         crypt_obj = self.client.get_object(self.udisks_block().get_object_path())
         if crypt_obj:
@@ -1255,7 +1255,7 @@ class Luks(UDisksTestCase):
 
     # needs to run before the other tests
     def test_0_create_teardown(self):
-        '''LUKS create/teardown'''
+        """LUKS create/teardown"""
 
         encrypted = self.setup_crypto_device()
 
@@ -1315,7 +1315,7 @@ class Luks(UDisksTestCase):
                 self.assertFalse(os.path.exists(clear_dev))
 
     def test_luks_mount(self):
-        '''LUKS mount/unmount'''
+        """LUKS mount/unmount"""
 
         encrypted = self.setup_crypto_device()
 
@@ -1353,7 +1353,7 @@ class Luks(UDisksTestCase):
             self.assertEqual(self.client.get_object(path), None)
 
     def test_luks_forced_removal(self):
-        '''LUKS forced removal'''
+        """LUKS forced removal"""
 
         # unlock and mount it
         encrypted = self.setup_crypto_device()
@@ -1410,7 +1410,7 @@ class Luks(UDisksTestCase):
         })
 
     def test_keyfile_equivalent(self):
-        '''Setup device using passphrase, unlock using keyfile.'''
+        """Setup device using passphrase, unlock using keyfile."""
         encrypted = self.setup_crypto_device()
         # wrong password, has bytes after a trailing '\0'
         self.assertRaises(GLib.GError, encrypted.call_unlock_sync,
@@ -1422,7 +1422,7 @@ class Luks(UDisksTestCase):
         encrypted.call_lock_sync(no_options, None)
 
     def test_plaintext_keyfile(self):
-        '''Setup a device using a plaintext keyfile.'''
+        """Setup a device using a plaintext keyfile."""
         # Using a plaintext keyfile should be equivalent to passphrase
         self.fs_create(None, 'ext4', GLib.Variant('a{sv}', {
             'encrypt.passphrase': GLib.Variant('ay', b's3kr1t'),
@@ -1563,10 +1563,10 @@ class Luks(UDisksTestCase):
 # ----------------------------------------------------------------------------
 
 class Polkit(UDisksTestCase, test_polkitd.PolkitTestCase):
-    '''Check operation with polkit.'''
+    """Check operation with polkit."""
 
     def test_internal_fs_forbidden(self):
-        '''Create FS on internal drive (forbidden)'''
+        """Create FS on internal drive (forbidden)"""
 
         self.start_polkitd(['org.freedesktop.udisks2.modify-device'])
 
@@ -1580,7 +1580,7 @@ class Polkit(UDisksTestCase, test_polkitd.PolkitTestCase):
         self.assertNotEqual(block.get_property('id-label'), 'polkitno')
 
     def test_internal_fs_allowed(self):
-        '''Create FS on internal drive (allowed)'''
+        """Create FS on internal drive (allowed)"""
 
         self.start_polkitd(['org.freedesktop.udisks2.modify-device-system',
                             'org.freedesktop.udisks2.modify-device'])
@@ -1593,7 +1593,7 @@ class Polkit(UDisksTestCase, test_polkitd.PolkitTestCase):
         self.assertEqual(block.get_property('id-label'), 'polkityes')
 
     def test_removable_fs(self):
-        '''Mount FS on removable drive (allowed)'''
+        """Mount FS on removable drive (allowed)"""
 
         self.mkfs('ext4', 'polkityes')
         self.start_polkitd(['org.freedesktop.udisks2.filesystem-mount',

--- a/src/tests/integration-test
+++ b/src/tests/integration-test
@@ -1073,6 +1073,12 @@ class FS(UDisksTestCase):
 
 class Fstab(UDisksTestCase):
     """Test /etc/fstab custom options"""
+    block = None
+    fs = None
+    mount_point = ""
+    orig_fstab = ""
+    p1label = ""
+    p1uuid = ""
 
     @classmethod
     def setUpClass(cls):
@@ -1100,13 +1106,13 @@ class Fstab(UDisksTestCase):
             raise SystemError('blkid does not contain partition UUID')
 
         cls.mkfs('ext2', partition=1, label='udtestfst')
-        cls.mountpoint = tempfile.mkdtemp()
+        cls.mount_point = tempfile.mkdtemp()
         cls.block = cls.udisks_block(partition=1)
         cls.fs = cls.udisks_filesystem(partition=1)
 
     @classmethod
     def tearDownClass(cls):
-        os.rmdir(cls.mountpoint)
+        os.rmdir(cls.mount_point)
         os.unlink(cls.orig_fstab)
 
     def tearDown(self):
@@ -1118,7 +1124,7 @@ class Fstab(UDisksTestCase):
 
         with open('/etc/fstab', 'a') as f:
             f.write('%s %s ext4 defaults,nosuid,noexec 0 0\n' %
-                    (self.devname(partition=1), self.mountpoint))
+                    (self.devname(partition=1), self.mount_point))
         os.sync()
         self.do_test()
 
@@ -1127,7 +1133,7 @@ class Fstab(UDisksTestCase):
 
         with open('/etc/fstab', 'a') as f:
             f.write('LABEL=udtestfst %s ext4 defaults,nosuid,noexec 0 0\n' %
-                    self.mountpoint)
+                    self.mount_point)
         os.sync()
         self.do_test()
 
@@ -1136,7 +1142,7 @@ class Fstab(UDisksTestCase):
 
         with open('/etc/fstab', 'a') as f:
             f.write('PARTUUID=%s %s ext4 defaults,nosuid,noexec 0 0\n' %
-                    (self.p1uuid, self.mountpoint))
+                    (self.p1uuid, self.mount_point))
 
         os.sync()
         self.do_test()
@@ -1146,7 +1152,7 @@ class Fstab(UDisksTestCase):
 
         with open('/etc/fstab', 'a') as f:
             f.write('PARTLABEL=%s %s ext4 defaults,nosuid,noexec 0 0\n' %
-                    (self.p1label, self.mountpoint))
+                    (self.p1label, self.mount_point))
 
         os.sync()
         self.do_test()
@@ -1156,14 +1162,14 @@ class Fstab(UDisksTestCase):
 
         with open('/etc/fstab', 'a') as f:
             f.write('UUID=%s %s ext4 defaults,nosuid,noexec 0 0\n' %
-                    (self.block.get_property('id-uuid'), self.mountpoint))
+                    (self.block.get_property('id-uuid'), self.mount_point))
         os.sync()
         self.do_test()
 
     def do_test(self):
         self.assertEqual(self.fs.get_property('mount-points'), [])
         mount_path = self.fs.call_mount_sync(no_options, None)
-        self.assertEqual(mount_path, self.mountpoint)
+        self.assertEqual(mount_path, self.mount_point)
         with open('/proc/self/mounts') as f:
             for line in f:
                 if line.startswith(self.devname()):

--- a/src/tests/integration-test
+++ b/src/tests/integration-test
@@ -1180,22 +1180,28 @@ class Smart(UDisksTestCase):
         This is a best-effort readonly test.
         '''
         hd = '/dev/sda'
+        has_smart = False
 
         if not os.path.exists(hd):
             self.write_stderr('[skip] ')
             return
 
-        has_smart = subprocess.call(['skdump', '--can-smart', hd],
-                                    stdout=subprocess.PIPE,
-                                    stderr=subprocess.STDOUT) == 0
+        process = subprocess.Popen(['skdump', '--can-smart', hd],
+                                   stdout=subprocess.PIPE)
+
+        (output, err) = process.communicate()
+        exit_code = process.wait()
+
+        if exit_code == 0 and output.decode().strip() == 'YES':
+            has_smart = True
 
         block = self.client.get_block_for_dev(os.stat(hd).st_rdev)
         self.assertNotEqual(block, None)
         drive = self.client.get_drive_for_block(block)
         ata = self.client.get_object(drive.get_object_path()).get_property('drive-ata')
-        self.assertEqual(ata is not None, has_smart)
 
         if has_smart:
+            self.assertEqual(ata is not None, has_smart)
             self.write_stderr('[avail] ')
             self.assertEqual(ata.get_property('smart-supported'), True)
             self.assertEqual(ata.get_property('smart-enabled'), True)

--- a/src/tests/integration-test
+++ b/src/tests/integration-test
@@ -896,10 +896,10 @@ class FS(UDisksTestCase):
         self.fs_create(None, fs_type, options)
 
         # properties
-        id = self.blkid()
-        self.assertEqual(id['ID_FS_USAGE'], fs_type == 'swap' and 'other' or 'filesystem')
-        self.assertEqual(id['ID_FS_TYPE'], fs_type)
-        l = id.get('ID_FS_LABEL', '')
+        b_id = self.blkid()
+        self.assertEqual(b_id['ID_FS_USAGE'], fs_type == 'swap' and 'other' or 'filesystem')
+        self.assertEqual(b_id['ID_FS_TYPE'], fs_type)
+        l = b_id.get('ID_FS_LABEL', '')
         if fs_type == 'vfat':
             l = l.lower()  # VFAT is case insensitive
         self.assertEqual(l, label or '')

--- a/src/tests/integration-test
+++ b/src/tests/integration-test
@@ -1015,7 +1015,7 @@ class FS(UDisksTestCase):
             # forcing mount CD drive as 'rw' should fail
             try:
                 ro_options = GLib.Variant('a{sv}', {'options': GLib.Variant('s', 'rw')})
-                mount_path = cd_fs.call_mount_sync(ro_options, None)
+                cd_fs.call_mount_sync(ro_options, None)
             except GLib.GError as e:
                 self.assertIn('is write-protected but `rw\' option given', str(e))
             else:
@@ -1263,7 +1263,7 @@ class Luks(UDisksTestCase):
     def test_0_create_teardown(self):
         """LUKS create/teardown"""
 
-        encrypted = self.setup_crypto_device()
+        self.setup_crypto_device()
 
         block = self.udisks_block()
         obj = self.client.get_object(block.get_object_path())

--- a/src/tests/integration-test
+++ b/src/tests/integration-test
@@ -99,7 +99,7 @@ class UDisksTestCase(unittest.TestCase):
 
         if os.geteuid() != 0:
             print('this test suite needs to run as root', file=sys.stderr)
-            sys.exit(0)
+            sys.exit(1)
 
         # run from local build tree if we are in one, otherwise use system instance
         klass.daemon_path = os.path.join(srcdir, 'src', '.libs', 'udisksd')
@@ -365,7 +365,7 @@ class UDisksTestCase(unittest.TestCase):
             if not os.path.exists(d):
                 sys.stderr.write('The directory %s does not exist; please '
                                  'create it before running these tests.\n' % d)
-                sys.exit(0)
+                sys.exit(1)
 
     @classmethod
     def setup_vdev(klass):

--- a/src/tests/integration-test
+++ b/src/tests/integration-test
@@ -273,15 +273,15 @@ class UDisksTestCase(unittest.TestCase):
         return subprocess.call(['mountpoint', path], stdout=subprocess.PIPE) == 0
 
     @classmethod
-    def mkfs(cls, type, label=None, partition=None):
+    def mkfs(cls, fs_type, label=None, partition=None):
         """Create file system using mkfs."""
 
-        if type == 'minix':
+        if fs_type == 'minix':
             assert label is None, 'minix does not support labels'
 
         # work around mkswap not properly cleaning up an existing reiserfs
         # signature (mailed kzak about it)
-        if type == 'swap':
+        if fs_type == 'swap':
             subprocess.check_call(['wipefs', '-a', cls.devname(partition)],
                                   stdout=subprocess.PIPE)
 
@@ -301,9 +301,10 @@ class UDisksTestCase(unittest.TestCase):
                      'btrfs': ['-f'],
                      'reiserfs': ['-ff']}
 
-        cmd = [mkcmd.get(type, 'mkfs.' + type)] + extra_opt.get(type, [])
+        cmd = [mkcmd.get(fs_type, 'mkfs.' + fs_type)]
+        cmd += extra_opt.get(fs_type, [])
         if label:
-            cmd += [label_opt.get(type, '-L'), label]
+            cmd += [label_opt.get(fs_type, '-L'), label]
         cmd.append(cls.devname(partition))
 
         subprocess.check_call(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
@@ -316,11 +317,11 @@ class UDisksTestCase(unittest.TestCase):
         cls.sync()
 
     @classmethod
-    def fs_create(cls, partition, type, options):
+    def fs_create(cls, partition, fs_type, options):
         """Create file system using udisks."""
 
         block = cls.udisks_block(partition)
-        block.call_format_sync(type, options, None)
+        block.call_format_sync(fs_type, options, None)
 
     @classmethod
     def retry_busy(cls, fn, *args):
@@ -779,21 +780,21 @@ class FS(UDisksTestCase):
         self.assertProperty(fs, 'mount-points', [])
         self.assertEqual(new_mount_path, mount_path)
 
-    def _do_fs_check(self, type):
+    def _do_fs_check(self, fs_type):
         """Run checks for a particular file system."""
-        if type == 'ntfs':
+        if fs_type == 'ntfs':
             mkfs = 'mkntfs'
         else:
-            mkfs = 'mkfs.' + type
+            mkfs = 'mkfs.' + fs_type
 
-        if type != 'swap' and subprocess.call(['which', mkfs],
-                                              stdout=subprocess.PIPE) != 0:
+        if fs_type != 'swap' and subprocess.call(['which', mkfs],
+                                                 stdout=subprocess.PIPE) != 0:
             self.write_stderr('[no %s, skip] ' % mkfs)
 
             # check correct D-Bus exception
             try:
-                self.fs_create(None, type, no_options)
-                self.fail('Expected failure for missing mkfs.' + type)
+                self.fs_create(None, fs_type, no_options)
+                self.fail('Expected failure for missing mkfs.' + fs_type)
             except GLib.GError as e:
                 self.assertIn('UDisks2.Error.Failed', e.message)
             return
@@ -801,41 +802,41 @@ class FS(UDisksTestCase):
         # do checks with command line tools (mkfs/mount/umount)
         self.write_stderr('[cli] ')
 
-        self._do_cli_check(type)
-        if type != 'minix':
-            self._do_cli_check(type, 'test%stst' % type)
+        self._do_cli_check(fs_type)
+        if fs_type != 'minix':
+            self._do_cli_check(fs_type, 'test%stst' % fs_type)
 
         # put a different fs here instead of zeroing, so that we verify that
         # udisks overrides existing FS (e. g. XFS complains then), and does not
         # leave traces of other FS around
-        if type == 'ext3':
+        if fs_type == 'ext3':
             self.mkfs('swap')
         else:
             self.mkfs('ext3')
 
         # do checks with udisks operations
         self.write_stderr('[ud] ')
-        self._do_udisks_check(type)
-        if type != 'minix':
-            self._do_udisks_check(type, 'test%stst' % type)
+        self._do_udisks_check(fs_type)
+        if fs_type != 'minix':
+            self._do_udisks_check(fs_type, 'test%stst' % fs_type)
             # also test fs_create with an empty label
-            self._do_udisks_check(type, '')
+            self._do_udisks_check(fs_type, '')
 
-    def _do_cli_check(self, type, label=None):
+    def _do_cli_check(self, fs_type, label=None):
         """udisks correctly picks up file system changes from command line tools"""
 
-        self.mkfs(type, label)
+        self.mkfs(fs_type, label)
 
         block = self.udisks_block()
 
-        self.assertProperty(block, 'id-usage', (type == 'swap') and 'other' or 'filesystem')
-        self.assertProperty(block, 'id-type', type)
+        self.assertProperty(block, 'id-usage', (fs_type == 'swap') and 'other' or 'filesystem')
+        self.assertProperty(block, 'id-type', fs_type)
         l = block.get_property('id-label')
-        if type == 'vfat':
+        if fs_type == 'vfat':
             l = l.lower()  # VFAT is case insensitive
         self.assertEqual(l, label or '')
         self.assertEqual(block.get_property('hint-name'), '')
-        if type != 'minix':
+        if fs_type != 'minix':
             self.assertEqual(block.get_property('id-uuid'), self.blkid()['ID_FS_UUID'])
 
         obj = self.client.get_object(self.block.get_object_path())
@@ -843,17 +844,17 @@ class FS(UDisksTestCase):
         self.assertEqual(obj.get_property('partition-table'), None)
 
         fs = obj.get_property('filesystem')
-        if type == 'swap':
+        if fs_type == 'swap':
             self.assertEqual(fs, None)
         else:
             self.assertNotEqual(fs, None)
 
-        if type == 'swap':
+        if fs_type == 'swap':
             return
 
         # mount it on two points
-        if type == 'ntfs' and subprocess.call(['which', 'mount.ntfs-3g'],
-                                              stdout=subprocess.PIPE) == 0:
+        if fs_type == 'ntfs' and subprocess.call(['which', 'mount.ntfs-3g'],
+                                                 stdout=subprocess.PIPE) == 0:
             # prefer mount.ntfs-3g if we have it (on Debian; Ubuntu
             # defaults to ntfs-3g if installed); TODO: check other distros
             mount_prog = 'mount.ntfs-3g'
@@ -874,7 +875,7 @@ class FS(UDisksTestCase):
 
         self.assertProperty(fs, 'mount-points', [mount_a])
 
-        if type != 'ntfs':
+        if fs_type != 'ntfs':
             # ntfs-3g does not support multiple mounts
             subprocess.check_call([mount_prog, self.device, mount_b])
             self.assertProperty(fs, 'mount-points', set([mount_a, mount_b]))
@@ -884,7 +885,7 @@ class FS(UDisksTestCase):
         subprocess.call(['umount', mount_a])
         self.assertProperty(fs, 'mount-points', [])
 
-    def _do_udisks_check(self, type, label=None):
+    def _do_udisks_check(self, fs_type, label=None):
         """udisks API correctly changes file system"""
 
         # create fs
@@ -892,27 +893,27 @@ class FS(UDisksTestCase):
             options = GLib.Variant('a{sv}', {'label': GLib.Variant('s', label)})
         else:
             options = no_options
-        self.fs_create(None, type, options)
+        self.fs_create(None, fs_type, options)
 
         # properties
         id = self.blkid()
-        self.assertEqual(id['ID_FS_USAGE'], type == 'swap' and 'other' or 'filesystem')
-        self.assertEqual(id['ID_FS_TYPE'], type)
+        self.assertEqual(id['ID_FS_USAGE'], fs_type == 'swap' and 'other' or 'filesystem')
+        self.assertEqual(id['ID_FS_TYPE'], fs_type)
         l = id.get('ID_FS_LABEL', '')
-        if type == 'vfat':
+        if fs_type == 'vfat':
             l = l.lower()  # VFAT is case insensitive
         self.assertEqual(l, label or '')
 
         block = self.udisks_block()
-        self.assertProperty(block, 'id-usage', (type == 'swap') and 'other' or 'filesystem')
-        self.assertProperty(block, 'id-type', type)
-        if type == 'vfat' and label:
+        self.assertProperty(block, 'id-usage', (fs_type == 'swap') and 'other' or 'filesystem')
+        self.assertProperty(block, 'id-type', fs_type)
+        if fs_type == 'vfat' and label:
             # VFAT is case insensitive
             self.assertEventually(lambda: block.get_property('id-label').lower(), label.lower())
         else:
             self.assertProperty(block, 'id-label', label or '')
 
-        if type == 'swap':
+        if fs_type == 'swap':
             return
 
         obj = self.client.get_object(self.block.get_object_path())
@@ -928,7 +929,7 @@ class FS(UDisksTestCase):
 
         self.assertIn('/media/', mount_path)
         if label:
-            if type == 'vfat':
+            if fs_type == 'vfat':
                 self.assertTrue(mount_path.lower().endswith(label))
             else:
                 self.assertTrue(mount_path.endswith(label))
@@ -943,7 +944,7 @@ class FS(UDisksTestCase):
         st = os.stat(mount_path)
         self.assertEqual((st.st_uid, st.st_gid), (0, 0))
 
-        self._do_file_perms_checks(type, mount_path)
+        self._do_file_perms_checks(fs_type, mount_path)
 
         # unmount
         self.retry_busy(fs.call_unmount_sync, no_options, None)
@@ -963,8 +964,8 @@ class FS(UDisksTestCase):
 
         # change label
         supported = True
-        l = 'n"a\m\\"e' + type
-        if type == 'vfat':
+        l = 'n"a\m\\"e' + fs_type
+        if fs_type == 'vfat':
             # VFAT does not support some characters
             self.assertRaises(GLib.GError, fs.call_set_label_sync, l, no_options, None)
             l = "n@a$me"
@@ -973,7 +974,7 @@ class FS(UDisksTestCase):
         except GLib.GError as e:
             if 'UDisks2.Error.NotSupported' in e.message:
                 # these fses are known to not support relabeling
-                self.assertIn(type, ['minix', 'f2fs'])
+                self.assertIn(fs_type, ['minix', 'f2fs'])
                 supported = False
             else:
                 raise
@@ -982,7 +983,7 @@ class FS(UDisksTestCase):
             block = self.udisks_block()
             blkid_label = self.blkid().get('ID_FS_LABEL_ENC', '').replace('\\x22', '"').replace(
                 '\\x5c', '\\').replace('\\x24', '$')
-            if type == 'vfat':
+            if fs_type == 'vfat':
                 # EXFAIL: often (but not always) the label appears in all upper case
                 self.assertEqual(blkid_label.upper(), l.upper())
                 self.assertEventually(lambda: block.get_property('id-label').upper(), l.upper())
@@ -1002,7 +1003,7 @@ class FS(UDisksTestCase):
         # this is known-broken for reiserfs and xfs right now:
         # https://github.com/karelzak/util-linux/issues/17
         # https://github.com/karelzak/util-linux/issues/18
-        if type not in ['reiserfs', 'xfs']:
+        if fs_type not in ['reiserfs', 'xfs']:
             # the scsi_debug CD drive content is the same as for the HD drive, but
             # udev does not know about this; so give it a nudge to re-probe
             subprocess.call(['udevadm', 'trigger', '--action=change',
@@ -1033,13 +1034,13 @@ class FS(UDisksTestCase):
                 self.assertFalse(os.path.exists(mount_path), 'mount point was not removed')
                 self.assertProperty(cd_fs, 'mount-points', [])
 
-    def _do_file_perms_checks(self, type, mount_point):
+    def _do_file_perms_checks(self, fs_type, mount_point):
         """Check for permissions for data files and executables.
 
         This particularly checks sane and useful permissions on non-Unix file
         systems like vfat.
         """
-        if type in BROKEN_PERMISSIONS_FS:
+        if fs_type in BROKEN_PERMISSIONS_FS:
             return
 
         f = os.path.join(mount_point, 'simpledata.txt')

--- a/src/tests/integration-test
+++ b/src/tests/integration-test
@@ -1629,12 +1629,12 @@ if __name__ == '__main__':
                            help='write daemon log to a file')
     argparser.add_argument('testname', nargs='*',
                            help='name of test class or method (e. g. "Drive", "FS.test_ext2")')
-    args = argparser.parse_args()
+    cli_args = argparser.parse_args()
 
-    UDisksTestCase.init(logfile=args.logfile)
-    if args.testname:
+    UDisksTestCase.init(logfile=cli_args.logfile)
+    if cli_args.testname:
         tests = unittest.TestLoader().loadTestsFromNames(
-            args.testname, __import__('__main__'))
+            cli_args.testname, __import__('__main__'))
     else:
         tests = unittest.TestLoader().loadTestsFromName('__main__')
     if unittest.TextTestRunner(verbosity=2).run(tests).wasSuccessful():

--- a/src/tests/integration-test
+++ b/src/tests/integration-test
@@ -71,6 +71,7 @@ import test_polkitd
 # GI_TYPELIB_PATH=udisks LD_LIBRARY_PATH=udisks/.libs
 VDEV_SIZE = 64000000  # size of virtual test device
 
+
 # Those file systems are known to have a broken handling of permissions, in
 # particular the executable bit
 BROKEN_PERMISSIONS_FS = ['ntfs', 'exfat']
@@ -1450,18 +1451,18 @@ class Luks(UDisksTestCase):
 
     def test_binary_keyfile(self):
 
-        KEYFILE = b's\0me \bina\ry \xda\ta\0\0\1\1\xff\xff'
+        key_file = b's\0me \bina\ry \xda\ta\0\0\1\1\xff\xff'
 
         self.fs_create(None, 'ext4', GLib.Variant('a{sv}', {
-            'encrypt.passphrase': GLib.Variant('ay', KEYFILE),
+            'encrypt.passphrase': GLib.Variant('ay', key_file),
             'label': GLib.Variant('s', 'treasure')}))
         crypt_obj = self.client.get_object(self.udisks_block().get_object_path())
         encrypted = crypt_obj.get_property('encrypted')
         encrypted.call_lock_sync(no_options, None)
 
         # wrong password
-        missing_byte = self.keyfile_options(KEYFILE[:-1])
-        extra_bytes = self.keyfile_options(KEYFILE+b'\0X')
+        missing_byte = self.keyfile_options(key_file[:-1])
+        extra_bytes = self.keyfile_options(key_file+b'\0X')
         self.assertRaises(GLib.GError, encrypted.call_unlock_sync,
                           'h4ckpassword', no_options, None)
         self.assertRaises(GLib.GError, encrypted.call_unlock_sync,
@@ -1470,24 +1471,24 @@ class Luks(UDisksTestCase):
                           '', extra_bytes, None)
 
         # correct password
-        encrypted.call_unlock_sync('', self.keyfile_options(KEYFILE), None)
+        encrypted.call_unlock_sync('', self.keyfile_options(key_file), None)
         encrypted.call_lock_sync(no_options, None)
 
     def test_ascii_keyfile_newline(self):
 
-        KEYFILE = b'ascii string\nwith newline\n'
+        key_file = b'ascii string\nwith newline\n'
 
         # setup crypto device
         self.fs_create(None, 'ext4', GLib.Variant('a{sv}', {
-            'encrypt.passphrase': GLib.Variant('ay', KEYFILE),
+            'encrypt.passphrase': GLib.Variant('ay', key_file),
             'label': GLib.Variant('s', 'treasure')}))
         crypt_obj = self.client.get_object(self.udisks_block().get_object_path())
         encrypted = crypt_obj.get_property('encrypted')
         encrypted.call_lock_sync(no_options, None)
 
         # wrong password
-        missing_byte = self.keyfile_options(KEYFILE[:-1])
-        extra_bytes = self.keyfile_options(KEYFILE+b'\0X')
+        missing_byte = self.keyfile_options(key_file[:-1])
+        extra_bytes = self.keyfile_options(key_file+b'\0X')
         self.assertRaises(GLib.GError, encrypted.call_unlock_sync,
                           'h4ckpassword', no_options, None)
         self.assertRaises(GLib.GError, encrypted.call_unlock_sync,
@@ -1496,17 +1497,17 @@ class Luks(UDisksTestCase):
                           '', extra_bytes, None)
 
         # correct password
-        encrypted.call_unlock_sync('', self.keyfile_options(KEYFILE), None)
+        encrypted.call_unlock_sync('', self.keyfile_options(key_file), None)
         encrypted.call_lock_sync(no_options, None)
 
         # We no longer mimic cryptsetup which in passphrase-mode stops input
         # at the first newline:
-        encrypted.call_unlock_sync(KEYFILE.decode('utf-8'), no_options, None)
+        encrypted.call_unlock_sync(key_file.decode('utf-8'), no_options, None)
 
     def test_change_passphrase(self):
 
-        KEYFILE0 = b's\0me \bina\ry \xda\ta\0\0\1\1\xff\xff\0'
-        KEYFILE1 = b's\0me \bina\ry \xda\ta\0\0\1\1\xff\xff\1'
+        key_file_0 = b's\0me \bina\ry \xda\ta\0\0\1\1\xff\xff\0'
+        key_file_1 = b's\0me \bina\ry \xda\ta\0\0\1\1\xff\xff\1'
 
         encrypted = self.setup_crypto_device()
 
@@ -1522,40 +1523,40 @@ class Luks(UDisksTestCase):
         # change: passphrase -> keyfile
         encrypted.call_change_passphrase_sync(
             'passphrase', '', GLib.Variant('a{sv}', {
-                'new_keyfile_contents': GLib.Variant('ay', KEYFILE0),
+                'new_keyfile_contents': GLib.Variant('ay', key_file_0),
             }),
             None)
 
         # verify new password:
         self.assertRaises(GLib.GError, encrypted.call_unlock_sync,
                           'passphrase', no_options, None)
-        encrypted.call_unlock_sync('', self.keyfile_options(KEYFILE0), None)
+        encrypted.call_unlock_sync('', self.keyfile_options(key_file_0), None)
         encrypted.call_lock_sync(no_options, None)
 
         # change: keyfile -> keyfile
         encrypted.call_change_passphrase_sync(
             '', '', GLib.Variant('a{sv}', {
-                'old_keyfile_contents': GLib.Variant('ay', KEYFILE0),
-                'new_keyfile_contents': GLib.Variant('ay', KEYFILE1),
+                'old_keyfile_contents': GLib.Variant('ay', key_file_0),
+                'new_keyfile_contents': GLib.Variant('ay', key_file_1),
             }),
             None)
 
         # verify new password:
         self.assertRaises(GLib.GError, encrypted.call_unlock_sync,
-                          '', self.keyfile_options(KEYFILE0), None)
-        encrypted.call_unlock_sync('', self.keyfile_options(KEYFILE1), None)
+                          '', self.keyfile_options(key_file_0), None)
+        encrypted.call_unlock_sync('', self.keyfile_options(key_file_1), None)
         encrypted.call_lock_sync(no_options, None)
 
         # change: keyfile -> passphrase
         encrypted.call_change_passphrase_sync(
             '', 's3kr1t', GLib.Variant('a{sv}', {
-                'old_keyfile_contents': GLib.Variant('ay', KEYFILE1),
+                'old_keyfile_contents': GLib.Variant('ay', key_file_1),
             }),
             None)
 
         # verify new password:
         self.assertRaises(GLib.GError, encrypted.call_unlock_sync,
-                          '', self.keyfile_options(KEYFILE1), None)
+                          '', self.keyfile_options(key_file_1), None)
         encrypted.call_unlock_sync('s3kr1t', no_options, None)
         encrypted.call_lock_sync(no_options, None)
 

--- a/src/tests/integration-test
+++ b/src/tests/integration-test
@@ -1412,7 +1412,8 @@ class Luks(UDisksTestCase):
             self.client.settle()
             self.assertEqual(self.client.get_object(path), None)
 
-    def keyfile_options(self, keyfile_contents):
+    @staticmethod
+    def keyfile_options(keyfile_contents):
         return GLib.Variant('a{sv}', {
             'keyfile_contents': GLib.Variant('ay', keyfile_contents)
         })
@@ -1422,11 +1423,11 @@ class Luks(UDisksTestCase):
         encrypted = self.setup_crypto_device()
         # wrong password, has bytes after a trailing '\0'
         self.assertRaises(GLib.GError, encrypted.call_unlock_sync,
-                          '', self.keyfile_options(b's3kr1t\0X'), None)
+                          '', Luks.keyfile_options(b's3kr1t\0X'), None)
         self.assertRaises(GLib.GError, encrypted.call_unlock_sync,
-                          '', self.keyfile_options(b's3kr1t\n'), None)
+                          '', Luks.keyfile_options(b's3kr1t\n'), None)
         # correct password, specified as keyfile
-        encrypted.call_unlock_sync('', self.keyfile_options(b's3kr1t'), None)
+        encrypted.call_unlock_sync('', Luks.keyfile_options(b's3kr1t'), None)
         encrypted.call_lock_sync(no_options, None)
 
     def test_plaintext_keyfile(self):
@@ -1444,12 +1445,12 @@ class Luks(UDisksTestCase):
         self.assertRaises(GLib.GError, encrypted.call_unlock_sync,
                           'h4ckpassword', no_options, None)
         self.assertRaises(GLib.GError, encrypted.call_unlock_sync,
-                          '', self.keyfile_options(b's3kr1t\0X'), None)
+                          '', Luks.keyfile_options(b's3kr1t\0X'), None)
         self.assertRaises(GLib.GError, encrypted.call_unlock_sync,
-                          '', self.keyfile_options(b's3kr1t\n'), None)
+                          '', Luks.keyfile_options(b's3kr1t\n'), None)
 
         # correct password
-        encrypted.call_unlock_sync('', self.keyfile_options(b's3kr1t'), None)
+        encrypted.call_unlock_sync('', Luks.keyfile_options(b's3kr1t'), None)
         encrypted.call_lock_sync(no_options, None)
 
         # correct password, specified as passphrase
@@ -1468,8 +1469,8 @@ class Luks(UDisksTestCase):
         encrypted.call_lock_sync(no_options, None)
 
         # wrong password
-        missing_byte = self.keyfile_options(key_file[:-1])
-        extra_bytes = self.keyfile_options(key_file+b'\0X')
+        missing_byte = Luks.keyfile_options(key_file[:-1])
+        extra_bytes = Luks.keyfile_options(key_file+b'\0X')
         self.assertRaises(GLib.GError, encrypted.call_unlock_sync,
                           'h4ckpassword', no_options, None)
         self.assertRaises(GLib.GError, encrypted.call_unlock_sync,
@@ -1478,7 +1479,7 @@ class Luks(UDisksTestCase):
                           '', extra_bytes, None)
 
         # correct password
-        encrypted.call_unlock_sync('', self.keyfile_options(key_file), None)
+        encrypted.call_unlock_sync('', Luks.keyfile_options(key_file), None)
         encrypted.call_lock_sync(no_options, None)
 
     def test_ascii_keyfile_newline(self):
@@ -1494,8 +1495,8 @@ class Luks(UDisksTestCase):
         encrypted.call_lock_sync(no_options, None)
 
         # wrong password
-        missing_byte = self.keyfile_options(key_file[:-1])
-        extra_bytes = self.keyfile_options(key_file+b'\0X')
+        missing_byte = Luks.keyfile_options(key_file[:-1])
+        extra_bytes = Luks.keyfile_options(key_file+b'\0X')
         self.assertRaises(GLib.GError, encrypted.call_unlock_sync,
                           'h4ckpassword', no_options, None)
         self.assertRaises(GLib.GError, encrypted.call_unlock_sync,
@@ -1504,7 +1505,7 @@ class Luks(UDisksTestCase):
                           '', extra_bytes, None)
 
         # correct password
-        encrypted.call_unlock_sync('', self.keyfile_options(key_file), None)
+        encrypted.call_unlock_sync('', Luks.keyfile_options(key_file), None)
         encrypted.call_lock_sync(no_options, None)
 
         # We no longer mimic cryptsetup which in passphrase-mode stops input
@@ -1537,7 +1538,7 @@ class Luks(UDisksTestCase):
         # verify new password:
         self.assertRaises(GLib.GError, encrypted.call_unlock_sync,
                           'passphrase', no_options, None)
-        encrypted.call_unlock_sync('', self.keyfile_options(key_file_0), None)
+        encrypted.call_unlock_sync('', Luks.keyfile_options(key_file_0), None)
         encrypted.call_lock_sync(no_options, None)
 
         # change: keyfile -> keyfile
@@ -1550,8 +1551,8 @@ class Luks(UDisksTestCase):
 
         # verify new password:
         self.assertRaises(GLib.GError, encrypted.call_unlock_sync,
-                          '', self.keyfile_options(key_file_0), None)
-        encrypted.call_unlock_sync('', self.keyfile_options(key_file_1), None)
+                          '', Luks.keyfile_options(key_file_0), None)
+        encrypted.call_unlock_sync('', Luks.keyfile_options(key_file_1), None)
         encrypted.call_lock_sync(no_options, None)
 
         # change: keyfile -> passphrase
@@ -1563,7 +1564,7 @@ class Luks(UDisksTestCase):
 
         # verify new password:
         self.assertRaises(GLib.GError, encrypted.call_unlock_sync,
-                          '', self.keyfile_options(key_file_1), None)
+                          '', Luks.keyfile_options(key_file_1), None)
         encrypted.call_unlock_sync('s3kr1t', no_options, None)
         encrypted.call_lock_sync(no_options, None)
 

--- a/src/tests/integration-test
+++ b/src/tests/integration-test
@@ -1242,7 +1242,8 @@ class Luks(UDisksTestCase):
         encrypted.call_lock_sync(no_options, None)
         return encrypted
 
-    def unlock_crypto_device(self, encrypted):
+    @staticmethod
+    def unlock_crypto_device(encrypted):
         return encrypted.call_unlock_sync(
             's3kr1t', no_options, None)
 
@@ -1290,7 +1291,7 @@ class Luks(UDisksTestCase):
             self.assertRaises(GLib.GError, encrypted.call_unlock_sync,
                               'h4ckpassword', no_options, None)
             # right password
-            clear_path = self.unlock_crypto_device(encrypted)
+            clear_path = Luks.unlock_crypto_device(encrypted)
 
             # check cleartext device info
             clear_obj = self.client.get_object(clear_path)
@@ -1326,7 +1327,7 @@ class Luks(UDisksTestCase):
 
         encrypted = self.setup_crypto_device()
 
-        path = self.unlock_crypto_device(encrypted)
+        path = Luks.unlock_crypto_device(encrypted)
         self.client.settle()
         obj = self.client.get_object(path)
         fs = obj.get_property('filesystem')
@@ -1365,7 +1366,7 @@ class Luks(UDisksTestCase):
         # unlock and mount it
         encrypted = self.setup_crypto_device()
         crypt_obj = self.client.get_object(self.udisks_block().get_object_path())
-        path = self.unlock_crypto_device(encrypted)
+        path = Luks.unlock_crypto_device(encrypted)
         try:
             fs = self.client.get_object(path).get_property('filesystem')
             mount_path = fs.call_mount_sync(no_options, None)
@@ -1392,7 +1393,7 @@ class Luks(UDisksTestCase):
                 self.readd_devices()
 
             # after putting it back, it should be mountable again
-            path = self.unlock_crypto_device(encrypted)
+            path = Luks.unlock_crypto_device(encrypted)
             self.client.settle()
             fs = self.client.get_object(path).get_property('filesystem')
             mount_path = fs.call_mount_sync(no_options, None)

--- a/src/tests/integration-test
+++ b/src/tests/integration-test
@@ -878,7 +878,7 @@ class FS(UDisksTestCase):
         if fs_type != 'ntfs':
             # ntfs-3g does not support multiple mounts
             subprocess.check_call([mount_prog, self.device, mount_b])
-            self.assertProperty(fs, 'mount-points', set([mount_a, mount_b]))
+            self.assertProperty(fs, 'mount-points', {mount_a, mount_b})
             subprocess.call(['umount', mount_b])
 
         # unmount it

--- a/src/tests/integration-test
+++ b/src/tests/integration-test
@@ -88,10 +88,11 @@ class UDisksTestCase(unittest.TestCase):
     This provides static functions which are useful for all test cases.
     """
     daemon = None
-    daemon_path = None
     daemon_log = None
+    daemon_path = None
+    dbus = None
     device = None
-
+    cd_device = ""
     client = None
     manager = None
 

--- a/src/tests/integration-test
+++ b/src/tests/integration-test
@@ -33,8 +33,9 @@
 import sys
 import os
 import contextlib
+from os.path import dirname
 
-srcdir = os.path.dirname(os.path.dirname(os.path.dirname(os.path.realpath(__file__))))
+srcdir = dirname(dirname(dirname(os.path.realpath(__file__))))
 libdir = os.path.join(srcdir, 'udisks', '.libs')
 
 # as we can't change LD_LIBRARY_PATH within a running program, and doing
@@ -65,7 +66,7 @@ gi.require_version('UDisks', '2.0')
 from gi.repository import GLib, Gio, UDisks
 
 # find local test_polkit.py
-sys.path.insert(0, os.path.dirname(__file__))
+sys.path.insert(0, dirname(__file__))
 import test_polkitd
 
 # GI_TYPELIB_PATH=udisks LD_LIBRARY_PATH=udisks/.libs
@@ -95,7 +96,7 @@ class UDisksTestCase(unittest.TestCase):
     manager = None
 
     @classmethod
-    def init(klass, logfile=None):
+    def init(cls, logfile=None):
         """start daemon and set up test environment"""
 
         if os.geteuid() != 0:
@@ -103,27 +104,28 @@ class UDisksTestCase(unittest.TestCase):
             sys.exit(1)
 
         # run from local build tree if we are in one, otherwise use system instance
-        klass.daemon_path = os.path.join(srcdir, 'src', '.libs', 'udisksd')
-        if (os.access(klass.daemon_path, os.X_OK)):
+        cls.daemon_path = os.path.join(srcdir, 'src', '.libs', 'udisksd')
+        if (os.access(cls.daemon_path, os.X_OK)):
             print('Testing binaries from local build tree')
-            klass.check_build_tree_config()
+            cls.check_build_tree_config()
         else:
             print('Testing installed system binaries')
-            klass.daemon_path = None
-            for l in open('/usr/share/dbus-1/system-services/org.freedesktop.UDisks2.service'):
+            cls.daemon_path = None
+            for l in open('/usr/share/dbus-1/system-services/'
+                          'org.freedesktop.UDisks2.service'):
                 if l.startswith('Exec='):
-                    klass.daemon_path = l.split('=', 1)[1].split()[0]
+                    cls.daemon_path = l.split('=', 1)[1].split()[0]
                     break
-            assert klass.daemon_path, 'could not determine daemon path from D-BUS .service file'
+            assert cls.daemon_path, 'could not determine daemon path from D-BUS .service file'
 
-        print('daemon path: ' + klass.daemon_path)
+        print('daemon path: ' + cls.daemon_path)
 
-        (klass.device, klass.cd_device) = klass.setup_vdev()
+        (cls.device, cls.cd_device) = cls.setup_vdev()
 
         # start polkit and udisks on a private DBus
-        klass.dbus = Gio.TestDBus()
-        klass.dbus.up()
-        os.environ['DBUS_SYSTEM_BUS_ADDRESS'] = klass.dbus.get_bus_address()
+        cls.dbus = Gio.TestDBus()
+        cls.dbus.up()
+        os.environ['DBUS_SYSTEM_BUS_ADDRESS'] = cls.dbus.get_bus_address()
         # do not try to communicate with the current desktop session; this will
         # confuse it, as it cannot see this D-BUS instance
         try:
@@ -131,58 +133,59 @@ class UDisksTestCase(unittest.TestCase):
         except KeyError:
             pass
         if logfile:
-            klass.daemon_log = open(logfile, 'w')
+            cls.daemon_log = open(logfile, 'w')
         else:
-            klass.daemon_log = tempfile.TemporaryFile()
-        atexit.register(klass.cleanup)
+            cls.daemon_log = tempfile.TemporaryFile()
+        atexit.register(cls.cleanup)
 
-        klass.start_daemon()
+        cls.start_daemon()
 
     @classmethod
-    def cleanup(klass):
+    def cleanup(cls):
         """stop daemon again and clean up test environment"""
 
-        subprocess.call(['umount', klass.device], stderr=subprocess.PIPE)  # if a test failed
+        # if a test failed
+        subprocess.call(['umount', cls.device], stderr=subprocess.PIPE)
 
-        klass.stop_daemon()
+        cls.stop_daemon()
 
-        klass.teardown_vdev(klass.device)
-        klass.device = None
+        cls.teardown_vdev(cls.device)
+        cls.device = None
 
         del os.environ['DBUS_SYSTEM_BUS_ADDRESS']
-        klass.dbus.down()
+        cls.dbus.down()
 
     @classmethod
-    def start_daemon(klass):
-        assert klass.daemon is None
-        klass.daemon = subprocess.Popen([klass.daemon_path, '--replace'],
-                                        stdout=klass.daemon_log,
-                                        stderr=subprocess.STDOUT)
-        assert klass.daemon.pid, 'daemon failed to start'
+    def start_daemon(cls):
+        assert cls.daemon is None
+        cls.daemon = subprocess.Popen([cls.daemon_path, '--replace'],
+                                      stdout=cls.daemon_log,
+                                      stderr=subprocess.STDOUT)
+        assert cls.daemon.pid, 'daemon failed to start'
 
         # wait until the daemon has started up
         timeout = 10
-        klass.manager = None
-        while klass.manager is None and timeout > 0:
+        cls.manager = None
+        while cls.manager is None and timeout > 0:
             time.sleep(0.2)
-            klass.client = UDisks.Client.new_sync(None)
-            assert klass.client is not None
-            klass.manager = klass.client.get_manager()
+            cls.client = UDisks.Client.new_sync(None)
+            assert cls.client is not None
+            cls.manager = cls.client.get_manager()
             timeout -= 1
-        assert klass.manager, 'daemon failed to start'
-        assert klass.daemon.pid, 'daemon failed to start'
+        assert cls.manager, 'daemon failed to start'
+        assert cls.daemon.pid, 'daemon failed to start'
 
-        klass.sync()
+        cls.sync()
 
     @classmethod
-    def stop_daemon(klass):
-        assert klass.daemon
-        os.kill(klass.daemon.pid, signal.SIGTERM)
+    def stop_daemon(cls):
+        assert cls.daemon
+        os.kill(cls.daemon.pid, signal.SIGTERM)
         os.wait()
-        klass.daemon = None
+        cls.daemon = None
 
     @classmethod
-    def sync(klass):
+    def sync(cls):
         """Wait until pending events finished processing.
 
         This should only be called for situations where we genuinely have an
@@ -194,29 +197,29 @@ class UDisksTestCase(unittest.TestCase):
         timeout = 100
         # wait until all GDBus events have been processed
         while context.pending() and timeout > 0:
-            klass.client.settle()
+            cls.client.settle()
             time.sleep(0.1)
             timeout -= 1
         if timeout <= 0:
-            klass.write_stderr('[wait timeout!] ')
+            cls.write_stderr('[wait timeout!] ')
 
     @classmethod
-    def zero_device(klass):
-        subprocess.call(['dd', 'if=/dev/zero', 'of=' + klass.device, 'bs=10M'],
+    def zero_device(cls):
+        subprocess.call(['dd', 'if=/dev/zero', 'of=' + cls.device, 'bs=10M'],
                         stderr=subprocess.PIPE)
         time.sleep(0.5)
-        klass.sync()
+        cls.sync()
 
     @classmethod
-    def devname(klass, partition=None, cd=False):
+    def devname(cls, partition=None, cd=False):
         """Get name of test device or one of its partitions
 
         If cd is True, return the CD device, otherwise the hard disk device.
         """
         if cd:
-            dev = klass.cd_device
+            dev = cls.cd_device
         else:
-            dev = klass.device
+            dev = cls.device
         if partition:
             if dev[-1].isdigit():
                 return dev + 'p' + str(partition)
@@ -226,35 +229,35 @@ class UDisksTestCase(unittest.TestCase):
             return dev
 
     @classmethod
-    def udisks_block(klass, partition=None, cd=False):
+    def udisks_block(cls, partition=None, cd=False):
         """Get UDisksBlock object for test device or partition
 
         If cd is True, return the CD device, otherwise the hard disk device.
         """
-        assert klass.client
-        devname = klass.devname(partition, cd)
+        assert cls.client
+        devname = cls.devname(partition, cd)
         dev_t = os.stat(devname).st_rdev
-        block = klass.client.get_block_for_dev(dev_t)
+        block = cls.client.get_block_for_dev(dev_t)
         assert block, 'did not find an UDisksBlock object for %s' % devname
         return block
 
     @classmethod
-    def udisks_filesystem(klass, partition=None, cd=False):
+    def udisks_filesystem(cls, partition=None, cd=False):
         """Get UDisksFilesystem object for test device or partition
 
         Return None if there is no file system on that device.
 
         If cd is True, return the CD device, otherwise the hard disk device.
         """
-        block = klass.udisks_block(partition, cd)
-        return klass.client.get_object(block.get_object_path()).get_filesystem()
+        block = cls.udisks_block(partition, cd)
+        return cls.client.get_object(block.get_object_path()).get_filesystem()
 
     @classmethod
-    def blkid(klass, partition=None, device=None):
+    def blkid(cls, partition=None, device=None):
         """Call blkid and return dictionary of results."""
 
         if not device:
-            device = klass.devname(partition)
+            device = cls.devname(partition)
         result = {}
         cmd = subprocess.Popen(['blkid', '-p', '-o', 'udev', device], stdout=subprocess.PIPE)
         for l in cmd.stdout:
@@ -264,13 +267,13 @@ class UDisksTestCase(unittest.TestCase):
         return result
 
     @classmethod
-    def is_mountpoint(klass, path):
+    def is_mountpoint(cls, path):
         """Check if given path is a mount point."""
 
         return subprocess.call(['mountpoint', path], stdout=subprocess.PIPE) == 0
 
     @classmethod
-    def mkfs(klass, type, label=None, partition=None):
+    def mkfs(cls, type, label=None, partition=None):
         """Create file system using mkfs."""
 
         if type == 'minix':
@@ -279,7 +282,7 @@ class UDisksTestCase(unittest.TestCase):
         # work around mkswap not properly cleaning up an existing reiserfs
         # signature (mailed kzak about it)
         if type == 'swap':
-            subprocess.check_call(['wipefs', '-a', klass.devname(partition)],
+            subprocess.check_call(['wipefs', '-a', cls.devname(partition)],
                                   stdout=subprocess.PIPE)
 
         mkcmd = {'swap': 'mkswap',
@@ -301,7 +304,7 @@ class UDisksTestCase(unittest.TestCase):
         cmd = [mkcmd.get(type, 'mkfs.' + type)] + extra_opt.get(type, [])
         if label:
             cmd += [label_opt.get(type, '-L'), label]
-        cmd.append(klass.devname(partition))
+        cmd.append(cls.devname(partition))
 
         subprocess.check_call(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
@@ -309,18 +312,18 @@ class UDisksTestCase(unittest.TestCase):
         # tell us when they are done; so do a little kludge here to know how
         # long we need to wait
         subprocess.call(['udevadm', 'trigger', '--action=change',
-                         '--sysname-match=' + os.path.basename(klass.devname(partition))])
-        klass.sync()
+                         '--sysname-match=' + os.path.basename(cls.devname(partition))])
+        cls.sync()
 
     @classmethod
-    def fs_create(klass, partition, type, options):
+    def fs_create(cls, partition, type, options):
         """Create file system using udisks."""
 
-        block = klass.udisks_block(partition)
+        block = cls.udisks_block(partition)
         block.call_format_sync(type, options, None)
 
     @classmethod
-    def retry_busy(klass, fn, *args):
+    def retry_busy(cls, fn, *args):
         """Call a function until it does not fail with "Busy"."""
 
         timeout = 10
@@ -330,18 +333,19 @@ class UDisksTestCase(unittest.TestCase):
             except GLib.GError as e:
                 if 'UDisks2.Error.DeviceBusy' not in e.message:
                     raise
-                klass.write_stderr('[busy] ')
+                cls.write_stderr('[busy] ')
                 time.sleep(0.3)
                 timeout -= 1
 
     @classmethod
-    def check_build_tree_config(klass):
+    def check_build_tree_config(cls):
         """Check configuration of build tree"""
 
         # read make variables
         make_vars = {}
         var_re = re.compile('^([a-zA-Z_]+) = (.*)$')
-        make = subprocess.Popen(['make', '-p', '/dev/null'], stdout=subprocess.PIPE)
+        make = subprocess.Popen(['make', '-p', '/dev/null'],
+                                stdout=subprocess.PIPE)
         for l in make.stdout:
             l = l.decode('UTF-8')
             m = var_re.match(l)
@@ -369,7 +373,7 @@ class UDisksTestCase(unittest.TestCase):
                 sys.exit(1)
 
     @classmethod
-    def setup_vdev(klass):
+    def setup_vdev(cls):
         """create virtual test devices
 
         It is zeroed out initially.
@@ -393,7 +397,8 @@ class UDisksTestCase(unittest.TestCase):
                         'ENV{ID_CDROM_MEDIA}=="?*", '
                         'IMPORT{program}="/sbin/blkid -o udev -p -u noraid $tempnode"\n')
             # reload udev
-            subprocess.call('sync; pkill --signal HUP udevd || pkill --signal HUP systemd-udevd',
+            subprocess.call('sync; pkill --signal HUP udevd || '
+                            'pkill --signal HUP systemd-udevd',
                             shell=True)
 
         # craete a fake SCSI hard drive
@@ -442,14 +447,14 @@ class UDisksTestCase(unittest.TestCase):
         return (rw_dev, ro_dev)
 
     @classmethod
-    def teardown_vdev(klass, device):
+    def teardown_vdev(cls, device):
         """release and remove virtual test device"""
 
-        klass.remove_device(device)
+        cls.remove_device(device)
         assert subprocess.call(['rmmod', 'scsi_debug']) == 0, 'Failure to rmmod scsi_debug'
 
     @classmethod
-    def remove_device(klass, device):
+    def remove_device(cls, device):
         """remove virtual test device"""
 
         device = device.split('/')[-1]
@@ -459,11 +464,11 @@ class UDisksTestCase(unittest.TestCase):
             f.close()
         while os.path.exists(device):
             time.sleep(0.1)
-        klass.sync()
+        cls.sync()
         time.sleep(0.5)  # TODO
 
     @classmethod
-    def readd_devices(klass):
+    def readd_devices(cls):
         """re-add virtual test devices after removal"""
 
         scan_files = glob('/sys/bus/pseudo/devices/adapter*/host*/scsi_host/host*/scan')
@@ -471,12 +476,12 @@ class UDisksTestCase(unittest.TestCase):
         for f in scan_files:
             open(f, 'w').write('- - -\n')
         timeout = 100
-        while not os.path.exists(klass.device) and timeout > 0:
+        while not os.path.exists(cls.device) and timeout > 0:
             time.sleep(0.1)
             timeout -= 1
-        assert os.path.exists(klass.device), 'timed out waiting for %s to exist' % klass.device
+        assert os.path.exists(cls.device), 'timed out waiting for %s to exist' % cls.device
         time.sleep(0.5)
-        klass.sync()
+        cls.sync()
 
     def assertEventually(self, fn, value):
         """Check that an function is eventually equal to value.
@@ -503,7 +508,7 @@ class UDisksTestCase(unittest.TestCase):
         self.assertEventually(lambda: obj.get_property(name), value)
 
     @classmethod
-    def write_stderr(klass, msg):
+    def write_stderr(cls, msg):
         """Write to stderr without buffering"""
         sys.stderr.write(msg)
         sys.stderr.flush()
@@ -1069,40 +1074,39 @@ class Fstab(UDisksTestCase):
     """Test /etc/fstab custom options"""
 
     @classmethod
-    def setUpClass(kls):
-        kls.orig_fstab = '/etc/fstab.udiskstest'
-        shutil.copy2('/etc/fstab', kls.orig_fstab)
+    def setUpClass(cls):
+        cls.orig_fstab = '/etc/fstab.udiskstest'
+        shutil.copy2('/etc/fstab', cls.orig_fstab)
 
         # create one partition
         subprocess.check_call(
-            ['parted', '-s', kls.device, 'mklabel', 'gpt'],
-            stdout=subprocess.PIPE)
+            ['parted', '-s', cls.device, 'mklabel', 'gpt'], stdout=subprocess.PIPE)
         subprocess.check_call(
-            ['parted', '-s', kls.device, 'mkpart', 'primary', '0', '64'],
+            ['parted', '-s', cls.device, 'mkpart', 'primary', '0', '64'],
             stdout=subprocess.PIPE)
-        kls.p1label = 'udtestp1'
+        cls.p1label = 'udtestp1'
         subprocess.check_call(
-            ['parted', '-s', kls.device, 'name', '1', kls.p1label],
+            ['parted', '-s', cls.device, 'name', '1', cls.p1label],
             stdout=subprocess.PIPE)
-        kls.sync()
+        cls.sync()
         blkid = subprocess.check_output(
-            ['blkid', '-oudev', '-p', kls.devname(1)], universal_newlines=True).splitlines()
+            ['blkid', '-oudev', '-p', cls.devname(1)], universal_newlines=True).splitlines()
         for line in blkid:
             if line.startswith('ID_PART_ENTRY_UUID='):
-                kls.p1uuid = line.split('=', 1)[1]
+                cls.p1uuid = line.split('=', 1)[1]
                 break
         else:
             raise SystemError('blkid does not contain partition UUID')
 
-        kls.mkfs('ext2', partition=1, label='udtestfst')
-        kls.mountpoint = tempfile.mkdtemp()
-        kls.block = kls.udisks_block(partition=1)
-        kls.fs = kls.udisks_filesystem(partition=1)
+        cls.mkfs('ext2', partition=1, label='udtestfst')
+        cls.mountpoint = tempfile.mkdtemp()
+        cls.block = cls.udisks_block(partition=1)
+        cls.fs = cls.udisks_filesystem(partition=1)
 
     @classmethod
-    def tearDownClass(kls):
-        os.rmdir(kls.mountpoint)
-        os.unlink(kls.orig_fstab)
+    def tearDownClass(cls):
+        os.rmdir(cls.mountpoint)
+        os.unlink(cls.orig_fstab)
 
     def tearDown(self):
         shutil.copy2(self.orig_fstab, '/etc/fstab')
@@ -1272,7 +1276,8 @@ class Luks(UDisksTestCase):
             self.assertEqual(block.get_property('id-type'), 'crypto_LUKS')
             self.assertEqual(block.get_property('id-usage'), 'crypto')
             self.assertEqual(block.get_property('id-label'), '')
-            self.assertEqual(block.get_property('id-uuid'), self.blkid()['ID_FS_UUID'])
+            self.assertEqual(block.get_property('id-uuid'),
+                             self.blkid()['ID_FS_UUID'])
             self.assertEqual(block.get_property('device'), self.devname())
 
             # check whether we can lock/unlock; we also need this to get the


### PR DESCRIPTION
The root of all my local problems was caused because I was **missing the udev rules file**!  This PR adds code to copy that over too in the CI `run_tests.py` code.  It also adds code to remove the files that we copied over if no files existed before, so that we leave the system in the same state.  The actual unlink is commented out right now as the `intergration-test` doesn't do this copying.  I will work on moving this setup/teardown into a separate library so that we can share it across different tests cases.

Note: I also re-factored the copy code into one common function.