### PR TITLE
support elogind; elogind is the logind standalone extracted from systemd source

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -171,6 +171,17 @@ AC_SUBST(HAVE_LIBSYSTEMD_LOGIN)
 AC_SUBST(LIBSYSTEMD_LOGIN_CFLAGS)
 AC_SUBST(LIBSYSTEMD_LOGIN_LIBS)
 
+PKG_CHECK_MODULES(LIBELOGIND, [libelogind >= 219],
+                  [have_libelogind=yes],
+                  [have_libelogins=no])
+AM_CONDITIONAL(HAVE_LIBELOGIND, test x$have_libelogind = xyes)
+if test "x$have_libelogind" = "xyes"; then
+  AC_DEFINE([HAVE_LIBELOGIND], 1, [Define to 1 if libelogind is available])
+fi
+AC_SUBST(HAVE_LIBELOGIND)
+AC_SUBST(LIBELOGIND_CFLAGS)
+AC_SUBST(LIBELOGIND_LIBS)
+
 # udevdir
 AC_ARG_WITH([udevdir],
             AS_HELP_STRING([--with-udevdir=DIR], [Directory for udev]),
@@ -601,6 +612,7 @@ echo "
         udevdir:                    ${udevdir}
         systemdsystemunitdir:       ${systemdsystemunitdir}
         using libsystemd-login:     ${have_libsystemd_login}
+        using libelogind:           ${have_libelogind}
         use /media for mounting:    ${fhs_media}
         acl support:                ${have_acl}
         libblockdev_part support:   ${have_libblockdev_part}

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -100,6 +100,7 @@ libudisks_daemon_la_CFLAGS =                                                   \
 	$(POLKIT_GOBJECT_1_CFLAGS)                                             \
 	$(ACL_CFLAGS)                                                          \
 	$(LIBSYSTEMD_LOGIN_CFLAGS)                                             \
+	$(LIBELOGIND_CFLAGS)                                                   \
 	$(PART_CFLAGS)                                                         \
 	$(NULL)
 
@@ -112,6 +113,7 @@ libudisks_daemon_la_LIBADD =                                                   \
 	$(POLKIT_GOBJECT_1_LIBS)                                               \
 	$(ACL_LIBS)                                                            \
 	$(LIBSYSTEMD_LOGIN_LIBS)                                               \
+	$(LIBELOGIND_LIBS)                                                     \
 	$(PART_LDFLAGS)                                                        \
 	$(top_builddir)/udisks/libudisks2.la                                   \
 	$(NULL)

--- a/src/udisksdaemonutil.c
+++ b/src/udisksdaemonutil.c
@@ -44,7 +44,15 @@
 #if defined(HAVE_LIBSYSTEMD_LOGIN)
 #include <systemd/sd-daemon.h>
 #include <systemd/sd-login.h>
+#endif
 
+#if defined(HAVE_ELOGIND) && !defined(HAVE_LIBSYSTEMD_LOGIN)
+#include <elogind/sd-login.h>
+/* re-use HAVE_LIBSYSTEMD_LOGIN to not clutter the source file */
+#define HAVE_LIBSYSTEMD_LOGIN 1
+#endif
+
+#if defined(HAVE_LIBSYSTEMD_LOGIN)
 #define LOGIND_AVAILABLE() (access("/run/systemd/seats/", F_OK) >= 0)
 #endif
 


### PR DESCRIPTION
Patch source to support elogind alternatively to libsystemd-login.
[Elogind](https://github.com/elogind/elogind) is the extracted logind standalone from systemd source.

All credits to sven eden of gentoo, I just ported the patch to 2.6.4