### PR TITLE
Disable ZRAM tests on Rawhide

### DIFF
--- a/src/tests/dbus-tests/test_zram.py
+++ b/src/tests/dbus-tests/test_zram.py
@@ -50,6 +50,8 @@ class UdisksZRAMTest(udiskstestcase.UdisksTestCase):
     @classmethod
     def setUpClass(cls):
         udiskstestcase.UdisksTestCase.setUpClass()
+        if cls.distro[1:] == ("fedora", "27"):
+            raise unittest.SkipTest('zram module (un)loading causes kernel panics on rawhide')
         if not cls.check_module_loaded('ZRAM'):
             udiskstestcase.UdisksTestCase.tearDownClass()
             raise unittest.SkipTest('Udisks module for zram tests not loaded, skipping.')


### PR DESCRIPTION
Loading and unloading the 'zram' module causes kernel panics on
rawhide kernels.