### PR TITLE
Re-add support the legacy BIOS bootable GPT flag

### DIFF
--- a/src/tests/dbus-tests/test_60_partitioning.py
+++ b/src/tests/dbus-tests/test_60_partitioning.py
@@ -447,7 +447,7 @@ class UdisksPartitionTest(udiskstestcase.UdisksTestCase):
         # make sure partition is not in the system
         self.assertFalse(os.path.isdir(part_syspath))
 
-    def test_flags(self):
+    def test_dos_flags(self):
         disk = self.get_object('/block_devices/' + os.path.basename(self.vdevs[0]))
         self.assertIsNotNone(disk)
 

--- a/src/tests/dbus-tests/test_60_partitioning.py
+++ b/src/tests/dbus-tests/test_60_partitioning.py
@@ -469,7 +469,7 @@ class UdisksPartitionTest(udiskstestcase.UdisksTestCase):
         dbus_flags = self.get_property(part, '.Partition', 'Flags')
         dbus_flags.assertEqual(128)
 
-        # test flags value from sysytem
+        # test flags value from system
         part_name = str(part.object_path).split('/')[-1]
         _ret, sys_flags = self.run_command('blkid /dev/%s -p -o value -s PART_ENTRY_FLAGS' % part_name)
         self.assertEqual(sys_flags, '0x80')
@@ -503,7 +503,7 @@ class UdisksPartitionTest(udiskstestcase.UdisksTestCase):
         dbus_type = self.get_property(part, '.Partition', 'Type')
         dbus_type.assertEqual(home_guid)
 
-        # test flags value from sysytem
+        # test flags value from system
         part_name = str(part.object_path).split('/')[-1]
         _ret, sys_type = self.run_command('blkid /dev/%s -p -o value -s PART_ENTRY_TYPE' % part_name)
         self.assertEqual(sys_type, home_guid)
@@ -537,7 +537,7 @@ class UdisksPartitionTest(udiskstestcase.UdisksTestCase):
         dbus_type = self.get_property(part, '.Partition', 'Type')
         dbus_type.assertEqual(part_type)
 
-        # test flags value from sysytem
+        # test flags value from system
         part_name = str(part.object_path).split('/')[-1]
         _ret, sys_type = self.run_command('blkid /dev/%s -p -o value -s PART_ENTRY_TYPE' % part_name)
         self.assertEqual(sys_type, part_type)
@@ -630,7 +630,7 @@ class UdisksPartitionTest(udiskstestcase.UdisksTestCase):
         dbus_name = self.get_property(part, '.Partition', 'Name')
         dbus_name.assertEqual('test')
 
-        # test flags value from sysytem
+        # test flags value from system
         part_name = str(part.object_path).split('/')[-1]
         _ret, sys_name = self.run_command('lsblk -d -no PARTLABEL /dev/%s' % part_name)
         self.assertEqual(sys_name, 'test')

--- a/src/udiskslinuxpartition.c
+++ b/src/udiskslinuxpartition.c
@@ -347,6 +347,8 @@ handle_set_flags (UDisksPartition       *partition,
     {
       if (flags & 1) /* 1 << 0 */
           bd_flags |= BD_PART_FLAG_GPT_SYSTEM_PART;
+      if (flags & 4) /* 1 << 2 */
+          bd_flags |= BD_PART_FLAG_LEGACY_BOOT;
       if (flags & 0x1000000000000000) /* 1 << 60 */
           bd_flags |= BD_PART_FLAG_GPT_READ_ONLY;
       if (flags & 0x4000000000000000) /* 1 << 62 */


### PR DESCRIPTION
This fixes a regression.

The documentation for the "Flags" property says that GPT bit 2 (Legacy BIOS
Bootable) is supported, and indeed it used to be the case (e.g. it works with
2.1.8-1 on Debian Stretch). But the code does not support it anymore as of
2.7.3-4 on current Debian sid.

This commit depends on BD_PART_FLAG_GPT_LEGACY_BOOT in libblockdev:

* issue: https://github.com/storaged-project/libblockdev/issues/287
* pull request: https://github.com/storaged-project/libblockdev/pull/288

Fixes: #415