### PR TITLE
CentOS/RHEL 7 test fixes

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -3,6 +3,8 @@
 SHELL = /bin/bash
 .SHELLFLAGS = -o pipefail -c
 
+PYTHON ?= python3
+
 NULL =
 
 SUBDIRS = data udisks src tools modules po doc
@@ -36,7 +38,7 @@ clean-local:
 
 dbus-tests:
 	$(MAKE) all &>/dev/null
-	sudo src/tests/dbus-tests/run_tests.py -l dbus_tests.log |& tee dbus_tests_output.log \
+	sudo $(PYTHON) src/tests/dbus-tests/run_tests.py -l dbus_tests.log |& tee dbus_tests_output.log \
        && echo "dbus-tests: SUCCESS" >> RESULTS || echo "dbus-tests: FAILED" >> RESULTS
 	@tail -1 RESULTS | grep -q "dbus-tests: SUCCESS"
 
@@ -48,7 +50,7 @@ unittests:
 
 integration-tests:
 	$(MAKE) all &>/dev/null
-	cd src/tests && sudo ./integration-test | tee -a ../../integration_tests_output.log \
+	cd src/tests && sudo $(PYTHON) ./integration-test | tee -a ../../integration_tests_output.log \
        && echo "integration-tests: SUCCESS" >> ../../RESULTS || echo "integration-tests: FAILED" >> ../../RESULTS
 	@tail -1 RESULTS | grep -q "integration-tests: SUCCESS"
 

--- a/configure.ac
+++ b/configure.ac
@@ -433,6 +433,7 @@ AM_CONDITIONAL(HAVE_ZRAM, [test "$have_kbd" = "yes" -a "$have_swap" = "yes"])
 
 # LSM module
 have_lsm=no
+have_libconfig=no
 AC_ARG_ENABLE(
     lsm, AS_HELP_STRING([--enable-lsm], [enable LibStorageMgmt support]))
 if test "x$enable_lsm" = "xyes" \
@@ -447,10 +448,13 @@ if test "x$enable_lsm" = "xyes" \
 
     PKG_CHECK_MODULES(
         [LIBCONFIG], [libconfig >= 1.3.2],
-        [AC_DEFINE(HAVE_LSM, 1, [Define if libconfig is available])
-            have_lsm=yes],
+        [have_libconfig=yes],
         [AC_MSG_WARN([libconfig 1.3.2 or newer not found.])
-            have_lsm=no])
+            have_libconfig=no])
+
+  if test "x$have_libconfig" = "xno"; then
+      have_lsm=no
+  fi
 
   if test "x$have_lsm" = "xno"; then
       if test "x$enable_lsm" = "xyes" -o "x$enable_modules" = "xyes"; then

--- a/src/tests/dbus-tests/targetcli_config.json
+++ b/src/tests/dbus-tests/targetcli_config.json
@@ -6,8 +6,6 @@
         "block_size": 512,
         "emulate_3pc": 1,
         "emulate_caw": 1,
-        "emulate_dpo": 1,
-        "emulate_fua_read": 1,
         "emulate_fua_write": 1,
         "emulate_model_alias": 1,
         "emulate_rest_reord": 0,
@@ -27,8 +25,7 @@
         "pi_prot_type": 0,
         "queue_depth": 128,
         "unmap_granularity": 1,
-        "unmap_granularity_alignment": 0,
-        "unmap_zeroes_data": 0
+        "unmap_granularity_alignment": 0
       },
       "dev": "/var/tmp/udisks_test_disk4",
       "name": "udisks_test_disk4",
@@ -42,8 +39,6 @@
         "block_size": 512,
         "emulate_3pc": 1,
         "emulate_caw": 1,
-        "emulate_dpo": 1,
-        "emulate_fua_read": 1,
         "emulate_fua_write": 1,
         "emulate_model_alias": 1,
         "emulate_rest_reord": 0,
@@ -63,8 +58,7 @@
         "pi_prot_type": 0,
         "queue_depth": 128,
         "unmap_granularity": 1,
-        "unmap_granularity_alignment": 0,
-        "unmap_zeroes_data": 0
+        "unmap_granularity_alignment": 0
       },
       "dev": "/var/tmp/udisks_test_disk3",
       "name": "udisks_test_disk3",
@@ -78,8 +72,6 @@
         "block_size": 512,
         "emulate_3pc": 1,
         "emulate_caw": 1,
-        "emulate_dpo": 1,
-        "emulate_fua_read": 1,
         "emulate_fua_write": 1,
         "emulate_model_alias": 1,
         "emulate_rest_reord": 0,
@@ -99,8 +91,7 @@
         "pi_prot_type": 0,
         "queue_depth": 128,
         "unmap_granularity": 1,
-        "unmap_granularity_alignment": 0,
-        "unmap_zeroes_data": 0
+        "unmap_granularity_alignment": 0
       },
       "dev": "/var/tmp/udisks_test_disk2",
       "name": "udisks_test_disk2",
@@ -114,8 +105,6 @@
         "block_size": 512,
         "emulate_3pc": 1,
         "emulate_caw": 1,
-        "emulate_dpo": 1,
-        "emulate_fua_read": 1,
         "emulate_fua_write": 1,
         "emulate_model_alias": 1,
         "emulate_rest_reord": 0,
@@ -135,8 +124,7 @@
         "pi_prot_type": 0,
         "queue_depth": 128,
         "unmap_granularity": 1,
-        "unmap_granularity_alignment": 0,
-        "unmap_zeroes_data": 0
+        "unmap_granularity_alignment": 0
       },
       "dev": "/var/tmp/udisks_test_disk1",
       "name": "udisks_test_disk1",
@@ -150,8 +138,6 @@
         "block_size": 512,
         "emulate_3pc": 1,
         "emulate_caw": 1,
-        "emulate_dpo": 1,
-        "emulate_fua_read": 1,
         "emulate_fua_write": 1,
         "emulate_model_alias": 1,
         "emulate_rest_reord": 0,
@@ -171,8 +157,7 @@
         "pi_prot_type": 0,
         "queue_depth": 128,
         "unmap_granularity": 1,
-        "unmap_granularity_alignment": 0,
-        "unmap_zeroes_data": 0
+        "unmap_granularity_alignment": 0
       },
       "dev": "/var/tmp/udisks_test_disk_iscsi1",
       "name": "udisks_test_iscsi1",
@@ -186,8 +171,6 @@
         "block_size": 512,
         "emulate_3pc": 1,
         "emulate_caw": 1,
-        "emulate_dpo": 1,
-        "emulate_fua_read": 1,
         "emulate_fua_write": 1,
         "emulate_model_alias": 1,
         "emulate_rest_reord": 0,
@@ -207,8 +190,7 @@
         "pi_prot_type": 0,
         "queue_depth": 128,
         "unmap_granularity": 1,
-        "unmap_granularity_alignment": 0,
-        "unmap_zeroes_data": 0
+        "unmap_granularity_alignment": 0
       },
       "dev": "/var/tmp/udisks_test_disk_iscsi2",
       "name": "udisks_test_iscsi2",
@@ -222,8 +204,6 @@
         "block_size": 512,
         "emulate_3pc": 1,
         "emulate_caw": 1,
-        "emulate_dpo": 1,
-        "emulate_fua_read": 1,
         "emulate_fua_write": 1,
         "emulate_model_alias": 1,
         "emulate_rest_reord": 0,
@@ -243,8 +223,7 @@
         "pi_prot_type": 0,
         "queue_depth": 128,
         "unmap_granularity": 1,
-        "unmap_granularity_alignment": 0,
-        "unmap_zeroes_data": 0
+        "unmap_granularity_alignment": 0
       },
       "dev": "/var/tmp/udisks_test_disk_iscsi3",
       "name": "udisks_test_iscsi3",
@@ -260,7 +239,6 @@
       "tpgs": [
         {
           "attributes": {
-            "fabric_prot_type": 0
           },
           "enable": true,
           "luns": [
@@ -282,7 +260,6 @@
       "tpgs": [
         {
           "attributes": {
-            "fabric_prot_type": 0
           },
           "enable": true,
           "luns": [
@@ -304,7 +281,6 @@
       "tpgs": [
         {
           "attributes": {
-            "fabric_prot_type": 0
           },
           "enable": true,
           "luns": [
@@ -326,7 +302,6 @@
       "tpgs": [
         {
           "attributes": {
-            "fabric_prot_type": 0
           },
           "enable": true,
           "luns": [
@@ -354,7 +329,6 @@
             "default_erl": 0,
             "demo_mode_discovery": 1,
             "demo_mode_write_protect": 0,
-            "fabric_prot_type": 0,
             "generate_node_acls": 1,
             "login_timeout": 15,
             "netif_timeout": 2,
@@ -417,7 +391,6 @@
             "default_erl": 0,
             "demo_mode_discovery": 1,
             "demo_mode_write_protect": 1,
-            "fabric_prot_type": 0,
             "generate_node_acls": 0,
             "login_timeout": 15,
             "netif_timeout": 2,
@@ -504,7 +477,6 @@
             "default_erl": 0,
             "demo_mode_discovery": 1,
             "demo_mode_write_protect": 1,
-            "fabric_prot_type": 0,
             "generate_node_acls": 0,
             "login_timeout": 15,
             "netif_timeout": 2,

--- a/src/tests/dbus-tests/test_20_LVM.py
+++ b/src/tests/dbus-tests/test_20_LVM.py
@@ -13,6 +13,7 @@ class UdisksLVMTest(udiskstestcase.UdisksTestCase):
     def setUpClass(cls):
         udiskstestcase.UdisksTestCase.setUpClass()
         if not cls.check_module_loaded('LVM2'):
+            udiskstestcase.UdisksTestCase.tearDownClass()
             raise unittest.SkipTest('Udisks module for LVM tests not loaded, skipping.')
 
     def _create_vg(self, vgname, devices):

--- a/src/tests/dbus-tests/test_30_iscsi.py
+++ b/src/tests/dbus-tests/test_30_iscsi.py
@@ -195,6 +195,12 @@ class UdisksISCSITest(udiskstestcase.UdisksTestCase):
 
     def test_session(self):
         manager = self.get_object('/Manager')
+
+        # first check if session objects are supported
+        supported = self.get_property_raw(manager, '.Manager.ISCSI.Initiator', 'SessionsSupported')
+        if not supported:
+            self.skipTest("ISCSI.Session objects not supported.")
+
         nodes, _ = manager.DiscoverSendTargets(self.address, self.port, self.no_options,
                                                dbus_interface=self.iface_prefix + '.Manager.ISCSI.Initiator')
 

--- a/src/tests/dbus-tests/test_30_iscsi.py
+++ b/src/tests/dbus-tests/test_30_iscsi.py
@@ -4,6 +4,7 @@ import dbus
 import glob
 import os
 import re
+import six
 import time
 import unittest
 
@@ -105,7 +106,7 @@ class UdisksISCSITest(udiskstestcase.UdisksTestCase):
 
         # wrong password
         msg = 'Login failed: initiator reported error'
-        with self.assertRaisesRegex(dbus.exceptions.DBusException, msg):
+        with six.assertRaisesRegex(self, dbus.exceptions.DBusException, msg):
             options['password'] = '12345'
             manager.Login(iqn, tpg, host, port, iface, options,
                           dbus_interface=self.iface_prefix + '.Manager.ISCSI.Initiator')

--- a/src/tests/dbus-tests/test_30_iscsi.py
+++ b/src/tests/dbus-tests/test_30_iscsi.py
@@ -199,6 +199,7 @@ class UdisksISCSITest(udiskstestcase.UdisksTestCase):
         # first check if session objects are supported
         supported = self.get_property_raw(manager, '.Manager.ISCSI.Initiator', 'SessionsSupported')
         if not supported:
+            udiskstestcase.UdisksTestCase.tearDownClass()
             self.skipTest("ISCSI.Session objects not supported.")
 
         nodes, _ = manager.DiscoverSendTargets(self.address, self.port, self.no_options,

--- a/src/tests/dbus-tests/test_40_drive.py
+++ b/src/tests/dbus-tests/test_40_drive.py
@@ -2,6 +2,7 @@ import time
 import dbus
 import glob
 import os
+import six
 import unittest
 import udiskstestcase
 
@@ -50,8 +51,8 @@ class UdisksDriveTest(udiskstestcase.UdisksTestCase):
 
         dev = self.get_device(self.vdevs[0])
         drive = self.get_drive(dev)
-        with self.assertRaisesRegex(dbus.exceptions.DBusException,
-                                    'is not hot-pluggable device'):
+        with six.assertRaisesRegex(self, dbus.exceptions.DBusException,
+                                   'is not hot-pluggable device'):
             drive.Eject(self.no_options)
 
         dev = self.get_device(self.cd_dev)
@@ -66,8 +67,8 @@ class UdisksDriveTest(udiskstestcase.UdisksTestCase):
 
             # check should fail since device cannot be powered off
             # sadly this is so far the only way we can test this function
-            with self.assertRaisesRegex(dbus.exceptions.DBusException,
-                                        'Failed: No usb device'):
+            with six.assertRaisesRegex(self, dbus.exceptions.DBusException,
+                                       'Failed: No usb device'):
                 drive.PowerOff(self.no_options)
 
     def test_30_setconfiguration(self):

--- a/src/tests/dbus-tests/test_40_drive.py
+++ b/src/tests/dbus-tests/test_40_drive.py
@@ -46,6 +46,7 @@ class UdisksDriveTest(udiskstestcase.UdisksTestCase):
             self.udev_settle()
             self.run_command('modprobe -r scsi_debug')
 
+    @udiskstestcase.skip_on(("centos", "enterprise_linux"), reason="SCSI debug bug causing kernel panic on CentOS/RHEL 7")
     def test_10_eject(self):
         ''' Test of Drive.Eject method '''
 
@@ -59,6 +60,7 @@ class UdisksDriveTest(udiskstestcase.UdisksTestCase):
         drive = self.get_drive(dev)
         drive.Eject(self.no_options)
 
+    @udiskstestcase.skip_on(("centos", "enterprise_linux"), reason="SCSI debug bug causing kernel panic on CentOS/RHEL 7")
     def test_20_poweroff(self):
         ''' Test of Drive.PowerOff method '''
         for dev in (self.vdevs[0], self.cd_dev):
@@ -71,6 +73,7 @@ class UdisksDriveTest(udiskstestcase.UdisksTestCase):
                                        'Failed: No usb device'):
                 drive.PowerOff(self.no_options)
 
+    @udiskstestcase.skip_on(("centos", "enterprise_linux"), reason="SCSI debug bug causing kernel panic on CentOS/RHEL 7")
     def test_30_setconfiguration(self):
         ''' Test of Drive.SetConfiguration method '''
         # set configuration value to some improbable value
@@ -81,6 +84,7 @@ class UdisksDriveTest(udiskstestcase.UdisksTestCase):
         conf_value.assertIsNotNone()
         self.assertEqual(str(conf_value.value['ata-pm-standby']), '286')
 
+    @udiskstestcase.skip_on(("centos", "enterprise_linux"), reason="SCSI debug bug causing kernel panic on CentOS/RHEL 7")
     def test_40_properties(self):
         ''' Test of Drive properties values '''
 

--- a/src/tests/dbus-tests/test_50_block.py
+++ b/src/tests/dbus-tests/test_50_block.py
@@ -79,6 +79,12 @@ class UdisksBlockTest(udiskstestcase.UdisksTestCase):
 
     def test_open(self):
 
+        # O_ACCMODE is node defined in Python 2 version of 'os' module
+        try:
+            from os import O_ACCMODE
+        except ImportError:
+            O_ACCMODE = 3
+
         # format the disk
         disk = self.get_object('/block_devices/' + os.path.basename(self.vdevs[0]))
         disk.Format('xfs', self.no_options, dbus_interface=self.iface_prefix + '.Block')
@@ -90,7 +96,7 @@ class UdisksBlockTest(udiskstestcase.UdisksTestCase):
         self.assertIsNotNone(dbus_fd)
 
         fd = dbus_fd.take()
-        mode = fcntl.fcntl(fd, fcntl.F_GETFL) & os.O_ACCMODE
+        mode = fcntl.fcntl(fd, fcntl.F_GETFL) & O_ACCMODE
         self.assertEqual(mode, os.O_RDONLY)
         os.close(fd)
 
@@ -99,7 +105,7 @@ class UdisksBlockTest(udiskstestcase.UdisksTestCase):
         self.assertIsNotNone(dbus_fd)
 
         fd = dbus_fd.take()
-        mode = fcntl.fcntl(fd, fcntl.F_GETFL) & os.O_ACCMODE
+        mode = fcntl.fcntl(fd, fcntl.F_GETFL) & O_ACCMODE
         self.assertEqual(mode, os.O_WRONLY)
         os.close(fd)
 

--- a/src/tests/dbus-tests/test_50_block.py
+++ b/src/tests/dbus-tests/test_50_block.py
@@ -74,7 +74,7 @@ class UdisksBlockTest(udiskstestcase.UdisksTestCase):
         dbus_type.assertIn(['0x42', '0x82'])
 
         part_name = str(part.object_path).split('/')[-1]
-        _ret, sys_type = self.run_command('lsblk -d -no PARTTYPE /dev/%s' % part_name)
+        _ret, sys_type = self.run_command('blkid /dev/%s -p -o value -s PART_ENTRY_TYPE' % part_name)
         self.assertIn(sys_type, ['0x42', '0x82'])
 
     def test_open(self):

--- a/src/tests/dbus-tests/test_60_partitioning.py
+++ b/src/tests/dbus-tests/test_60_partitioning.py
@@ -79,7 +79,11 @@ class UdisksPartitionTableTest(udiskstestcase.UdisksTestCase):
         sys_start = int(self.read_file('%s/start' % part_syspath))
         self.assertEqual(sys_start * BLOCK_SIZE, 1024**2)
 
-        _ret, sys_type = self.run_command('lsblk -d -no PARTTYPE /dev/%s' % part_name)
+        # format the partition so blkid is able to display info about it
+        # (yes, it is stupid, but this is how blkid works on CentOS/RHEL 7)
+        _ret, _out = self.run_command('mkfs.ext2 /dev/%s' % part_name)
+
+        _ret, sys_type = self.run_command('blkid /dev/%s -p -o value -s PART_ENTRY_TYPE' % part_name)
         self.assertEqual(sys_type, part_type)
 
         # check uuid and part number
@@ -120,7 +124,7 @@ class UdisksPartitionTableTest(udiskstestcase.UdisksTestCase):
 
         # check system type
         part_name = str(ext_part.object_path).split('/')[-1]
-        _ret, sys_pttype = self.run_command('lsblk -d -no PARTTYPE /dev/%s' % part_name)
+        _ret, sys_pttype = self.run_command('blkid /dev/%s -p -o value -s PART_ENTRY_TYPE' % part_name)
         self.assertIn(sys_pttype, ['0x5', '0xf', '0x85'])  # lsblk prints 0xf instead of 0x0f
 
         # create logical partition
@@ -195,7 +199,11 @@ class UdisksPartitionTableTest(udiskstestcase.UdisksTestCase):
         _ret, sys_name = self.run_command('lsblk -d -no PARTLABEL /dev/%s' % part_name)
         self.assertEqual(sys_name, gpt_name)
 
-        _ret, sys_type = self.run_command('lsblk -d -no PARTTYPE /dev/%s' % part_name)
+        # format the partition so blkid is able to display info about it
+        # (yes, it is stupid, but this is how blkid works on CentOS/RHEL 7)
+        _ret, _out = self.run_command('mkfs.ext2 /dev/%s' % part_name)
+
+        _ret, sys_type = self.run_command('blkid /dev/%s -p -o value -s PART_ENTRY_TYPE' % part_name)
         self.assertEqual(sys_type, gpt_type)
 
     def test_create_with_format(self):
@@ -327,7 +335,7 @@ class UdisksPartitionTest(udiskstestcase.UdisksTestCase):
 
         # test flags value from sysytem
         part_name = str(part.object_path).split('/')[-1]
-        _ret, sys_flags = self.run_command('lsblk -d -no PARTFLAGS /dev/%s' % part_name)
+        _ret, sys_flags = self.run_command('blkid /dev/%s -p -o value -s PART_ENTRY_FLAGS' % part_name)
         self.assertEqual(sys_flags, '0x80')
 
     def test_gpt_type(self):
@@ -361,7 +369,7 @@ class UdisksPartitionTest(udiskstestcase.UdisksTestCase):
 
         # test flags value from sysytem
         part_name = str(part.object_path).split('/')[-1]
-        _ret, sys_type = self.run_command('lsblk -d -no PARTTYPE /dev/%s' % part_name)
+        _ret, sys_type = self.run_command('blkid /dev/%s -p -o value -s PART_ENTRY_TYPE' % part_name)
         self.assertEqual(sys_type, home_guid)
 
     def test_dos_type(self):
@@ -395,7 +403,7 @@ class UdisksPartitionTest(udiskstestcase.UdisksTestCase):
 
         # test flags value from sysytem
         part_name = str(part.object_path).split('/')[-1]
-        _ret, sys_type = self.run_command('lsblk -d -no PARTTYPE /dev/%s' % part_name)
+        _ret, sys_type = self.run_command('blkid /dev/%s -p -o value -s PART_ENTRY_TYPE' % part_name)
         self.assertEqual(sys_type, part_type)
 
     def test_name(self):

--- a/src/tests/dbus-tests/test_60_partitioning.py
+++ b/src/tests/dbus-tests/test_60_partitioning.py
@@ -1,5 +1,6 @@
 import dbus
 import os
+import six
 import time
 
 import udiskstestcase
@@ -42,7 +43,7 @@ class UdisksPartitionTableTest(udiskstestcase.UdisksTestCase):
         # first try to create partition with name -> should fail because mbr
         # doesn't support partition names
         msg = 'MBR partition table does not support names'
-        with self.assertRaisesRegex(dbus.exceptions.DBusException, msg):
+        with six.assertRaisesRegex(self, dbus.exceptions.DBusException, msg):
             disk.CreatePartition(dbus.UInt64(1024**2), dbus.UInt64(100 * 1024**2), part_type, 'name',
                                         self.no_options, dbus_interface=self.iface_prefix + '.PartitionTable')
 
@@ -344,7 +345,7 @@ class UdisksPartitionTest(udiskstestcase.UdisksTestCase):
 
         # first try some invalid guid
         msg = 'org.freedesktop.UDisks2.Error.Failed: .* is not a valid UUID'
-        with self.assertRaisesRegex(dbus.exceptions.DBusException, msg):
+        with six.assertRaisesRegex(self, dbus.exceptions.DBusException, msg):
             part.SetType('aaaa', self.no_options,
                          dbus_interface=self.iface_prefix + '.Partition')
 
@@ -378,7 +379,7 @@ class UdisksPartitionTest(udiskstestcase.UdisksTestCase):
 
         # try to set part type to an extended partition type -- should fail
         msg = 'Refusing to change partition type to that of an extended partition'
-        with self.assertRaisesRegex(dbus.exceptions.DBusException, msg):
+        with six.assertRaisesRegex(self, dbus.exceptions.DBusException, msg):
             part.SetType('0x05', self.no_options,
                          dbus_interface=self.iface_prefix + '.Partition')
 
@@ -412,7 +413,7 @@ class UdisksPartitionTest(udiskstestcase.UdisksTestCase):
 
         # first try some invalid name (longer than 36 characters)
         msg = 'Max partition name length is 36 characters'
-        with self.assertRaisesRegex(dbus.exceptions.DBusException, msg):
+        with six.assertRaisesRegex(self, dbus.exceptions.DBusException, msg):
             part.SetName('a' * 37, self.no_options,
                          dbus_interface=self.iface_prefix + '.Partition')
 

--- a/src/tests/dbus-tests/test_70_encrypted.py
+++ b/src/tests/dbus-tests/test_70_encrypted.py
@@ -1,5 +1,6 @@
 import dbus
 import os
+import six
 
 import udiskstestcase
 
@@ -108,13 +109,13 @@ class UdisksEncryptedTest(udiskstestcase.UdisksTestCase):
 
         # no password
         msg = 'org.freedesktop.UDisks2.Error.Failed: No key available.*'
-        with self.assertRaisesRegex(dbus.exceptions.DBusException, msg):
+        with six.assertRaisesRegex(self, dbus.exceptions.DBusException, msg):
             disk.Unlock("", self.no_options,
                         dbus_interface=self.iface_prefix + '.Encrypted')
 
         # wrong password
         msg = 'org.freedesktop.UDisks2.Error.Failed: Error unlocking %s *' % self.vdevs[0]
-        with self.assertRaisesRegex(dbus.exceptions.DBusException, msg):
+        with six.assertRaisesRegex(self, dbus.exceptions.DBusException, msg):
             disk.Unlock('shbdkjaf', self.no_options,
                         dbus_interface=self.iface_prefix + '.Encrypted')
 
@@ -144,7 +145,7 @@ class UdisksEncryptedTest(udiskstestcase.UdisksTestCase):
 
         # should not be possible to close mounted luks
         msg = 'org.freedesktop.UDisks2.Error.Failed: Error locking'
-        with self.assertRaisesRegex(dbus.exceptions.DBusException, msg):
+        with six.assertRaisesRegex(self, dbus.exceptions.DBusException, msg):
             disk.Lock(self.no_options, dbus_interface=self.iface_prefix + '.Encrypted')
 
         # now unmount it and try to close it again
@@ -166,7 +167,7 @@ class UdisksEncryptedTest(udiskstestcase.UdisksTestCase):
 
         # old password, should fail
         msg = 'org.freedesktop.UDisks2.Error.Failed: Error unlocking %s *' % self.vdevs[0]
-        with self.assertRaisesRegex(dbus.exceptions.DBusException, msg):
+        with six.assertRaisesRegex(self, dbus.exceptions.DBusException, msg):
             disk.Unlock('test', self.no_options,
                         dbus_interface=self.iface_prefix + '.Encrypted')
 

--- a/src/tests/dbus-tests/test_80_filesystem.py
+++ b/src/tests/dbus-tests/test_80_filesystem.py
@@ -75,7 +75,7 @@ class UdisksFSTestCase(udiskstestcase.UdisksTestCase):
         self.assertIsNotNone(disk)
 
         # create filesystem with label
-        label = 'test'
+        label = 'TEST' if self._fs_name == 'vfat' else 'test'  # XXX mkfs.vfat changes labels to uppercase
         d = dbus.Dictionary(signature='sv')
         d['label'] = label
         disk.Format(self._fs_name, d, dbus_interface=self.iface_prefix + '.Block')

--- a/src/tests/dbus-tests/test_80_filesystem.py
+++ b/src/tests/dbus-tests/test_80_filesystem.py
@@ -1,5 +1,7 @@
 import dbus
 import os
+import six
+import shutil
 import tempfile
 import unittest
 
@@ -162,11 +164,11 @@ class UdisksFSTestCase(udiskstestcase.UdisksTestCase):
         self.addCleanup(self._clean_format, disk)
 
         # create a tempdir
-        tmp = tempfile.TemporaryDirectory()
-        self.addCleanup(tmp.cleanup)
+        tmp = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, tmp)
 
         # configuration items as arrays of dbus.Byte
-        mnt = self.str_to_ay(tmp.name)
+        mnt = self.str_to_ay(tmp)
         fstype = self.str_to_ay(self._fs_name)
         opts = self.str_to_ay('ro')
 
@@ -184,13 +186,13 @@ class UdisksFSTestCase(udiskstestcase.UdisksTestCase):
         dbus_mounts = self.get_property(disk, '.Filesystem', 'MountPoints')
         dbus_mounts.assertLen(1)  # just one mountpoint
         dbus_mnt = self.ay_to_str(dbus_mounts.value[0])  # mountpoints are arrays of bytes
-        self.assertEqual(dbus_mnt, tmp.name)
+        self.assertEqual(dbus_mnt, tmp)
 
         # system mountpoint
-        self.assertTrue(os.path.ismount(tmp.name))
+        self.assertTrue(os.path.ismount(tmp))
 
         _ret, out = self.run_command('mount | grep %s' % self.vdevs[0])
-        self.assertIn(tmp.name, out)
+        self.assertIn(tmp, out)
         self.assertIn('ro', out)
 
 
@@ -236,7 +238,7 @@ class XFSTestCase(UdisksFSTestCase):
     def _invalid_label(self, disk):
         label = 'a a'  # space not allowed
         msg = 'org.freedesktop.UDisks2.Error.Failed: Error setting label'
-        with self.assertRaisesRegex(dbus.exceptions.DBusException, msg):
+        with six.assertRaisesRegex(self, dbus.exceptions.DBusException, msg):
             disk.SetLabel(label, self.no_options, dbus_interface=self.iface_prefix + '.Filesystem')
 
 
@@ -251,7 +253,7 @@ class VFATTestCase(UdisksFSTestCase):
     def _invalid_label(self, disk):
         label = 'a' * 12  # at most 11 characters
         msg = 'org.freedesktop.UDisks2.Error.Failed: Error setting label'
-        with self.assertRaisesRegex(dbus.exceptions.DBusException, msg):
+        with six.assertRaisesRegex(self, dbus.exceptions.DBusException, msg):
             disk.SetLabel(label, self.no_options, dbus_interface=self.iface_prefix + '.Filesystem')
 
     def _add_user(self):
@@ -276,11 +278,11 @@ class VFATTestCase(UdisksFSTestCase):
 
     def _set_user_mountable(self, disk):
         # create a tempdir
-        tmp = tempfile.TemporaryDirectory()
-        self.addCleanup(tmp.cleanup)
+        tmp = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, tmp)
 
         # configuration items as arrays of dbus.Byte
-        mnt = self.str_to_ay(tmp.name)
+        mnt = self.str_to_ay(tmp)
         fstype = self.str_to_ay(self._fs_name)
         opts = self.str_to_ay('users,x-udisks-auth')
 
@@ -565,7 +567,7 @@ class FailsystemTestCase(UdisksFSTestCase):
         # try to create some nonexisting filesystem
         msg = 'org.freedesktop.UDisks2.Error.NotSupported: Creation of file system '\
               'type definitely-nonexisting-fs is not supported'
-        with self.assertRaisesRegex(dbus.exceptions.DBusException, msg):
+        with six.assertRaisesRegex(self, dbus.exceptions.DBusException, msg):
             disk.Format('definitely-nonexisting-fs', self.no_options,
                         dbus_interface=self.iface_prefix + '.Block')
 
@@ -587,7 +589,7 @@ class FailsystemTestCase(UdisksFSTestCase):
 
         msg = 'org.freedesktop.UDisks2.Error.NotSupported: File system '\
               'type %s does not support labels' % fs._fs_name
-        with self.assertRaisesRegex(dbus.exceptions.DBusException, msg):
+        with six.assertRaisesRegex(self, dbus.exceptions.DBusException, msg):
             disk.Format(fs._fs_name, d, dbus_interface=self.iface_prefix + '.Block')
 
         # create minix filesystem without label and try to set it later
@@ -596,7 +598,7 @@ class FailsystemTestCase(UdisksFSTestCase):
 
         msg = 'org.freedesktop.UDisks2.Error.NotSupported: Don\'t know how to '\
               'change label on device of type filesystem:%s' % fs._fs_name
-        with self.assertRaisesRegex(dbus.exceptions.DBusException, msg):
+        with six.assertRaisesRegex(self, dbus.exceptions.DBusException, msg):
             disk.SetLabel('test', self.no_options, dbus_interface=self.iface_prefix + '.Filesystem')
 
     def test_mount_auto(self):
@@ -619,7 +621,7 @@ class FailsystemTestCase(UdisksFSTestCase):
         d['fstype'] = 'xfs'
 
         msg = '[Ww]rong fs type'
-        with self.assertRaisesRegex(dbus.exceptions.DBusException, msg):
+        with six.assertRaisesRegex(self, dbus.exceptions.DBusException, msg):
             mnt_path = disk.Mount(d, dbus_interface=self.iface_prefix + '.Filesystem')
             self.assertIsNone(mnt_path)
 
@@ -630,14 +632,14 @@ class FailsystemTestCase(UdisksFSTestCase):
 
         msg = 'org.freedesktop.UDisks2.Error.OptionNotPermitted: Mount option '\
               '`definitely-nonexisting-option\' is not allowed'
-        with self.assertRaisesRegex(dbus.exceptions.DBusException, msg):
+        with six.assertRaisesRegex(self, dbus.exceptions.DBusException, msg):
             mnt_path = disk.Mount(d, dbus_interface=self.iface_prefix + '.Filesystem')
             self.assertIsNone(mnt_path)
 
         # should not be mounted -- so lets try to unmount it
         msg = 'org.freedesktop.UDisks2.Error.NotMounted: Device `%s\' is not '\
               'mounted' % self.vdevs[0]
-        with self.assertRaisesRegex(dbus.exceptions.DBusException, msg):
+        with six.assertRaisesRegex(self, dbus.exceptions.DBusException, msg):
             disk.Unmount(self.no_options, dbus_interface=self.iface_prefix + '.Filesystem')
 
     def test_mount_fstab(self):

--- a/src/tests/dbus-tests/test_91_lsm.py
+++ b/src/tests/dbus-tests/test_91_lsm.py
@@ -1,5 +1,7 @@
 import os
 import dbus
+import unittest
+
 import udiskstestcase
 
 
@@ -9,6 +11,12 @@ class UdisksLsmLocalTestCase(udiskstestcase.UdisksTestCase):
     """
     _LED_CONTROL_METHOD_NAMES = ["TurnFaultLEDOn", "TurnFaultLEDOff",
                                  "TurnIdentLEDOn", "TurnIdentLEDOff"]
+
+    @classmethod
+    def setUpClass(cls):
+        udiskstestcase.UdisksTestCase.setUpClass()
+        if not cls.check_module_loaded('LSM'):
+            raise unittest.SkipTest('Udisks module for LSM tests not loaded, skipping.')
 
     def _get_dbus_drv_obj(self, dbus_blk_obj):
         obj_path = self.get_property_raw(dbus_blk_obj, '.Block', 'Drive')

--- a/src/tests/dbus-tests/test_91_lsm.py
+++ b/src/tests/dbus-tests/test_91_lsm.py
@@ -31,7 +31,7 @@ class UdisksLsmLocalTestCase(udiskstestcase.UdisksTestCase):
                 method_name,
                 dbus_interface=self.iface_prefix + ".Drive.LsmLocal")
             try:
-                method({})
+                method(self.no_options)
                 self.fail("LED control should failed as NotSupported on "
                           "LIO disks")
             except dbus.exceptions.DBusException as dbus_err:

--- a/src/tests/dbus-tests/test_91_lsm.py
+++ b/src/tests/dbus-tests/test_91_lsm.py
@@ -16,6 +16,7 @@ class UdisksLsmLocalTestCase(udiskstestcase.UdisksTestCase):
     def setUpClass(cls):
         udiskstestcase.UdisksTestCase.setUpClass()
         if not cls.check_module_loaded('LSM'):
+            udiskstestcase.UdisksTestCase.tearDownClass()
             raise unittest.SkipTest('Udisks module for LSM tests not loaded, skipping.')
 
     def _get_dbus_drv_obj(self, dbus_blk_obj):

--- a/src/tests/dbus-tests/test_bcache.py
+++ b/src/tests/dbus-tests/test_bcache.py
@@ -16,6 +16,7 @@ class UdisksBcacheTest(udiskstestcase.UdisksTestCase):
     def setUpClass(cls):
         udiskstestcase.UdisksTestCase.setUpClass()
         if not cls.check_module_loaded('Bcache'):
+            udiskstestcase.UdisksTestCase.tearDownClass()
             raise unittest.SkipTest('Udisks module for bcache tests not loaded, skipping.')
 
     def setUp(self):

--- a/src/tests/dbus-tests/test_btrfs.py
+++ b/src/tests/dbus-tests/test_btrfs.py
@@ -22,6 +22,7 @@ class UdisksBtrfsTest(udiskstestcase.UdisksTestCase):
     def setUpClass(cls):
         udiskstestcase.UdisksTestCase.setUpClass()
         if not cls.check_module_loaded('BTRFS'):
+            udiskstestcase.UdisksTestCase.tearDownClass()
             raise unittest.SkipTest('Udisks module for btrfs tests not loaded, skipping.')
 
     @contextmanager

--- a/src/tests/dbus-tests/test_job.py
+++ b/src/tests/dbus-tests/test_job.py
@@ -1,4 +1,3 @@
-import datetime
 import os
 import time
 import threading
@@ -58,7 +57,7 @@ class UdisksJobTest(udiskstestcase.UdisksTestCase):
         disk_name = os.path.basename(self.vdevs[0])
         obj_path = self.path_prefix + '/block_devices/' + disk_name
 
-        start_time = datetime.datetime.now().timestamp()
+        start_time = time.time()
 
         watch_thread = threading.Thread(target=self._wait_for_job_thread, args=('format-erase', obj_path))
         watch_thread.start()

--- a/src/tests/dbus-tests/test_loop.py
+++ b/src/tests/dbus-tests/test_loop.py
@@ -1,6 +1,7 @@
 import time
 import dbus
 import os
+import shutil
 import tempfile
 import udiskstestcase
 
@@ -48,10 +49,10 @@ class UdisksLoopDeviceTest(udiskstestcase.UdisksTestCase):
         # to be able to check that property value is set we need to mount the
         # device first
         flag_file_name = '/sys/class/block/%s/loop/autoclear' % os.path.basename(self.dev_name)
-        tmp = tempfile.TemporaryDirectory()
-        self.addCleanup(tmp.cleanup)
+        tmp = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, tmp)
         self.run_command('mkfs -t ext4 %s' % self.dev_name)
-        self.run_command('mount %s %s' % (self.dev_name, tmp.name))
+        self.run_command('mount %s %s' % (self.dev_name, tmp))
         self.iface.SetAutoclear(True, self.no_options)
         self.udev_settle()
         autoclear_flag = self.get_property(self.device, '.Loop', 'Autoclear')

--- a/src/tests/dbus-tests/test_mdraid.py
+++ b/src/tests/dbus-tests/test_mdraid.py
@@ -123,7 +123,7 @@ class RAIDLevel(udiskstestcase.UdisksTestCase):
 
         # name of the array reported by 'mdadm' should look like 'nodename':'array_name'
         # if it's smaller than 31 characters
-        nodename = os.uname().nodename
+        nodename = os.uname()[1]
         if len(nodename + array_name) < 31:
             dbus_name.assertEqual("%s:%s" % (nodename, array_name))
         else:
@@ -209,7 +209,7 @@ class RAID0TestCase(RAIDLevel):
         # name of the array reported by 'mdadm' should look like 'nodename':'array_name'
         # if it's smaller than 31 characters
         # because we didn't specify name of the array, it should be just the number part from 'md12X'
-        nodename = os.uname().nodename
+        nodename = os.uname()[1]
         if len(nodename + md_name[2:]) < 31:
             dbus_name.assertEqual("%s:%s" % (nodename, md_name[2:]))
         else:

--- a/src/tests/dbus-tests/test_zram.py
+++ b/src/tests/dbus-tests/test_zram.py
@@ -51,6 +51,7 @@ class UdisksZRAMTest(udiskstestcase.UdisksTestCase):
     def setUpClass(cls):
         udiskstestcase.UdisksTestCase.setUpClass()
         if not cls.check_module_loaded('ZRAM'):
+            udiskstestcase.UdisksTestCase.tearDownClass()
             raise unittest.SkipTest('Udisks module for zram tests not loaded, skipping.')
 
         cls._save_conf_files()

--- a/src/tests/dbus-tests/udiskstestcase.py
+++ b/src/tests/dbus-tests/udiskstestcase.py
@@ -15,6 +15,37 @@ def get_call_long(call):
     return call_long
 
 
+def skip_on(skip_on_distros, skip_on_version="", reason=""):
+    """A function returning a decorator to skip some test on a given distribution-version combination
+
+    :param skip_on_distros: distro(s) to skip the test on
+    :type skip_on_distros: str or tuple of str
+    :param str skip_on_version: version of distro(s) to skip the tests on (only
+                                checked on distribution match)
+
+    """
+    if isinstance(skip_on_distros, str):
+        skip_on_distros = (skip_on_distros,)
+
+    bus = dbus.SystemBus()
+
+    # get information about the distribution from systemd (hostname1)
+    sys_info = bus.get_object("org.freedesktop.hostname1", "/org/freedesktop/hostname1")
+    cpe = str(sys_info.Get("org.freedesktop.hostname1", "OperatingSystemCPEName", dbus_interface=dbus.PROPERTIES_IFACE))
+
+    # 2nd to 4th fields from e.g. "cpe:/o:fedoraproject:fedora:25" or "cpe:/o:redhat:enterprise_linux:7.3:GA:server"
+    project, distro, version = tuple(cpe.split(":")[2:5])
+
+    def decorator(func):
+        if distro in skip_on_distros and (not skip_on_version or skip_on_version == version):
+            msg = "not supported on this distribution in this version" + (": %s" % reason if reason else "")
+            return unittest.skip(msg)(func)
+        else:
+            return func
+
+    return decorator
+
+
 class DBusProperty(object):
 
     TIMEOUT = 5

--- a/src/tests/integration-test
+++ b/src/tests/integration-test
@@ -1738,6 +1738,14 @@ class MDRaid(UDisksTestCase):
 
 # ----------------------------------------------------------------------------
 
+
+def get_distro_version():
+    # 3rd to 6th fields from e.g. "CPE OS Name: cpe:/o:fedoraproject:fedora:27" or "CPE OS Name: cpe:/o:centos:centos:7"
+    out = subprocess.check_output('hostnamectl status | grep "CPE OS Name"', shell=True).decode().strip()
+    _project, distro, version = tuple(out.split(":")[3:65])
+
+    return (distro, version)
+
 if __name__ == '__main__':
     argparser = argparse.ArgumentParser(description='udisks2 integration test suite')
     argparser.add_argument('-l', '--log-file', dest='logfile',
@@ -1745,6 +1753,12 @@ if __name__ == '__main__':
     argparser.add_argument('testname', nargs='*',
                            help='name of test class or method (e. g. "Drive", "FS.test_ext2")')
     cli_args = argparser.parse_args()
+
+    distro, version = get_distro_version()
+    if distro in ('centos', 'enterprise_linux'):
+        print('Skipping integration tests on "%s %s".'\
+              'SCSI debug devices causing kernel panic.' % (distro, version))
+        sys.exit(0)
 
     UDisksTestCase.init(logfile=cli_args.logfile)
     if cli_args.testname:

--- a/src/tests/integration-test
+++ b/src/tests/integration-test
@@ -30,6 +30,8 @@
 # - add and test method for changing LUKS passphrase
 # - test Format with take-ownership
 
+from __future__ import print_function
+
 import sys
 import os
 import contextlib
@@ -46,7 +48,7 @@ if 'LD_LIBRARY_PATH' not in os.environ and os.path.isdir(libdir):
     os.environ['GI_TYPELIB_PATH'] = '%s/udisks:%s' % (
         srcdir,
         os.environ.get('GI_TYPELIB_PATH', ''))
-    os.execv(sys.argv[0], sys.argv)
+    os.execv(sys.executable, [sys.executable] + sys.argv)
     assert False, 'not expecting to land here'
 
 import subprocess
@@ -392,7 +394,8 @@ class UDisksTestCase(unittest.TestCase):
         # udev's cdrom_id does not recognize tracks
         scsi_debug_rules = '/run/udev/rules.d/60-persistent-storage-scsi_debug.rules'
         if os.path.isdir('/run/udev') and not os.path.exists(scsi_debug_rules):
-            os.makedirs('/run/udev/rules.d', exist_ok=True)
+            if not os.path.exists('/run/udev/rules.d'):
+                os.makedirs('/run/udev/rules.d')
             with open(scsi_debug_rules, 'w') as f:
                 f.write('KERNEL=="sr*", ENV{DISK_EJECT_REQUEST}!="?*", '
                         'ATTRS{model}=="scsi_debug*", '
@@ -863,8 +866,9 @@ class FS(UDisksTestCase):
             mount_prog = 'mount'
         mount_a = os.path.join(self.workdir, 'mp_a')
         mount_b = os.path.join(self.workdir, 'mp_b')
-        with contextlib.suppress(FileExistsError):
+        if not os.path.exists(mount_a):
             os.mkdir(mount_a)
+        if not os.path.exists(mount_b):
             os.mkdir(mount_b)
 
         ret = subprocess.call([mount_prog, self.device, mount_a])
@@ -1126,7 +1130,7 @@ class Fstab(UDisksTestCase):
         with open('/etc/fstab', 'a') as f:
             f.write('%s %s ext4 defaults,nosuid,noexec 0 0\n' %
                     (self.devname(partition=1), self.mount_point))
-        os.sync()
+        os.system('sync')
         self.do_test()
 
     def test_label(self):
@@ -1135,7 +1139,7 @@ class Fstab(UDisksTestCase):
         with open('/etc/fstab', 'a') as f:
             f.write('LABEL=udtestfst %s ext4 defaults,nosuid,noexec 0 0\n' %
                     self.mount_point)
-        os.sync()
+        os.system('sync')
         self.do_test()
 
     def test_partuuid(self):
@@ -1145,7 +1149,7 @@ class Fstab(UDisksTestCase):
             f.write('PARTUUID=%s %s ext4 defaults,nosuid,noexec 0 0\n' %
                     (self.p1uuid, self.mount_point))
 
-        os.sync()
+        os.system('sync')
         self.do_test()
 
     def test_partlabel(self):
@@ -1155,7 +1159,7 @@ class Fstab(UDisksTestCase):
             f.write('PARTLABEL=%s %s ext4 defaults,nosuid,noexec 0 0\n' %
                     (self.p1label, self.mount_point))
 
-        os.sync()
+        os.system('sync')
         self.do_test()
 
     def test_uuid(self):
@@ -1164,7 +1168,7 @@ class Fstab(UDisksTestCase):
         with open('/etc/fstab', 'a') as f:
             f.write('UUID=%s %s ext4 defaults,nosuid,noexec 0 0\n' %
                     (self.block.get_property('id-uuid'), self.mount_point))
-        os.sync()
+        os.system('sync')
         self.do_test()
 
     def do_test(self):

--- a/src/udiskslinuxpartitiontable.c
+++ b/src/udiskslinuxpartitiontable.c
@@ -350,6 +350,8 @@ udisks_linux_partition_table_handle_create_partition (UDisksPartitionTable   *ta
           goto out;
         }
     }
+  else
+    g_clear_error (&error);
 
   part_spec = bd_part_create_part (device_name, part_type, offset,
                                    size, BD_PART_ALIGN_OPTIMAL, &error);


### PR DESCRIPTION
These changes allow running dbus tests on CentOS/RHEL 7 using Python 2.