### PR TITLE
Try harder when removing format as cleanup in tests

### DIFF
--- a/src/tests/dbus-tests/test_60_partitioning.py
+++ b/src/tests/dbus-tests/test_60_partitioning.py
@@ -15,7 +15,12 @@ class UdisksPartitionTableTest(udiskstestcase.UdisksTestCase):
     def _remove_format(self, device):
         d = dbus.Dictionary(signature='sv')
         d['erase'] = True
-        device.Format('empty', d, dbus_interface=self.iface_prefix + '.Block')
+        try:
+            device.Format('empty', d, dbus_interface=self.iface_prefix + '.Block')
+        except dbus.exceptions.DBusException:
+            self.udev_settle()
+            time.sleep(5)
+            device.Format('empty', d, dbus_interface=self.iface_prefix + '.Block')
 
     def _create_format(self, device, ftype):
         device.Format(ftype, self.no_options, dbus_interface=self.iface_prefix + '.Block')
@@ -404,7 +409,12 @@ class UdisksPartitionTest(udiskstestcase.UdisksTestCase):
     def _remove_format(self, device):
         d = dbus.Dictionary(signature='sv')
         d['erase'] = True
-        device.Format('empty', d, dbus_interface=self.iface_prefix + '.Block')
+        try:
+            device.Format('empty', d, dbus_interface=self.iface_prefix + '.Block')
+        except dbus.exceptions.DBusException:
+            self.udev_settle()
+            time.sleep(5)
+            device.Format('empty', d, dbus_interface=self.iface_prefix + '.Block')
 
     def _create_format(self, device, ftype):
         device.Format(ftype, self.no_options, dbus_interface=self.iface_prefix + '.Block')


### PR DESCRIPTION
It may easily fail because often the cleanup runs right after
some big changes that trigger "a nice uevent storm". We don't
care about the cleanup to work on the first attempt so let's just
give it one more chance after some delay.