### PR TITLE
Require 'udev' not 'systemd-udev'

### DIFF
--- a/packaging/udisks2.spec.in
+++ b/packaging/udisks2.spec.in
@@ -62,7 +62,7 @@ BuildRequires: systemd
 # Needed to pull in the system bus daemon
 Requires: dbus >= %{dbus_version}
 # Needed to pull in the udev daemon
-Requires: systemd-udev >= %{systemd_version}
+Requires: udev >= %{systemd_version}
 # We need at least this version for bugfixes/features etc.
 Requires: libatasmart >= %{libatasmart_version}
 # For mount, umount, mkswap


### PR DESCRIPTION
There's no 'udev' package in recent Fedora and RHEL/CentOS
distributions, but 'udev' is correctly provided by the packages
providing the udev-related tools -- 'systemd-udev' on Fedora and
'systemd' on RHEL/CentOS.