### PR TITLE
Fix detection of drives created using isohybrid images (#1437791)

### DIFF
--- a/data/80-udisks2.rules
+++ b/data/80-udisks2.rules
@@ -144,12 +144,15 @@ KERNEL=="sr*", ENV{ID_VENDOR}=="SanDisk", ENV{ID_MODEL}=="Cruzer", ENV{ID_FS_LAB
 
 # Content created using isohybrid (typically used on CDs and USB
 # sticks for bootable media) is a bit special insofar that the
-# interesting content is on a DOS partition with type 0x00 ... which
+# interesting content is on a DOS partition with type 0x00* ... which
 # is hidden above. So undo this.
 #
 # See http://mjg59.dreamwidth.org/11285.html for more details
 #
-ENV{ID_PART_TABLE_TYPE}=="dos", ENV{ID_PART_ENTRY_TYPE}=="0x0", ENV{ID_PART_ENTRY_NUMBER}=="1", ENV{ID_FS_TYPE}=="iso9660|udf", ENV{UDISKS_IGNORE}="0"
+# *) This is true only for 64bit images. For 32bit images the type is 0x17
+# (Hidden HPFS/NTFS/exFAT). This is most likely a bug but we still need to
+# stop ignoring these.
+ENV{ID_PART_TABLE_TYPE}=="dos", ENV{ID_PART_ENTRY_TYPE}=="0x0|0x17", ENV{ID_PART_ENTRY_NUMBER}=="1", ENV{ID_FS_TYPE}=="iso9660|udf", ENV{UDISKS_IGNORE}="0"
 
 # Zram devices setup
 KERNEL=="zram[0-9]", ENV{SYSTEMD_WANTS}="zram-setup@zram%n.service", TAG+="systemd"


### PR DESCRIPTION
Partitions created using 32bit isohybrid images have a wrong
partition type (0x17 instead of 0x00) and we need to stop ignoring
these too.