### PR TITLE
Try more to ignore WD SmartWare virtual CDs

### DIFF
--- a/data/80-udisks2.rules
+++ b/data/80-udisks2.rules
@@ -126,8 +126,11 @@ ENV{ID_PART_ENTRY_SCHEME}=="gpt", \
   ENV{ID_PART_ENTRY_TYPE}=="c12a7328-f81f-11d2-ba4b-00a0c93ec93b|21686148-6449-6e6f-744e-656564454649|a19d880f-05fc-4d3b-a006-743f0f84911e|e6d6d379-f507-44c2-a23c-238f2a3df928|e3c9e316-0b5c-4db8-817d-f92df00215ae|de94bba4-06d1-4d40-a16a-bfd50179d6ac", \
   ENV{UDISKS_IGNORE}="1"
 
-# MAC recovery/tool partitions which are useless on Linux
+# MAC recovery/tool partitions/devices which are useless on Linux
 ENV{ID_PART_ENTRY_SCHEME}=="mac", \
+  ENV{ID_CDROM}=="?*", ENV{ID_FS_TYPE}=="udf", ENV{ID_FS_LABEL}=="WD*SmartWare", \
+  ENV{UDISKS_IGNORE}="1"
+ENV{ID_PART_TABLE_TYPE}=="mac", \
   ENV{ID_CDROM}=="?*", ENV{ID_FS_TYPE}=="udf", ENV{ID_FS_LABEL}=="WD*SmartWare", \
   ENV{UDISKS_IGNORE}="1"
 


### PR DESCRIPTION
The virtual CD is/may be a whole block device with a partition
table which has ID_PART_TABLE_TYPE instead of
ID_PART_ENTRY_SCHEME.

Resolves: #344