### PR TITLE
Fix checking for distribution and version in integration tests

### DIFF
--- a/src/tests/integration-test
+++ b/src/tests/integration-test
@@ -1747,7 +1747,11 @@ class MDRaid(UDisksTestCase):
 def get_distro_version():
     # 3rd to 6th fields from e.g. "CPE OS Name: cpe:/o:fedoraproject:fedora:27" or "CPE OS Name: cpe:/o:centos:centos:7"
     out = subprocess.check_output('hostnamectl status | grep "CPE OS Name"', shell=True).decode().strip()
-    _project, distro, version = tuple(out.split(":")[3:65])
+    try:
+        _project, distro, version = tuple(out.split(":")[3:6])
+    except ValueError:
+        print('Failed to get distribution and version from "%s". Aborting.' % out)
+        sys.exit(1)
 
     return (distro, version)
 


### PR DESCRIPTION
And also don't try to run the tests if we fail to detect the
distribution and/or version.

Resolves: rhbz#1508385