### PR TITLE
Fix setting "SetupByUID" property when adding a new loop device

### DIFF
--- a/src/tests/dbus-tests/test_loop.py
+++ b/src/tests/dbus-tests/test_loop.py
@@ -107,6 +107,10 @@ class UdisksManagerLoopDeviceTest(udiskstestcase.UdisksTestCase):
         ro = self.get_property(loop_dev_obj, ".Block", "ReadOnly")
         ro.assertFalse()
 
+        # should be set up by root (uid 0)
+        uid = self.get_property(loop_dev_obj, '.Loop', 'SetupByUID')
+        uid.assertEqual(0)
+
     def test_20_create_with_offset(self):
         opts = dbus.Dictionary({"offset": dbus.UInt64(4096)}, signature=dbus.Signature('sv'))
         with open(self.LOOP_DEVICE_FILENAME, "r+b") as loop_file:


### PR DESCRIPTION
This commit adds back calling "udisks_state_add_loop" method after
creating the loop device. This was accidentally removed when
rewriting the loop code to use libblockdev.

Fixes #356 