### PR TITLE
Make iSCSI Login and Logout wait for DBus objects update

### DIFF
--- a/modules/iscsi/Makefile.am
+++ b/modules/iscsi/Makefile.am
@@ -68,6 +68,8 @@ libudisks2_iscsi_la_SOURCES =                                                  \
 	udisksiscsimoduleiface.c                                               \
 	udisksiscsiutil.h                                                      \
 	udisksiscsiutil.c                                                      \
+	udisksiscsidbusutil.h                                                  \
+	udisksiscsidbusutil.c                                                  \
 	$(NULL)
 
 if BUILD_ISCSI_SESSION_OBJECT

--- a/modules/iscsi/udisksiscsidbusutil.c
+++ b/modules/iscsi/udisksiscsidbusutil.c
@@ -1,0 +1,60 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*-
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ */
+
+#include "config.h"
+
+#include "udisksiscsidbusutil.h"
+
+/**
+ * udisks_object_get_iscsi_session:
+ * @object: A #UDisksObject.
+ *
+ * Gets the #UDisksISCSISession instance for the D-Bus interface <link linkend="gdbus-interface-org-freedesktop-UDisks2-ISCSI-Session.top_of_page">org.freedesktop.UDisks2.ISCSI.Session</link> on @object, if any.
+ *
+ * Returns: (transfer full): A #UDisksISCSISession that must be freed with g_object_unref() or %NULL if @object does not implement the interface.
+ */
+UDisksISCSISession *
+udisks_object_get_iscsi_session (UDisksObject *object)
+{
+  GDBusInterface *ret;
+  ret = g_dbus_object_get_interface (G_DBUS_OBJECT (object), "org.freedesktop.UDisks2.ISCSI.Session");
+  if (ret == NULL)
+    return NULL;
+  return UDISKS_ISCSI_SESSION (ret);
+}
+
+/**
+ * udisks_object_peek_iscsi_session: (skip)
+ * @object: A #UDisksObject.
+ *
+ * Like udisks_object_get_iscsi_session() but doesn't increase the reference count on the returned object.
+ *
+ * <warning>It is not safe to use the returned object if you are on another thread than the one where the #GDBusObjectManagerClient or #GDBusObjectManagerServer for @object is running.</warning>
+ *
+ * Returns: (transfer none): A #UDisksISCSISession or %NULL if @object does not implement the interface. Do not free the returned object, it is owned by @object.
+ */
+UDisksISCSISession *
+udisks_object_peek_iscsi_session (UDisksObject *object)
+{
+  GDBusInterface *ret;
+  ret = g_dbus_object_get_interface (G_DBUS_OBJECT (object), "org.freedesktop.UDisks2.ISCSI.Session");
+  if (ret == NULL)
+    return NULL;
+  g_object_unref (ret);
+  return UDISKS_ISCSI_SESSION (ret);
+}

--- a/modules/iscsi/udisksiscsidbusutil.h
+++ b/modules/iscsi/udisksiscsidbusutil.h
@@ -1,0 +1,32 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*-
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ */
+
+#ifndef __UDISKS_ISCSI_DBUS_UTIL_H__
+#define __UDISKS_ISCSI_DBUS_UTIL_H__
+
+#include <udisks/udisks-generated.h>
+#include "udisks-iscsi-generated.h"
+
+G_BEGIN_DECLS
+
+UDisksISCSISession *udisks_object_get_iscsi_session  (UDisksObject *object);
+UDisksISCSISession *udisks_object_peek_iscsi_session (UDisksObject *object);
+
+G_END_DECLS
+
+#endif /* __UDISKS_ISCSI_DBUS_UTIL_H__ */

--- a/src/tests/dbus-tests/test_30_iscsi.py
+++ b/src/tests/dbus-tests/test_30_iscsi.py
@@ -59,9 +59,6 @@ class UdisksISCSITest(udiskstestcase.UdisksTestCase):
         self.addCleanup(self._force_lougout, self.noauth_iqn)
         manager.Login(iqn, tpg, host, port, iface, self.no_options,
                       dbus_interface=self.iface_prefix + '.Manager.ISCSI.Initiator')
-        # FIXME: Login() should wait for the glob below to match something to
-        # make sure the device is really setup when it returns
-        time.sleep(1)
 
         devs = glob.glob('/dev/disk/by-path/*%s*' % iqn)
         self.assertEqual(len(devs), 1)
@@ -77,9 +74,6 @@ class UdisksISCSITest(udiskstestcase.UdisksTestCase):
 
         manager.Logout(iqn, tpg, host, port, iface, self.no_options,
                        dbus_interface=self.iface_prefix + '.Manager.ISCSI.Initiator')
-        # FIXME: Logout() should wait for the glob below to match nothing to
-        # make sure the device is really removed when it returns
-        time.sleep(1)
 
         devs = glob.glob('/dev/disk/by-path/*%s*' % iqn)
         self.assertEqual(len(devs), 0)
@@ -120,9 +114,6 @@ class UdisksISCSITest(udiskstestcase.UdisksTestCase):
         self.addCleanup(self._force_lougout, self.chap_iqn)
         manager.Login(iqn, tpg, host, port, iface, options,
                       dbus_interface=self.iface_prefix + '.Manager.ISCSI.Initiator')
-        # FIXME: Login() should wait for the glob below to match something to
-        # make sure the device is really setup when it returns
-        time.sleep(1)
 
         devs = glob.glob('/dev/disk/by-path/*%s*' % iqn)
         self.assertEqual(len(devs), 1)
@@ -138,9 +129,6 @@ class UdisksISCSITest(udiskstestcase.UdisksTestCase):
 
         manager.Logout(iqn, tpg, host, port, iface, self.no_options,
                        dbus_interface=self.iface_prefix + '.Manager.ISCSI.Initiator')
-        # FIXME: Logout() should wait for the glob below to match nothing to
-        # make sure the device is really removed when it returns
-        time.sleep(1)
 
         devs = glob.glob('/dev/disk/by-path/*%s*' % iqn)
         self.assertEqual(len(devs), 0)
@@ -174,9 +162,6 @@ class UdisksISCSITest(udiskstestcase.UdisksTestCase):
         self.addCleanup(self._force_lougout, self.mutual_iqn)
         manager.Login(iqn, tpg, host, port, iface, options,
                       dbus_interface=self.iface_prefix + '.Manager.ISCSI.Initiator')
-        # FIXME: Login() should wait for the glob below to match something to
-        # make sure the device is really setup when it returns
-        time.sleep(1)
 
         devs = glob.glob('/dev/disk/by-path/*%s*' % iqn)
         self.assertEqual(len(devs), 1)
@@ -192,9 +177,6 @@ class UdisksISCSITest(udiskstestcase.UdisksTestCase):
 
         manager.Logout(iqn, tpg, host, port, iface, self.no_options,
                        dbus_interface=self.iface_prefix + '.Manager.ISCSI.Initiator')
-        # FIXME: Logout() should wait for the glob below to match nothing to
-        # make sure the device is really removed when it returns
-        time.sleep(1)
 
         devs = glob.glob('/dev/disk/by-path/*%s*' % iqn)
         self.assertEqual(len(devs), 0)
@@ -224,8 +206,6 @@ class UdisksISCSITest(udiskstestcase.UdisksTestCase):
         self.addCleanup(self._force_lougout, self.noauth_iqn)
         manager.Login(iqn, tpg, host, port, iface, self.no_options,
                       dbus_interface=self.iface_prefix + '.Manager.ISCSI.Initiator')
-        # FIXME: Login() should wait for the session to be created (if supported/enabled)
-        time.sleep(1)
 
         # /org/freedesktop/UDisks2/iscsi/sessionX should be created
         udisks = self.get_object('')
@@ -249,8 +229,6 @@ class UdisksISCSITest(udiskstestcase.UdisksTestCase):
         # logout using session
         session.Logout(self.no_options,
                        dbus_interface=self.iface_prefix + '.ISCSI.Session')
-        # FIXME: Logout() should wait for the session to be removed (if supported/enabled)
-        time.sleep(1)
 
         # make sure the session object is no longer on dbus
         objects = udisks.GetManagedObjects(dbus_interface='org.freedesktop.DBus.ObjectManager')


### PR DESCRIPTION
Login and Logout methods now wait for the device and session
objects to be added to (removed from) DBus.

Fixes #342