### PR TITLE
Move new partition start if overlaps with extended partition metadata

### DIFF
--- a/src/tests/dbus-tests/test_60_partitioning.py
+++ b/src/tests/dbus-tests/test_60_partitioning.py
@@ -123,7 +123,7 @@ class UdisksPartitionTableTest(udiskstestcase.UdisksTestCase):
         self.assertIn(sys_pttype, ['0x5', '0xf', '0x85'])  # lsblk prints 0xf instead of 0x0f
 
         # create logical partition
-        log_path = disk.CreatePartition(dbus.UInt64(2 * 1024**2), dbus.UInt64(50 * 1024**2), '', '',
+        log_path = disk.CreatePartition(dbus.UInt64(1024**2), dbus.UInt64(100 * 1024**2), '', '',
                                         self.no_options, dbus_interface=self.iface_prefix + '.PartitionTable')
         self.udev_settle()
 
@@ -135,6 +135,11 @@ class UdisksPartitionTableTest(udiskstestcase.UdisksTestCase):
         # check if its a 'contained'
         dbus_cont = self.get_property(log_part, '.Partition', 'IsContained')
         dbus_cont.assertTrue()
+
+        # create one more logical partition
+        log_path = disk.CreatePartition(dbus.UInt64(101 * 1024**2), dbus.UInt64(100 * 1024**2), '', '',
+                                        self.no_options, dbus_interface=self.iface_prefix + '.PartitionTable')
+        self.udev_settle()
 
     def test_create_gpt_partition(self):
         disk = self.get_object('/block_devices/' + os.path.basename(self.vdevs[0]))


### PR DESCRIPTION
We shouldn't allow to create logical partitions that start on the
extended partition metadata, but users have no way how to tell
how big the metadata are, so we want to fix the logical partition
for them.