### PR TITLE
Add and use a service for cleaning up mount point directories

### DIFF
--- a/data/Makefile.am
+++ b/data/Makefile.am
@@ -15,14 +15,14 @@ dbusconf_DATA = $(dbusconf_in_files:.conf.in=.conf)
 $(dbusconf_DATA): $(dbusconf_in_files) Makefile
 	cp $< $@
 
-systemdservice_in_files = udisks2.service.in
+systemdservice_in_files = udisks2.service.in clean-mount-point@.service
 
 if HAVE_SYSTEMD
 systemdservicedir       = $(systemdsystemunitdir)
 systemdservice_DATA     = $(systemdservice_in_files:.service.in=.service)
 
-$(systemdservice_DATA): $(systemdservice_in_files) Makefile
-	@sed -e "s|\@udisksdprivdir\@|$(libexecdir)/udisks2|" $< > $@
+$(systemdservice_DATA): udisks2.service.in Makefile
+	@sed -e "s|\@udisksdprivdir\@|$(libexecdir)/udisks2|" udisks2.service.in > udisks2.service
 endif
 
 udevrulesdir = $(udevdir)/rules.d

--- a/data/clean-mount-point@.service
+++ b/data/clean-mount-point@.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Clean the %f mount point
+Before=%i.mount
+BindsTo=%i.mount
+DefaultDependencies=no
+
+[Service]
+Type=oneshot
+RemainAfterExit=true
+ExecStop=/bin/rm -fd %f

--- a/packaging/udisks2.spec
+++ b/packaging/udisks2.spec
@@ -238,14 +238,17 @@ chrpath --delete %{buildroot}/%{_libexecdir}/udisks2/udisksd
 
 %post -n %{name}
 %systemd_post udisks2.service
+%systemd_post clean-mount-point@.service
 udevadm control --reload
 udevadm trigger
 
 %preun -n %{name}
 %systemd_preun udisks2.service
+%systemd_preun clean-mount-point@.service
 
 %postun -n %{name}
 %systemd_postun_with_restart udisks2.service
+%systemd_postun clean-mount-point@.service
 
 %post -n lib%{name} -p /sbin/ldconfig
 
@@ -275,6 +278,7 @@ udevadm trigger
 %{_sysconfdir}/dbus-1/system.d/org.freedesktop.UDisks2.conf
 %{_datadir}/bash-completion/completions/udisksctl
 %{_unitdir}/udisks2.service
+%{_unitdir}/clean-mount-point@.service
 %{_udevrulesdir}/80-udisks2.rules
 %{_sbindir}/umount.udisks2
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -113,7 +113,8 @@ libudisks_daemon_la_LIBADD =                                                   \
 	$(GIO_LIBS)                                                            \
 	$(GMODULE_LIBS)                                                        \
 	$(GUDEV_LIBS)                                                          \
-	$(BLOCKDEV_LIBS)                                                          \
+	$(BLOCKDEV_LIBS)                                                       \
+	-lbd_utils                                                             \
 	$(LIBATASMART_LIBS)                                                    \
 	$(POLKIT_GOBJECT_1_LIBS)                                               \
 	$(ACL_LIBS)                                                            \


### PR DESCRIPTION
When udisks2 is used for mounting devices, it may need to create
the mount point directory. If unmount happens later, udisks2
cleans after itself and removes the mount point
directory. However, if the unmount happens during reboot, the
udisks2 daemon may already be terminated not having a chance to
do the cleanup. We need a different mechanism to do the job in
such cases.

systemd provides us with such a mechanism so let's make use of
it.

Resolves: rhbz#1384796