### PR TITLE
Fix how we create UDF file systems

### DIFF
--- a/src/tests/dbus-tests/test_80_filesystem.py
+++ b/src/tests/dbus-tests/test_80_filesystem.py
@@ -650,6 +650,11 @@ class F2FSTestCase(UdisksFSTestCase):
     _can_label = False
     _can_mount = True and UdisksFSTestCase.module_loaded('f2fs')
 
+class UDFTestCase(UdisksFSTestCase):
+    _fs_name = 'udf'
+    _can_create = True and UdisksFSTestCase.command_exists('mkudffs')
+    _can_label = False
+    _can_mount = True and UdisksFSTestCase.module_loaded('udf')
 
 class FailsystemTestCase(UdisksFSTestCase):
     # test that not supported operations fail 'nicely'

--- a/src/udiskslinuxfsinfo.c
+++ b/src/udiskslinuxfsinfo.c
@@ -169,7 +169,7 @@ const FSInfo _fs_info[] =
       NULL,
       FALSE, /* supports_online_label_rename */
       FALSE, /* supports_owners */
-      "mkudffs --vid $LABEL $DEVICE",
+      "mkudffs --utf8 --media-type=hd --udfrev=0x201 --blocksize=$BLOCKSIZE --vid $LABEL --lvid $LABEL $DEVICE",
       NULL,
     },
     {


### PR DESCRIPTION
As described in #338, 'mkudffs' is supposed be run in a different
way to actually create a modern UDF file system with all the
desired parameters.

Among the other things, older versions of 'mkudffs' are not able
to determine the device's block size so we need to do it on our
own which requires some extra effort.

Resolves: #338