### PR TITLE
Fixes needed to configure, compile and build on RHEL/CentOS 7

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -95,6 +95,13 @@ if test -z "$XSLTPROC"; then
   AC_MSG_ERROR([xsltproc is needed])
 fi
 
+if test -z "$enable_modules"; then
+  enable_modules=no
+fi
+if test -z "$enable_available_modules"; then
+  enable_available_modules=no
+fi
+
 GTK_DOC_CHECK([1.3],[--flavour no-tmpl])
 
 AC_ARG_ENABLE(man,
@@ -246,7 +253,8 @@ AM_CONDITIONAL(HAVE_ACL, [test "$have_acl" = "yes"])
 have_lvm2=no
 AC_ARG_ENABLE(lvm2, AS_HELP_STRING([--enable-lvm2], [enable LVM2 support]))
 if test "x$enable_lvm2" = "xyes" \
-     -o "x$enable_modules" = "xyes"; then
+     -o "x$enable_modules" = "xyes" \
+     -o "x$enable_available_modules" = "xyes"; then
 
   CFLAGS="$GLIB_CFLAGS -I/usr/include/blockdev"
   LDFLAGS="$GLIB_LIBS"
@@ -259,8 +267,10 @@ if test "x$enable_lvm2" = "xyes" \
   CFLAGS=$SAVE_CFLAGS
   LDFLAGS=$SAVE_LDFLAGS
 
-  if test \( "x$have_lvm2" = "xno" \); then
-    AC_MSG_ERROR([lvm2 support requested but libraries not found])
+  if test "x$have_lvm2" = "xno"; then
+     if test "x$enable_lvm2" = "xyes" -o "x$enable_modules" = "xyes"; then
+         AC_MSG_ERROR([lvm2 support requested but libraries not found])
+     fi
   fi
 fi
 AM_CONDITIONAL(HAVE_LVM2, [test "$have_lvm2" = "yes"])
@@ -269,10 +279,13 @@ AM_CONDITIONAL(HAVE_LVM2, [test "$have_lvm2" = "yes"])
 have_lvmcache=no
 AC_ARG_ENABLE(lvmcache, AS_HELP_STRING([--enable-lvmcache], [enable LVMCache support]))
 if test "x$enable_lvmcache" = "xyes" \
-     -o "x$enable_modules" = "xyes"; then
+     -o "x$enable_modules" = "xyes" \
+     -o "x$enable_available_modules" = "xyes"; then
 
   if test "x$have_lvm2" = "xno"; then
-    AC_MSG_ERROR([lvmcache support requested, but lvm2 module not enabled])
+     if test "x$enable_lvmcache" = "xyes" -o "x$enable_modules" = "xyes"; then
+         AC_MSG_ERROR([lvmcache support requested, but lvm2 module not enabled])
+     fi
   fi
   have_lvmcache=yes
   AC_DEFINE(HAVE_LVMCACHE, 1, [Define if lvmcache is available])
@@ -285,7 +298,8 @@ have_libiscsi_session_info="no"
 have_libiscsi_session_info_msg=""
 AC_ARG_ENABLE(iscsi, AS_HELP_STRING([--enable-iscsi], [enable iSCSI support]))
 if test "x$enable_iscsi" = "xyes" \
-     -o "x$enable_modules" = "xyes"; then
+     -o "x$enable_modules" = "xyes" \
+     -o "x$enable_available_modules" = "xyes"; then
   # libiscsi.h
   AC_CHECK_HEADER([libiscsi.h],
                   [AC_DEFINE(HAVE_ISCSI, 1, [Define if libiscsi from iscsi-initiator-utils is available])
@@ -316,7 +330,9 @@ if test "x$enable_iscsi" = "xyes" \
   fi
 
   if test "x$have_iscsi" = "xno"; then
-    AC_MSG_ERROR([iSCSI support requested but libraries not found])
+     if test "x$enable_iscsi" = "xyes" -o "x$enable_modules" = "xyes"; then
+         AC_MSG_ERROR([iSCSI support requested but libraries not found])
+     fi
   fi
   AC_SUBST([ISCSI_LIBS])
 fi
@@ -327,7 +343,8 @@ AM_CONDITIONAL(BUILD_ISCSI_SESSION_OBJECT, [test "x$have_libiscsi_session_info" 
 have_btrfs=no
 AC_ARG_ENABLE(btrfs, AS_HELP_STRING([--enable-btrfs], [enable BTRFS support]))
 if test "x$enable_btrfs" = "xyes" \
-     -o "x$enable_modules" = "xyes"; then
+     -o "x$enable_modules" = "xyes" \
+     -o "x$enable_available_modules" = "xyes"; then
     # libblockdev
     SAVE_CFLAGS=$CFLAGS
     SAVE_LDFLAGS=$LDFLAGS
@@ -347,7 +364,9 @@ if test "x$enable_btrfs" = "xyes" \
     LDFLAGS=$SAVE_LDFLAGS
 
     if test "x$have_btrfs" = "xno"; then
-      AC_MSG_ERROR([BTRFS support requested but header or library not found])
+     if test "x$enable_btrfs" = "xyes" -o "x$enable_modules" = "xyes"; then
+         AC_MSG_ERROR([BTRFS support requested but header or library not found])
+     fi
     fi
 fi
 AM_CONDITIONAL(HAVE_BTRFS, [test "x$have_btrfs" = "xyes"])
@@ -358,7 +377,8 @@ have_swap="no"
 have_zram="no"
 AC_ARG_ENABLE(zram, AS_HELP_STRING([--enable-zram], [enable ZRAM support]))
 if test "x$enable_zram" = "xyes" \
-     -o "x$enable_modules" = "xyes"; then
+     -o "x$enable_modules" = "xyes" \
+     -o "x$enable_available_modules" = "xyes"; then
     # libblockdev
     SAVE_CFLAGS=$CFLAGS
     SAVE_LDFLAGS=$LDFLAGS
@@ -374,7 +394,9 @@ if test "x$enable_zram" = "xyes" \
                     have_kbd=no])
 
     if test "x$have_kbd" = "xno"; then
-      AC_MSG_ERROR([KBD support requested but header or library not found])
+        if test "x$enable_zram" = "xyes" -o "x$enable_modules" = "xyes"; then
+            AC_MSG_ERROR([KBD support requested but header or library not found])
+        fi
     fi
 
     CFLAGS="$GLIB_CFLAGS"
@@ -392,7 +414,9 @@ if test "x$enable_zram" = "xyes" \
     LDFLAGS=$SAVE_LDFLAGS
 
     if test "x$have_swap" = "xno"; then
-      AC_MSG_ERROR([SWAP support requested but header or library not found])
+        if test "x$enable_zram" = "xyes" -o "x$enable_modules" = "xyes"; then
+            AC_MSG_ERROR([SWAP support requested but header or library not found])
+        fi
     fi
 
     have_zram="yes"
@@ -409,7 +433,8 @@ have_lsm=no
 AC_ARG_ENABLE(
     lsm, AS_HELP_STRING([--enable-lsm], [enable LibStorageMgmt support]))
 if test "x$enable_lsm" = "xyes" \
-        -o "x$enable_modules" = "xyes"; then
+     -o "x$enable_modules" = "xyes" \
+     -o "x$enable_available_modules" = "xyes"; then
     PKG_CHECK_MODULES(
         [LIBLSM], [libstoragemgmt >= 1.3.0],
         [AC_DEFINE(HAVE_LSM, 1, [Define if liblibstoragemgmt is available])
@@ -425,7 +450,9 @@ if test "x$enable_lsm" = "xyes" \
             have_lsm=no])
 
   if test "x$have_lsm" = "xno"; then
-    AC_MSG_ERROR([LibStorageMgmt support requested but libraries not found])
+      if test "x$enable_lsm" = "xyes" -o "x$enable_modules" = "xyes"; then
+          AC_MSG_ERROR([LibStorageMgmt support requested but libraries not found])
+      fi
   fi
 fi
 AM_CONDITIONAL(HAVE_LSM, [test "x$have_lsm" = "xyes"])
@@ -434,7 +461,8 @@ AM_CONDITIONAL(HAVE_LSM, [test "x$have_lsm" = "xyes"])
 have_bcache=no
 AC_ARG_ENABLE(bcache, AS_HELP_STRING([--enable-bcache], [enable Bcache support]))
 if test "x$enable_bcache" = "xyes" \
-     -o "x$enable_modules" = "xyes"; then
+     -o "x$enable_modules" = "xyes" \
+     -o "x$enable_available_modules" = "xyes"; then
     # libblockdev
     SAVE_CFLAGS=$CFLAGS
     SAVE_LDFLAGS=$LDFLAGS
@@ -452,7 +480,9 @@ if test "x$enable_bcache" = "xyes" \
     LDFLAGS=$SAVE_LDFLAGS
 
     if test "x$have_bcache" = "xno"; then
-      AC_MSG_ERROR([Bcache support requested but header or library not found])
+        if test "x$enable_bcache" = "xyes" -o "x$enable_modules" = "xyes"; then
+            AC_MSG_ERROR([Bcache support requested but header or library not found])
+        fi
     fi
 fi
 AM_CONDITIONAL(HAVE_BCACHE, [test "x$have_bcache" = "xyes"])
@@ -598,6 +628,14 @@ AC_DEFINE([PACKAGE_NAME_UDISKS2], ["udisks2"], [Full package name for UDisks2 co
 # Generate
 #
 
+if test "x$enable_modules" = "xyes"; then
+  enable_modules_info=yes
+elif test "x$enable_available_modules" = "xyes"; then
+    enable_modules_info=available
+else
+  enable_modules_info=no
+fi
+
 AC_OUTPUT([
 Makefile
 data/Makefile
@@ -696,6 +734,8 @@ echo "
         Maintainer mode:            ${USE_MAINTAINER_MODE}
         Building api docs:          ${enable_gtk_doc}
         Building man pages:         ${enable_man}
+
+        Enable modules:             ${enable_modules_info}
 
         BTRFS module:               ${have_btrfs}
         iSCSI module:               ${have_iscsi}${have_libiscsi_session_info_msg}

--- a/configure.ac
+++ b/configure.ac
@@ -479,6 +479,12 @@ if test "x$enable_bcache" = "xyes" \
     CFLAGS=$SAVE_CFLAGS
     LDFLAGS=$SAVE_LDFLAGS
 
+    # also check that libblockdev was compiled with the bcache support
+    pkg-config --cflags blockdev|grep -q WITH_BD_BCACHE
+    if test $? == 1; then
+       have_bcache=no
+    fi
+
     if test "x$have_bcache" = "xno"; then
         if test "x$enable_bcache" = "xyes" -o "x$enable_modules" = "xyes"; then
             AC_MSG_ERROR([Bcache support requested but header or library not found])

--- a/m4/ax_check_enable_debug.m4
+++ b/m4/ax_check_enable_debug.m4
@@ -1,0 +1,124 @@
+# ===========================================================================
+#  https://www.gnu.org/software/autoconf-archive/ax_check_enable_debug.html
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   AX_CHECK_ENABLE_DEBUG([enable by default=yes/info/profile/no], [ENABLE DEBUG VARIABLES ...], [DISABLE DEBUG VARIABLES NDEBUG ...], [IS-RELEASE])
+#
+# DESCRIPTION
+#
+#   Check for the presence of an --enable-debug option to configure, with
+#   the specified default value used when the option is not present.  Return
+#   the value in the variable $ax_enable_debug.
+#
+#   Specifying 'yes' adds '-g -O0' to the compilation flags for all
+#   languages. Specifying 'info' adds '-g' to the compilation flags.
+#   Specifying 'profile' adds '-g -pg' to the compilation flags and '-pg' to
+#   the linking flags. Otherwise, nothing is added.
+#
+#   Define the variables listed in the second argument if debug is enabled,
+#   defaulting to no variables.  Defines the variables listed in the third
+#   argument if debug is disabled, defaulting to NDEBUG.  All lists of
+#   variables should be space-separated.
+#
+#   If debug is not enabled, ensure AC_PROG_* will not add debugging flags.
+#   Should be invoked prior to any AC_PROG_* compiler checks.
+#
+#   IS-RELEASE can be used to change the default to 'no' when making a
+#   release.  Set IS-RELEASE to 'yes' or 'no' as appropriate. By default, it
+#   uses the value of $ax_is_release, so if you are using the AX_IS_RELEASE
+#   macro, there is no need to pass this parameter.
+#
+#     AX_IS_RELEASE([git-directory])
+#     AX_CHECK_ENABLE_DEBUG()
+#
+# LICENSE
+#
+#   Copyright (c) 2011 Rhys Ulerich <rhys.ulerich@gmail.com>
+#   Copyright (c) 2014, 2015 Philip Withnall <philip@tecnocode.co.uk>
+#
+#   Copying and distribution of this file, with or without modification, are
+#   permitted in any medium without royalty provided the copyright notice
+#   and this notice are preserved.
+
+#serial 8
+
+AC_DEFUN([AX_CHECK_ENABLE_DEBUG],[
+    AC_BEFORE([$0],[AC_PROG_CC])dnl
+    AC_BEFORE([$0],[AC_PROG_CXX])dnl
+    AC_BEFORE([$0],[AC_PROG_F77])dnl
+    AC_BEFORE([$0],[AC_PROG_FC])dnl
+
+    AC_MSG_CHECKING(whether to enable debugging)
+
+    ax_enable_debug_default=m4_tolower(m4_normalize(ifelse([$1],,[no],[$1])))
+    ax_enable_debug_is_release=m4_tolower(m4_normalize(ifelse([$4],,
+                                                              [$ax_is_release],
+                                                              [$4])))
+
+    # If this is a release, override the default.
+    AS_IF([test "$ax_enable_debug_is_release" = "yes"],
+      [ax_enable_debug_default="no"])
+
+    m4_define(ax_enable_debug_vars,[m4_normalize(ifelse([$2],,,[$2]))])
+    m4_define(ax_disable_debug_vars,[m4_normalize(ifelse([$3],,[NDEBUG],[$3]))])
+
+    AC_ARG_ENABLE(debug,
+        [AS_HELP_STRING([--enable-debug=]@<:@yes/info/profile/no@:>@,[compile with debugging])],
+        [],enable_debug=$ax_enable_debug_default)
+
+    # empty mean debug yes
+    AS_IF([test "x$enable_debug" = "x"],
+      [enable_debug="yes"])
+
+    # case of debug
+    AS_CASE([$enable_debug],
+      [yes],[
+        AC_MSG_RESULT(yes)
+        CFLAGS="${CFLAGS} -g -O0"
+        CXXFLAGS="${CXXFLAGS} -g -O0"
+        FFLAGS="${FFLAGS} -g -O0"
+        FCFLAGS="${FCFLAGS} -g -O0"
+        OBJCFLAGS="${OBJCFLAGS} -g -O0"
+      ],
+      [info],[
+        AC_MSG_RESULT(info)
+        CFLAGS="${CFLAGS} -g"
+        CXXFLAGS="${CXXFLAGS} -g"
+        FFLAGS="${FFLAGS} -g"
+        FCFLAGS="${FCFLAGS} -g"
+        OBJCFLAGS="${OBJCFLAGS} -g"
+      ],
+      [profile],[
+        AC_MSG_RESULT(profile)
+        CFLAGS="${CFLAGS} -g -pg"
+        CXXFLAGS="${CXXFLAGS} -g -pg"
+        FFLAGS="${FFLAGS} -g -pg"
+        FCFLAGS="${FCFLAGS} -g -pg"
+        OBJCFLAGS="${OBJCFLAGS} -g -pg"
+        LDFLAGS="${LDFLAGS} -pg"
+      ],
+      [
+        AC_MSG_RESULT(no)
+        dnl Ensure AC_PROG_CC/CXX/F77/FC/OBJC will not enable debug flags
+        dnl by setting any unset environment flag variables
+        AS_IF([test "x${CFLAGS+set}" != "xset"],
+          [CFLAGS=""])
+        AS_IF([test "x${CXXFLAGS+set}" != "xset"],
+          [CXXFLAGS=""])
+        AS_IF([test "x${FFLAGS+set}" != "xset"],
+          [FFLAGS=""])
+        AS_IF([test "x${FCFLAGS+set}" != "xset"],
+          [FCFLAGS=""])
+        AS_IF([test "x${OBJCFLAGS+set}" != "xset"],
+          [OBJCFLAGS=""])
+      ])
+
+    dnl Define various variables if debugging is disabled.
+    dnl assert.h is a NOP if NDEBUG is defined, so define it by default.
+    AS_IF([test "x$enable_debug" = "xyes"],
+      [m4_map_args_w(ax_enable_debug_vars, [AC_DEFINE(], [,,[Define if debugging is enabled])])],
+      [m4_map_args_w(ax_disable_debug_vars, [AC_DEFINE(], [,,[Define if debugging is disabled])])])
+    ax_enable_debug=$enable_debug
+])


### PR DESCRIPTION
So that we can run tests on RHEL/CentOS 7 and build *udisks2* for EPEL 7 in our copr repositories.