### PR TITLE
Fix broken partition authorization code

### DIFF
--- a/src/udiskslinuxpartition.c
+++ b/src/udiskslinuxpartition.c
@@ -114,7 +114,7 @@ check_authorization (UDisksPartition       *partition,
   UDisksBlock *block = NULL;
   UDisksObject *object = NULL;
   GError *error = NULL;
-  gboolean rc = TRUE;
+  gboolean rc = FALSE;
 
   object = udisks_daemon_util_dup_object (partition, &error);
   if (object == NULL)


### PR DESCRIPTION
Since 089c06e5823e009b962c642ef12a97e174a46a4e
there were no authorization checks for partition
objects, so anyone could delete them.