### PR TITLE
Integration test: Fix error message for mounting RO devices

### DIFF
--- a/src/tests/integration-test
+++ b/src/tests/integration-test
@@ -1022,7 +1022,12 @@ class FS(UDisksTestCase):
                 ro_options = GLib.Variant('a{sv}', {'options': GLib.Variant('s', 'rw')})
                 cd_fs.call_mount_sync(ro_options, None)
             except GLib.GError as e:
-                self.assertIn('is write-protected but `rw\' option given', str(e))
+                new_msg = 'is write-protected but explicit read-write mode requested'
+                old_msg = 'is write-protected but `rw\' option given'
+                if not (old_msg in str(e) or new_msg  in str(e)):
+                    self.fail('Mounting read-only device with \'rw\' option failed'
+                              'with an unxepected error.\nGot: %s\nExpected: \'%s\''
+                              ' or \'%s\'' % (str(e), new_msg, old_msg))
             else:
                 self.retry_busy(cd_fs.call_unmount_sync, no_options, None)
                 self.fail('Mounting read-only device didn\'t fail with \'rw\' option.')


### PR DESCRIPTION
Expected error is different when using new error codes and messages
from libmount >= 2.30