### PR TITLE
Correct alignment specified in the docs

### DIFF
--- a/data/org.freedesktop.UDisks2.xml
+++ b/data/org.freedesktop.UDisks2.xml
@@ -1345,7 +1345,7 @@
         used for benchmarking the device (transfer rate, access time
         etc.). Note that the file descriptor may be opened with the
         <literal>O_DIRECT</literal> and <literal>O_SYNC</literal>
-        flags so care must be taken to only perform page-aligned I/O.
+        flags so care must be taken to only perform block-aligned I/O.
 
         If the <parameter>writable</parameter> in @options is %TRUE
         then the returned file descriptor will be writable. This only


### PR DESCRIPTION
I/O needs to be block-aligned because of the `O_DIRECT` flag. There was no
reason for page-alignment found.

Reference: [`0139855`](https://github.com/storaged-project/udisks/commit/0139855348ae204311b12b0d80c48d98a6bc9d51#commitcomment-22860904).