### PR TITLE
Add a function to "take ownership" of a filesystem

### DIFF
--- a/data/org.freedesktop.UDisks2.policy.in
+++ b/data/org.freedesktop.UDisks2.policy.in
@@ -70,6 +70,19 @@
   </action>
 
   <!-- ###################################################################### -->
+  <!-- Taking ownership of filesystems -->
+
+  <action id="org.freedesktop.udisks2.filesystem-take-ownership">
+    <_description>Take ownership of a filesystem</_description>
+    <_message>Authentication is required to take ownership of a filesystem.</_message>
+    <defaults>
+      <allow_any>auth_admin</allow_any>
+      <allow_inactive>auth_admin</allow_inactive>
+      <allow_active>auth_admin_keep</allow_active>
+    </defaults>
+  </action>
+
+  <!-- ###################################################################### -->
   <!-- Unlocking encrypted devices -->
 
   <action id="org.freedesktop.udisks2.encrypted-unlock">

--- a/data/org.freedesktop.UDisks2.xml
+++ b/data/org.freedesktop.UDisks2.xml
@@ -1836,6 +1836,19 @@
       <arg name="options" direction="in" type="a{sv}"/>
       <arg name="repaired" direction="out" type="b"/>
     </method>
+
+    <!-- TakeOwnership:
+         @options: Options (in addition to <link linkend="udisks-std-options">standard options</link>) includes <parameter>recursive</parameter> (of type 'b').
+         @since: 2.7.2
+
+         Changes ownership of the filesystem to the UID and GID of the calling
+         user.
+
+         Filesystems that don't support ownership result in an error.
+    -->
+    <method name="TakeOwnership">
+      <arg name="options" direction="in" type="a{sv}"/>
+    </method>
   </interface>
 
   <!-- ********************************************************************** -->

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -57,6 +57,7 @@ libudisks_daemon_la_SOURCES =                                                  \
 	udiskslinuxpartition.h         udiskslinuxpartition.c                  \
 	udiskslinuxpartitiontable.h    udiskslinuxpartitiontable.c             \
 	udiskslinuxfilesystem.h        udiskslinuxfilesystem.c                 \
+	udiskslinuxfilesystemhelpers.h udiskslinuxfilesystemhelpers.c          \
 	udiskslinuxencrypted.h         udiskslinuxencrypted.c                  \
 	udiskslinuxencryptedhelpers.h udiskslinuxencryptedhelpers.c            \
 	udiskslinuxswapspace.h         udiskslinuxswapspace.c                  \

--- a/src/udiskslinuxfilesystemhelpers.c
+++ b/src/udiskslinuxfilesystemhelpers.c
@@ -1,0 +1,182 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*-
+ *
+ * Copyright (C) 2017 Red Hat, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * Author: Vratislav Podzimek <vpodzime@redhat.com>
+ *
+ */
+
+#include <glib.h>
+#include <stdio.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#include <blockdev/fs.h>
+
+#include "udiskslinuxfilesystemhelpers.h"
+#include "udiskslogging.h"
+
+
+static gboolean recursive_chown (const gchar *directory, uid_t caller_uid, gid_t caller_gid)
+{
+  GDir * gdir = NULL;
+  const gchar *fname = NULL;
+  GError *local_error = NULL;
+  gchar path[PATH_MAX + 1] = {0};
+
+  gdir = g_dir_open (directory, 0, &local_error);
+  if (gdir == NULL)
+    {
+      g_clear_error (&local_error);
+      return FALSE;
+    }
+
+  if (chown (directory, caller_uid, caller_gid) != 0)
+    {
+      g_dir_close (gdir);
+      return FALSE;
+    }
+
+  while ((fname = g_dir_read_name (gdir)))
+    {
+      snprintf (path, sizeof (path), "%s/%s", directory, fname);
+      if (g_file_test (path, G_FILE_TEST_IS_DIR))
+        {
+          if (!recursive_chown (path, caller_uid, caller_gid))
+            {
+              g_dir_close (gdir);
+              return FALSE;
+            }
+        }
+      else if (g_file_test (path, G_FILE_TEST_IS_REGULAR) && !g_file_test (path, G_FILE_TEST_IS_SYMLINK))
+        {
+          if (chown (path, caller_uid, caller_gid) != 0)
+            {
+              g_dir_close (gdir);
+              return FALSE;
+            }
+        }
+    }
+
+  g_dir_close (gdir);
+  return TRUE;
+}
+
+
+gboolean take_filesystem_ownership (const gchar *device,
+                                    const gchar *fstype,
+                                    uid_t caller_uid,
+                                    gid_t caller_gid,
+                                    gboolean recursive,
+                                    GError **error)
+
+{
+
+  gchar *mountpoint = NULL;
+  GError *local_error = NULL;
+  gboolean unmount = FALSE;
+  gboolean success = TRUE;
+
+  mountpoint = bd_fs_get_mountpoint (device, &local_error);
+  if (mountpoint == NULL)
+    {
+      if (local_error != NULL)
+        {
+          g_set_error (error, UDISKS_ERROR, UDISKS_ERROR_FAILED,
+                       "Error when getting mountpoint for %s: %s.",
+                       device, local_error->message);
+          g_clear_error (&local_error);
+          success = FALSE;
+          goto out;
+        }
+      else
+        {
+          /* device is not mounted, we need to mount it */
+          mountpoint = g_mkdtemp (g_strdup (PACKAGE_LOCALSTATE_DIR "/run/udisks2/temp-mount-XXXXXX"));
+          if (mountpoint == NULL)
+            {
+              g_set_error (error, UDISKS_ERROR, UDISKS_ERROR_FAILED,
+                           "Cannot create temporary mountpoint.");
+              success = FALSE;
+              goto out;
+            }
+
+          if (!bd_fs_mount (device, mountpoint, fstype, NULL, NULL, &local_error))
+            {
+              g_set_error (error, UDISKS_ERROR, UDISKS_ERROR_FAILED,
+                           "Cannot mount %s at %s: %s",
+                           device, mountpoint, local_error->message);
+              g_clear_error (&local_error);
+              if (g_rmdir (mountpoint) != 0)
+                  udisks_warning ("Error removing temporary mountpoint directory %s.", mountpoint);
+              success = FALSE;
+              goto out;
+            }
+          else
+            unmount = TRUE;  // unmount during cleanup
+        }
+    }
+
+  if (recursive)
+    {
+      if (!recursive_chown (mountpoint, caller_uid, caller_gid))
+        {
+            g_set_error (error, UDISKS_ERROR, UDISKS_ERROR_FAILED,
+                         "Cannot recursively chown %s to uid=%u and gid=%u: %m",
+                         mountpoint, caller_uid, caller_gid);
+
+          success = FALSE;
+          goto out;
+        }
+    }
+  else
+    {
+      if (chown (mountpoint, caller_uid, caller_gid) != 0)
+        {
+          g_set_error (error, UDISKS_ERROR, UDISKS_ERROR_FAILED,
+                       "Cannot chown %s to uid=%u and gid=%u: %m",
+                       mountpoint, caller_uid, caller_gid);
+          success = FALSE;
+          goto out;
+        }
+    }
+
+  if (chmod (mountpoint, 0700) != 0)
+    {
+      g_set_error (error, UDISKS_ERROR, UDISKS_ERROR_FAILED,
+                   "Cannot chmod %s to mode 0700: %m",
+                   mountpoint);
+      success = FALSE;
+      goto out;
+    }
+
+ out:
+  if (unmount)
+    {
+      if (! bd_fs_unmount (mountpoint, FALSE, FALSE, NULL, &local_error))
+        {
+          udisks_warning ("Error unmounting temporary mountpoint %s: %s",
+                          mountpoint, local_error->message);
+          g_clear_error (&local_error);
+        }
+      if (g_rmdir (mountpoint) != 0)
+          udisks_warning ("Error removing temporary mountpoint directory %s.", mountpoint);
+    }
+
+  g_free (mountpoint);
+
+  return success;
+}

--- a/src/udiskslinuxfilesystemhelpers.h
+++ b/src/udiskslinuxfilesystemhelpers.h
@@ -1,0 +1,44 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*-
+ *
+ * Copyright (C) 2017 Red Hat, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * Author: Vratislav Podzimek <vpodzime@redhat.com>
+ *
+ */
+
+#ifndef __UDISKS_LINUX_FILESYSTEM_HELPERS_H__
+#define __UDISKS_LINUX_FILESYSTEM_HEPLERS_H__
+
+#include <glib.h>
+#include <glib/gstdio.h>
+#include <unistd.h>
+
+#include <blockdev/fs.h>
+
+G_BEGIN_DECLS
+
+gboolean take_filesystem_ownership (const gchar *device,
+                                    const gchar *fstype,
+                                    uid_t caller_uid,
+                                    gid_t caller_gid,
+                                    gboolean recursive,
+                                    GError **error);
+
+G_END_DECLS
+
+
+#endif /* __UDISKS_LINUX_FILESYSTEM_HEPLERS_H__ */


### PR DESCRIPTION
We already allow taking ownership when creating a filesystem
(basically running chown on the filesystem root after creating it)
but it could be useful to have this functionality for existing
filesystems too because right now it isn't possible to write to
devices with filesystems created using different tools and it isn't
user friendly to run chmod/chown manually.