### PR TITLE
Add Filesystem Resize, Check, Repair

### DIFF
--- a/data/org.freedesktop.UDisks2.xml
+++ b/data/org.freedesktop.UDisks2.xml
@@ -1707,6 +1707,47 @@
     <method name="Unmount">
       <arg name="options" direction="in" type="a{sv}"/>
     </method>
+
+    <!--
+        Resize:
+        @size: The target size in bytes, 0 for maximum.
+        @options: Options (currently unused except for <link linkend="udisks-std-options">standard options</link>).
+
+        Resizes the filesystem.
+
+        Shrinking operations need to move data which causes this action to be
+        slow. The filesystem-resize job for the object might expose progress.
+    -->
+    <method name="Resize">
+      <arg name="size" direction="in" type="t"/>
+      <arg name="options" direction="in" type="a{sv}"/>
+    </method>
+
+    <!-- Check:
+         @options: Options (currently unused except for <link linkend="udisks-std-options">standard options</link>).
+         @consistent: Whether the filesystem is undamaged.
+
+         Checks the filesystem for consistency.
+
+         Unsupported filesystems result in an error.
+    -->
+    <method name="Check">
+      <arg name="options" direction="in" type="a{sv}"/>
+      <arg name="consistent" direction="out" type="b"/>
+    </method>
+
+    <!-- Repair:
+         @options: Options (currently unused except for <link linkend="udisks-std-options">standard options</link>).
+         @repaired: Whether the filesystem could be successfully repaired.
+
+         Tries to repair the filesystem.
+
+         Unsupported filesystems result in an error.
+    -->
+    <method name="Repair">
+      <arg name="options" direction="in" type="a{sv}"/>
+      <arg name="repaired" direction="out" type="b"/>
+    </method>
   </interface>
 
   <!-- ********************************************************************** -->
@@ -2230,6 +2271,8 @@
              <listitem><para>Unmounting a filesystem.</para></listitem></varlistentry>
            <varlistentry><term>filesystem-modify</term>
              <listitem><para>Modifying a filesystem.</para></listitem></varlistentry>
+           <varlistentry><term>filesystem-resize</term>
+             <listitem><para>Resizing a filesystem.</para></listitem></varlistentry>
            <varlistentry><term>format-erase</term>
              <listitem><para>Erasing a device.</para></listitem></varlistentry>
            <varlistentry><term>format-mkfs</term>

--- a/packaging/udisks2.spec
+++ b/packaging/udisks2.spec
@@ -5,7 +5,7 @@
 %global libatasmart_version             0.17
 %global dbus_version                    1.4.0
 %global with_gtk_doc                    1
-%global libblockdev_version             2.4
+%global libblockdev_version             2.10
 
 %define is_fedora                       0%{?rhel} == 0
 %define is_git                          %(git show > /dev/null 2>&1 && echo 1 || echo 0)

--- a/udisks/udisksclient.c
+++ b/udisks/udisksclient.c
@@ -2492,6 +2492,7 @@ udisks_client_get_job_description (UDisksClient   *client,
       g_hash_table_insert (hash, (gpointer) "filesystem-mount",     (gpointer) C_("job", "Mounting Filesystem"));
       g_hash_table_insert (hash, (gpointer) "filesystem-unmount",   (gpointer) C_("job", "Unmounting Filesystem"));
       g_hash_table_insert (hash, (gpointer) "filesystem-modify",    (gpointer) C_("job", "Modifying Filesystem"));
+      g_hash_table_insert (hash, (gpointer) "filesystem-resize",    (gpointer) C_("job", "Resizing Filesystem"));
       g_hash_table_insert (hash, (gpointer) "format-erase",         (gpointer) C_("job", "Erasing Device"));
       g_hash_table_insert (hash, (gpointer) "format-mkfs",          (gpointer) C_("job", "Creating Filesystem"));
       g_hash_table_insert (hash, (gpointer) "loop-setup",           (gpointer) C_("job", "Setting Up Loop Device"));


### PR DESCRIPTION
The Filesystem interface now has a resize method
that checks if the action is safe during mount.
It also supports resizing to maximum.
The progress parsing of the utility still missing.

Hello,
this is how I would like to do the final interface.
The progress property of the job is not yet populated because this needs some work in libblockdev, but that is mostly only relevant for shrinking operations which need to move data.

Depends on https://github.com/storaged-project/libblockdev/pull/217