### PR TITLE
Do not clean all .service files

### DIFF
--- a/data/Makefile.am
+++ b/data/Makefile.am
@@ -51,7 +51,7 @@ EXTRA_DIST =                                                                   \
 
 clean-local:
 	rm -f *~                                                               \
+	udisks2.service                                                        \
 	$(dbusservice_DATA)                                                    \
 	$(dbusconf_DATA)                                                       \
-	$(systemdservice_DATA)                                                 \
 	$(polkit_DATA)


### PR DESCRIPTION
clean-mount-point@.service is not created from a template and
thus should not be removed.