### PR TITLE
UDisksClient: Do not try remove changed_blacklist hash table in finalize

### DIFF
--- a/udisks/udisksclient.c
+++ b/udisks/udisksclient.c
@@ -127,19 +127,12 @@ static void
 udisks_client_finalize (GObject *object)
 {
   UDisksClient *client = UDISKS_CLIENT (object);
-  UDisksClientClass *client_class = UDISKS_CLIENT_GET_CLASS (client);
 
   if (client->changed_timeout_source != NULL)
     g_source_destroy (client->changed_timeout_source);
 
   if (client->initialization_error != NULL)
     g_clear_error (&(client->initialization_error));
-
-  if (client_class->changed_blacklist != NULL)
-    {
-      g_hash_table_destroy (client_class->changed_blacklist);
-      client_class->changed_blacklist = NULL;
-    }
 
   /* might be NULL if failing early in the constructor */
   if (client->object_manager != NULL)


### PR DESCRIPTION
"changed_blacklist" table is a class member and we really don't
want to destroy it when destroying one instance of the UDisksClient.