### PR TITLE
Try to wait a bit longer before retrying to remove a partition

### DIFF
--- a/src/tests/dbus-tests/test_60_partitioning.py
+++ b/src/tests/dbus-tests/test_60_partitioning.py
@@ -24,7 +24,8 @@ class UdisksPartitionTableTest(udiskstestcase.UdisksTestCase):
         try:
             part.Delete(self.no_options, dbus_interface=self.iface_prefix + '.Partition')
         except dbus.exceptions.DBusException:
-            time.sleep(1)
+            self.udev_settle()
+            time.sleep(5)
             part.Delete(self.no_options, dbus_interface=self.iface_prefix + '.Partition')
 
     def test_create_mbr_partition(self):


### PR DESCRIPTION
Looks like 1 second is quite often not enough. Also, we need udev
to do its job first.