### PR TITLE
Query methods for available utility binaries

### DIFF
--- a/data/org.freedesktop.UDisks2.xml
+++ b/data/org.freedesktop.UDisks2.xml
@@ -40,6 +40,65 @@
     <property name="SupportedFilesystems" type="as" access="read"/>
 
     <!--
+        CanFormat:
+        @type: The filesystem type to be tested for formatting availability.
+        @available: Formatting availability and the required binary name if missing (i.e. no error and returns FALSE).
+
+        Tests for availability to create the given filesystem.
+        See the #org.freedesktop.UDisks2.Manager:SupportedFilesystems property
+        for a list of known types. Unknown or unsupported filesystems result in an error.
+    -->
+    <method name="CanFormat">
+      <arg name="type" direction="in" type="s"/>
+      <arg name="available" direction="out" type="(bs)"/>
+    </method>
+
+    <!--
+        CanResize:
+        @type: The filesystem type to be tested for resize availability.
+        @available: Resizing availability, flags for allowed resizing (i.e. growing/shrinking support for online/offline) and the required binary name if missing (i.e. no error and returns FALSE).
+
+        Tests for availability to resize the given filesystem.
+        The mode flags indicate if growing and/or shriking resize is available if mounted/unmounted.
+        The mode corresponds to bitwise-OR combined BDFsResizeFlags of the libblockdev FS plugin:
+        BD_FS_OFFLINE_SHRINK = 2, shrinking resize allowed when unmounted
+        BD_FS_OFFLINE_GROW = 4, growing resize allowed when unmounted
+        BD_FS_ONLINE_SHRINK = 8, shrinking resize allowed when mounted
+        BD_FS_ONLINE_GROW = 16, growing resize allowed when mounted
+        Unknown filesystems or filesystems which do not support resizing result in errors.
+    -->
+    <method name="CanResize">
+      <arg name="type" direction="in" type="s"/>
+      <arg name="available" direction="out" type="(bts)"/>
+    </method>
+
+    <!--
+        CanCheck:
+        @type: The filesystem type to be tested for consistency check availability.
+        @available: Checking availability and the required binary name if missing (i.e. no error and returns FALSE).
+
+        Tests for availability to check the given filesystem.
+        Unsupported filesystems or filesystems which do not support checking result in errors.
+    -->
+    <method name="CanCheck">
+      <arg name="type" direction="in" type="s"/>
+      <arg name="available" direction="out" type="(bs)"/>
+    </method>
+
+    <!--
+        CanRepair:
+        @type: The filesystem type to be tested for repair availability.
+        @available: Repair availability and the required binary name if missing (i.e. no error and returns FALSE).
+
+        Tests for availability repair the given filesystem.
+        Unsupported filesystems or filesystems which do not support repairing result in errors.
+    -->
+    <method name="CanRepair">
+      <arg name="type" direction="in" type="s"/>
+      <arg name="available" direction="out" type="(bs)"/>
+    </method>
+
+    <!--
         LoopSetup:
         @fd: An index for the file descriptor to use.
         @options: Options - known options (in addition to <link linkend="udisks-std-options">standard options</link>) includes <parameter>offset</parameter> (of type 't'), <parameter>size</parameter> (of type 't'), <parameter>read-only</parameter> (of type 'b') and <parameter>no-part-scan</parameter> (of type 'b').

--- a/src/tests/dbus-tests/test_10_basic.py
+++ b/src/tests/dbus-tests/test_10_basic.py
@@ -1,6 +1,7 @@
 import udiskstestcase
 import dbus
 import os
+from distutils.spawn import find_executable
 
 class UdisksBaseTest(udiskstestcase.UdisksTestCase):
     '''This is a base test suite'''
@@ -44,6 +45,108 @@ class UdisksBaseTest(udiskstestcase.UdisksTestCase):
         fss = self.get_property(self.manager_obj, '.Manager', 'SupportedFilesystems')
         self.assertEqual({str(s) for s in fss.value},
                          {'nilfs2', 'btrfs', 'swap', 'ext3', 'udf', 'xfs', 'minix', 'ext2', 'ext4', 'f2fs', 'reiserfs', 'ntfs', 'vfat', 'exfat'})
+
+    def test_40_can_format(self):
+        '''Test for installed filesystem creation utility with CanFormat'''
+        manager = self.get_interface(self.manager_obj, '.Manager')
+        with self.assertRaises(dbus.exceptions.DBusException):
+            manager.CanFormat('wxyz')
+        avail, util = manager.CanFormat('xfs')
+        if avail:
+            self.assertEqual(util, '')
+        else:
+            self.assertEqual(util, 'mkfs.xfs')
+        self.assertEqual(avail, find_executable('mkfs.xfs') is not None)
+        avail, util = manager.CanFormat('f2fs')
+        if avail:
+            self.assertEqual(util, '')
+        else:
+            self.assertEqual(util, 'mkfs.f2fs')
+        self.assertEqual(avail, find_executable('mkfs.f2fs') is not None)
+        avail, util = manager.CanFormat('ext4')
+        if avail:
+            self.assertEqual(util, '')
+        else:
+            self.assertEqual(util, 'mkfs.ext4')
+        self.assertEqual(avail, find_executable('mkfs.ext4') is not None)
+        for fs in map(str, self.get_property(self.manager_obj, '.Manager', 'SupportedFilesystems').value):
+            avail, util = manager.CanFormat(fs)
+            # currently UDisks relies on executables for filesystem creation
+            if avail:
+                self.assertEqual(util, '')
+            else:
+                self.assertGreater(len(util), 0)
+
+    def test_40_can_resize(self):
+        '''Test for installed filesystem resize utility with CanResize'''
+        offline_shrink = 0b00010
+        offline_grow   = 0b00100
+        online_shrink  = 0b01000
+        online_grow    = 0b10000
+        manager = self.get_interface(self.manager_obj, '.Manager')
+        with self.assertRaises(dbus.exceptions.DBusException):
+            manager.CanResize('nilfs2')
+        avail, mode, util = manager.CanResize('xfs')
+        # the resize mode flage values are defined in the method documentation
+        self.assertEqual(mode, online_grow | offline_grow)
+        if avail:
+            self.assertEqual(util, '')
+        else:
+            self.assertEqual(util, 'xfs_growfs')
+        self.assertEqual(avail, find_executable('xfs_growfs') is not None)
+        avail, mode, util = manager.CanResize('ext4')
+        self.assertEqual(mode, offline_shrink | offline_grow | online_grow)
+        if avail:
+            self.assertEqual(util, '')
+        else:
+            self.assertEqual(util, 'resize2fs')
+        self.assertEqual(avail, find_executable('resize2fs') is not None)
+        avail, mode, util = manager.CanResize('vfat')
+        self.assertTrue(avail)  # libparted, no executable
+        self.assertEqual(util, '')
+        self.assertEqual(mode, offline_shrink | offline_grow)
+
+    def test_40_can_repair(self):
+        '''Test for installed filesystem repair utility with CanRepair'''
+        manager = self.get_interface(self.manager_obj, '.Manager')
+        with self.assertRaises(dbus.exceptions.DBusException):
+            manager.CanRepair('nilfs2')
+        avail, util = manager.CanRepair('xfs')
+        if avail:
+            self.assertEqual(util, '')
+        else:
+            self.assertEqual(util, 'xfs_repair')
+        self.assertEqual(avail, find_executable('xfs_repair') is not None)
+        avail, util = manager.CanRepair('ext4')
+        if avail:
+            self.assertEqual(util, '')
+        else:
+            self.assertEqual(util, 'e2fsck')
+        self.assertEqual(avail, find_executable('e2fsck') is not None)
+        avail, util = manager.CanRepair('vfat')
+        self.assertTrue(avail)  # libparted, no executable
+        self.assertEqual(util, '')
+
+    def test_40_can_check(self):
+        '''Test for installed filesystem check utility with CanCheck'''
+        manager = self.get_interface(self.manager_obj, '.Manager')
+        with self.assertRaises(dbus.exceptions.DBusException):
+            manager.CanCheck('nilfs2')
+        avail, util = manager.CanCheck('xfs')
+        if avail:
+            self.assertEqual(util, '')
+        else:
+            self.assertEqual(util, 'xfs_db')
+        self.assertEqual(avail, find_executable('xfs_db') is not None)
+        avail, util = manager.CanCheck('ext4')
+        if avail:
+            self.assertEqual(util, '')
+        else:
+            self.assertEqual(util, 'e2fsck')
+        self.assertEqual(avail, find_executable('e2fsck') is not None)
+        avail, util = manager.CanCheck('vfat')
+        self.assertTrue(avail)  # libparted, no executable
+        self.assertEqual(util, '')
 
     def test_80_device_presence(self):
         '''Test the debug devices are present on the bus'''


### PR DESCRIPTION
The availibility of creation, resize, check and repair utility
for a filesystem can be queried through new methods CanFormat,
CanResize, CanCheck and CanRepair in org.freedesktop.UDisks2.Manager
which is useful for UIs.

It makes use of the functions in PR https://github.com/rhinstaller/libblockdev/pull/217
and so is not ready for merging. But it would be nice to know if this makes sense. In general the semantics are to return an error if an action is not supported and return false if only the binary is missing.