### PR TITLE
Manually trigger uevent after changing filesystem label

### DIFF
--- a/src/udiskslinuxfilesystem.c
+++ b/src/udiskslinuxfilesystem.c
@@ -1995,6 +1995,13 @@ handle_set_label (UDisksFilesystem      *filesystem,
                                                    NULL, /* input_string */
                                                    "%s", command);
 
+  /* XXX: label property is automatically updated after an udev change
+   * event for this device, but udev sometimes returns the old label
+   * so just trigger the uevent again now to be sure the property
+   * has been updated
+  */
+  udisks_linux_block_object_trigger_uevent (UDISKS_LINUX_BLOCK_OBJECT (object));
+
   if (success)
     udisks_filesystem_complete_set_label (filesystem, invocation);
   else


### PR DESCRIPTION
This should fix failing tests -- udev sometimes returns old
value when checking for label after "normal" uevents (triggered
by the change).