### PR TITLE
Make sure the table_type is consistent in handle_create_partition

### DIFF
--- a/src/udiskslinuxpartitiontable.c
+++ b/src/udiskslinuxpartitiontable.c
@@ -337,7 +337,7 @@ udisks_linux_partition_table_handle_create_partition (UDisksPartitionTable   *ta
 
   device_name = g_strdup (udisks_block_get_device (block));
 
-  table_type = udisks_partition_table_get_type_ (table);
+  table_type = udisks_partition_table_dup_type_ (table);
   wait_data = g_new0 (WaitForPartitionData, 1);
   if (g_strcmp0 (table_type, "dos") == 0)
     {
@@ -552,6 +552,7 @@ udisks_linux_partition_table_handle_create_partition (UDisksPartitionTable   *ta
   udisks_simple_job_complete (UDISKS_SIMPLE_JOB (job), TRUE, NULL);
 
  out:
+  g_free (table_type);
   g_free (wait_data);
   g_free (overlapping_part);
   g_clear_error (&error);


### PR DESCRIPTION
By using table_get_type_() we get a pointer to the property which
may change between being tested for one of the supported values
and later being actually used to determine what to do based on
its value. That may cause various failures, including
segmentation faults.

A particular example is when working with a GPT partition table
where the udev-blkid machinery can tell us that there's a "gpt"
partition table, but later change it to "PMBR" (maybe
temporarily) while the thread handling the
handle_create_partition() function is midway.