### PR TITLE
udiskssimplejob.c: Allow NULL for message

### DIFF
--- a/src/udiskssimplejob.c
+++ b/src/udiskssimplejob.c
@@ -110,7 +110,7 @@ udisks_simple_job_complete (UDisksSimpleJob     *job,
                             const gchar         *message)
 {
   g_return_if_fail (UDISKS_IS_SIMPLE_JOB (job));
-  udisks_job_emit_completed (UDISKS_JOB (job), success, message);
+  udisks_job_emit_completed (UDISKS_JOB (job), success, (message) ? message : "");
 }
 
 /* ---------------------------------------------------------------------------------------------------- */


### PR DESCRIPTION
The API states that passing NULL is acceptable, but when done we end up
down a path which causes an assertion which will trigger an abort if
G_DEBUG=fatal-criticals is enabled.  Pass an empty message when message is
NULL to avoid this.  Numerous other code paths are already calling this
function with message == "".

Signed-off-by: Tony Asleson <tasleson@redhat.com>