### PR TITLE
configure.ac: Save/Restore compiler/linker flags

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -248,6 +248,9 @@ AC_ARG_ENABLE(lvm2, AS_HELP_STRING([--enable-lvm2], [enable LVM2 support]))
 if test "x$enable_lvm2" = "xyes" \
      -o "x$enable_modules" = "xyes"; then
 
+  SAVE_CFLAGS=$CFLAGS
+  SAVE_LDFLAGS=$LDFLAGS
+
   CFLAGS="$GLIB_CFLAGS -I/usr/include/blockdev"
   LDFLAGS="$GLIB_LIBS"
   AC_MSG_CHECKING([libblockdev-lvm presence])


### PR DESCRIPTION
If you do '--enable-lvm2' you stomp on the complier and linker flags.
I found this because I was unable to build a daemon with debug symbols
and all the modules enabled.

Signed-off-by: Tony Asleson <tasleson@redhat.com>