### PR TITLE
Give kernel a time to scan partitions on a loop device

### DIFF
--- a/src/tests/dbus-tests/test_loop.py
+++ b/src/tests/dbus-tests/test_loop.py
@@ -231,5 +231,7 @@ class UdisksManagerLoopDeviceTest(udiskstestcase.UdisksTestCase):
         path, loop_dev = loop_dev_obj_path.rsplit("/", 1)
         self.addCleanup(self.run_command, "losetup -d /dev/%s" % loop_dev)
 
+        time.sleep(1)
+
         # partitions should be scanned
         self.assertTrue(os.path.exists("/dev/%sp1" % loop_dev))


### PR DESCRIPTION
It may take some short time and thus our tests may fail for no
real reason. Let's try to wait a second and then check if the
partitions were scanned or not.