### PR TITLE
Allow the user to specify the partition type

### DIFF
--- a/data/org.freedesktop.UDisks2.xml
+++ b/data/org.freedesktop.UDisks2.xml
@@ -1406,7 +1406,7 @@
         @size: The desired size of the partition, in bytes.
         @type: The type of partition to create (cf. the #org.freedesktop.UDisks2.Partition:Type property) or blank to use the default for the partition table type and OS.
         @name: The name for the new partition or blank if the partition table do not support names.
-        @options: Options (currently unused except for <link linkend="udisks-std-options">standard options</link>).
+        @options: Options - known options (in addition to <link linkend="udisks-std-options">standard options</link>) include <parameter>partition-type</parameter> (of type 's').
         @created_partition: An object path to the created block device object implementing the #org.freedesktop.UDisks2.Partition interface.
 
         Creates a new partition.
@@ -1418,6 +1418,10 @@
         The newly created partition may also end up being slightly
         larger or smaller than the requested @size bytes for the same
         reasons.
+
+        For <literal>dos</literal> partition tables, the partition type can be
+        set with the @partition-type option. Possible values are: "primary",
+        "extended" or "logical".
 
         The newly created partition will be wiped of known filesystem
         signatures using the
@@ -1439,7 +1443,7 @@
         @size: The desired size of the partition, in bytes.
         @type: The type of partition to create (cf. the #org.freedesktop.UDisks2.Partition:Type property) or blank to use the default for the partition table type and OS.
         @name: The name for the new partition or blank if the partition table do not support names.
-        @options: Options (currently unused except for <link linkend="udisks-std-options">standard options</link>).
+        @options: Options - known options (in addition to <link linkend="udisks-std-options">standard options</link>) include <parameter>partition-type</parameter> (of type 's').
         @created_partition: An object path to the created block device object implementing the #org.freedesktop.UDisks2.Partition interface.
         @format_type: The type to use for Format.
         @format_options: Options for Format.


### PR DESCRIPTION
Not sure if I like this implementation since theoretically the partition type can always be guessed correctly except if the partition type should be extended. (Note that doing so would alter existing behavior and therefore break applications that rely on the current behavior.)
Deriving "extended" from the filesystem partition seems legit and is already done by udisks.

Note that on my end the `test_fill_with_primary_partitions` fails after adding the second partition due to this error: 

> Error waiting for partition to appear: Timed out waiting for object

I've got no clue why that happens. Help wanted.

---

Implement feature requested in #318.

Allow the user to specify the "partition-type" option in
"CreatePartition" to explicitly specify whether the partition should be
a primary, extended or logical partition.