### PR TITLE
Added GObject introspection for LVM module

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -7,7 +7,7 @@ PYTHON ?= python3
 
 NULL =
 
-SUBDIRS = data udisks src tools modules po doc
+SUBDIRS = data generated udisks src tools modules po doc gi
 
 ACLOCAL_AMFLAGS = -I m4 ${ACLOCAL_FLAGS}
 

--- a/README.txt
+++ b/README.txt
@@ -1,0 +1,35 @@
+TODO: This file should not be part of the final commit
+* work in progress, sorry about the mess
+
+Introspection work so far:
+
+* added new directory "generated"
+  ** contains new Makefile.am that runs before everything else
+     to generate all generated files (udisks + modules)
+  ** works, no attention needed
+
+* added new directory "gi" <- INTROSPECTION LOCATED HERE
+  ** contains new Makefile.am that runs after everything else
+  ** introspection has to be run last when everything is done (it runs its own compilation)
+  ** contents mostly moved from/based on ./udisks/Makefile.am
+  ** Makefile called correctly, introspection runs ok on core functions
+
+* how to compile and run (on VM):
+  ** sudo git clean -xdf (purge)
+  ** ./autogen.sh --enable-modules --disable-gtk-doc --prefix=/usr && make
+     *** make produces bunch of warnings that I think may be related to the issue
+  ** sudo make install
+
+* how to reproduce the issue:
+  ** as root:
+  ** # export LD_LIBRARY_PATH=/usr/lib64/udisks2/modules
+  ** # ./udisks/udisks-pygi-example.py
+  ** produces two debug udisks warnings (source: ./modules/lvm2/udiskslvm2dbusutil.c:154,165)
+  ** produces "./udisks/udisks-pygi-example.py:28: Warning: invalid cast from 'GDBusProxy' to 'UDisksLogicalVolume'"
+     which is the main problem
+  ** warning itself is correctly raised in the "UDISKS_LOGICAL_VOLUME" macro
+
+Introspection information:
+man g-ir-scanner
+man g-ir-compiler
+https://wiki.gnome.org/Projects/GObjectIntrospection/AutotoolsIntegration

--- a/configure.ac
+++ b/configure.ac
@@ -21,7 +21,7 @@ AC_CONFIG_SRCDIR([src])
 AC_CONFIG_HEADERS([config.h])
 AC_CONFIG_AUX_DIR([build-aux])
 
-AM_INIT_AUTOMAKE([1.11 foreign silent-rules dist-bzip2 no-dist-gzip])
+AM_INIT_AUTOMAKE([1.11 foreign silent-rules dist-bzip2 no-dist-gzip subdir-objects])
 AM_MAINTAINER_MODE
 AM_SILENT_RULES([yes])
 
@@ -646,6 +646,8 @@ fi
 AC_OUTPUT([
 Makefile
 data/Makefile
+gi/Makefile
+generated/Makefile
 udisks/Makefile
 udisks/udisks2.conf
 udisks/udisks2.pc

--- a/generated/Makefile.am
+++ b/generated/Makefile.am
@@ -1,0 +1,51 @@
+## Process this file with automake to produce Makefile.in
+
+NULL =
+
+SUBDIRS =
+
+LVM2_MODULE_DIR = $(top_srcdir)/modules/lvm2
+
+$(dbus_built_sources) : Makefile.am $(top_srcdir)/data/org.freedesktop.UDisks2.xml
+	gdbus-codegen                                                   \
+	    --interface-prefix org.freedesktop.UDisks2.                 \
+	    --c-namespace UDisks                                        \
+	    --c-generate-object-manager                                 \
+	    --output-directory $(top_srcdir)/udisks                     \
+	    --generate-c-code udisks-generated                          \
+	    --generate-docbook udisks-generated-doc                     \
+	    $(top_srcdir)/data/org.freedesktop.UDisks2.xml              \
+	    $(NULL)
+
+dbus_built_sources =                                                \
+    $(top_srcdir)/udisks/udisks-generated.h                         \
+    $(top_srcdir)/udisks/udisks-generated.c                         \
+    $(NULL)
+
+
+$(dbus_lvm2_built_sources): Makefile.am $(LVM2_MODULE_DIR)/data/org.freedesktop.UDisks2.lvm2.xml
+	gdbus-codegen                                                   \
+	    --interface-prefix org.freedesktop.UDisks2.                 \
+	    --c-namespace UDisks                                        \
+	    --output-directory $(LVM2_MODULE_DIR)                       \
+	    --generate-c-code udisks-lvm2-generated                     \
+	    --generate-docbook udisks-generated-doc                     \
+	    $(LVM2_MODULE_DIR)/data/org.freedesktop.UDisks2.lvm2.xml    \
+	    $(NULL)
+
+dbus_lvm2_built_sources =                                           \
+	$(LVM2_MODULE_DIR)/udisks-lvm2-generated.h                      \
+	$(LVM2_MODULE_DIR)/udisks-lvm2-generated.c                      \
+	$(NULL)
+
+BUILT_SOURCES =                                                     \
+	$(dbus_built_sources)                                           \
+	$(dbus_lvm2_built_sources)                                      \
+	$(NULL)
+
+CLEANFILES =                                                        \
+	$(NULL)
+
+EXTRA_DIST =                                                        \
+	$(NULL)
+

--- a/gi/Makefile.am
+++ b/gi/Makefile.am
@@ -1,0 +1,126 @@
+## Process this file with automake to produce Makefile.in
+
+SUBDIRS =
+
+NULL =
+
+MODULES_DIR = ../modules
+
+LVM2_MODULE_DIR = $(MODULES_DIR)/lvm2
+UDISKS_DIR = ../udisks
+
+# LVM2 module ------------------------------------------------------------
+
+lvm2_SOURCES =                                            \
+	$(LVM2_MODULE_DIR)/udisks-lvm2-generated.h            \
+	$(LVM2_MODULE_DIR)/udisks-lvm2-generated.c            \
+	$(MODULES_DIR)/udisksmoduleiface.h                    \
+	$(MODULES_DIR)/udisksmoduleifacetypes.h               \
+	$(MODULES_DIR)/udisksmoduleobject.h                   \
+	$(MODULES_DIR)/udisksmoduleobject.c                   \
+	$(LVM2_MODULE_DIR)/udiskslvm2types.h                  \
+	$(LVM2_MODULE_DIR)/udiskslvm2moduleiface.c            \
+	$(LVM2_MODULE_DIR)/udiskslinuxlogicalvolume.h         \
+	$(LVM2_MODULE_DIR)/udiskslinuxlogicalvolume.c         \
+	$(LVM2_MODULE_DIR)/udiskslinuxlogicalvolumeobject.h   \
+	$(LVM2_MODULE_DIR)/udiskslinuxlogicalvolumeobject.c   \
+	$(LVM2_MODULE_DIR)/udiskslinuxphysicalvolume.h        \
+	$(LVM2_MODULE_DIR)/udiskslinuxphysicalvolume.c        \
+	$(LVM2_MODULE_DIR)/udiskslinuxvolumegroup.h           \
+	$(LVM2_MODULE_DIR)/udiskslinuxvolumegroup.c           \
+	$(LVM2_MODULE_DIR)/udiskslinuxvolumegroupobject.h     \
+	$(LVM2_MODULE_DIR)/udiskslinuxvolumegroupobject.c     \
+	$(LVM2_MODULE_DIR)/udiskslinuxblocklvm2.h             \
+	$(LVM2_MODULE_DIR)/udiskslinuxblocklvm2.c             \
+	$(LVM2_MODULE_DIR)/udiskslvm2daemonutil.h             \
+	$(LVM2_MODULE_DIR)/udiskslvm2daemonutil.c             \
+	$(LVM2_MODULE_DIR)/udiskslvm2dbusutil.h               \
+	$(LVM2_MODULE_DIR)/udiskslvm2dbusutil.c               \
+	$(LVM2_MODULE_DIR)/udiskslvm2util.h                   \
+	$(LVM2_MODULE_DIR)/udiskslvm2util.c                   \
+	$(LVM2_MODULE_DIR)/udiskslinuxmanagerlvm2.h           \
+	$(LVM2_MODULE_DIR)/udiskslinuxmanagerlvm2.c           \
+	$(LVM2_MODULE_DIR)/udiskslvm2state.h                  \
+	$(LVM2_MODULE_DIR)/udiskslvm2state.c                  \
+	$(LVM2_MODULE_DIR)/jobhelpers.h                       \
+	$(LVM2_MODULE_DIR)/jobhelpers.c                       \
+	$(NULL)
+
+# ------------------------------------------------------------------------
+
+BUILT_SOURCES =                                           \
+	$(UDISKS_DIR)/udisksenumtypes.h                       \
+	$(UDISKS_DIR)/udisksenumtypes.c                       \
+	$(UDISKS_DIR)/udisks-generated.h                      \
+	$(UDISKS_DIR)/udisks-generated.c                      \
+	$(UDISKS_DIR)/udisksversion.h                         \
+	$(NULL)
+
+libudisks2_la_SOURCES =                                   \
+	$(BUILT_SOURCES)                                      \
+	$(UDISKS_DIR)/udisksclient.h                          \
+	$(UDISKS_DIR)/udisksclient.c                          \
+	$(UDISKS_DIR)/udisksobjectinfo.h                      \
+	$(UDISKS_DIR)/udisksobjectinfo.c                      \
+	$(UDISKS_DIR)/udisksenums.h                           \
+	$(UDISKS_DIR)/udiskserror.h                           \
+	$(UDISKS_DIR)/udiskserror.c                           \
+	$(UDISKS_DIR)/udiskstypes.h                           \
+	$(NULL)
+
+libudisks2_la_cflags =                                    \
+	$(GLIB_CFLAGS)                                        \
+	$(GIO_CFLAGS)                                         \
+	$(NULL)
+
+if HAVE_INTROSPECTION
+
+INTROSPECTION_GIRS = UDisks-2.0.gir
+
+girdir = $(INTROSPECTION_GIRDIR)
+gir_DATA = UDisks-2.0.gir
+
+typelibdir = $(INTROSPECTION_TYPELIBDIR)
+typelib_DATA = UDisks-2.0.typelib
+
+UDisks_2_0_gir_SCANNERFLAGS =                             \
+	--c-include='udisks/udisks.h'                         \
+	--warn-all                                            \
+	--namespace UDisks                                    \
+	--identifier-prefix UDisks                            \
+	--symbol-prefix udisks                                \
+	--accept-unprefixed	                              \
+	--warn-all                                            \
+	$(NULL)
+
+UDisks_2_0_gir_CFLAGS =                                   \
+	$(libudisks2_la_cflags)                               \
+	-DUDISKS_COMPILATION                                  \
+	-I ../src                                       \
+	-I ..                                     \
+	$(NULL)
+
+UDisks-2.0.gir:	../src/libudisks-daemon.la $(UDISKS_DIR)/libudisks2.la $(LVM2_MODULE_DIR)/libudisks2_lvm2.la
+UDisks_2_0_gir_INCLUDES = \
+	Gio-2.0           \
+	GUdev-1.0         \
+	Polkit-1.0        \
+	$(NULL)
+UDisks_2_0_gir_LIBS =                                     \
+	blockdev                         \
+	../src/libudisks-daemon.la                            \
+	$(UDISKS_DIR)/libudisks2.la                           \
+	$(LVM2_MODULE_DIR)/libudisks2_lvm2.la                 \
+	$(NULL)
+UDisks_2_0_gir_FILES =                                    \
+	$(libudisks2_la_SOURCES)                              \
+	$(lvm2_SOURCES)                                       \
+	$(NULL)
+UDisks_2_0_gir_EXPORT_PACKAGES = udisks2
+
+include $(INTROSPECTION_MAKEFILE)
+
+endif # HAVE_INTROSPECTION
+
+CLEANFILES =
+

--- a/modules/bcache/Makefile.am
+++ b/modules/bcache/Makefile.am
@@ -57,10 +57,10 @@ libudisks2_bcacheinclude_HEADERS =                                            \
 
 libudisks2_bcache_la_SOURCES =                                                \
 	$(BUILT_SOURCES)                                                      \
-	$(top_srcdir)/modules/udisksmoduleiface.h                             \
-	$(top_srcdir)/modules/udisksmoduleifacetypes.h                        \
-	$(top_srcdir)/modules/udisksmoduleobject.h                            \
-	$(top_srcdir)/modules/udisksmoduleobject.c                            \
+	../udisksmoduleiface.h                                                \
+	../udisksmoduleifacetypes.h                                           \
+	../udisksmoduleobject.h                                               \
+	../udisksmoduleobject.c                                               \
 	udiskslinuxblockbcache.c                                              \
 	udiskslinuxblockbcache.h                                              \
 	udiskslinuxmanagerbcache.h                                            \

--- a/modules/btrfs/Makefile.am
+++ b/modules/btrfs/Makefile.am
@@ -55,12 +55,12 @@ libudisks2_btrfsinclude_HEADERS =                                              \
 	$(top_srcdir)/modules/udisksmoduleobject.h                             \
 	$(NULL)
 
-libudisks2_btrfs_la_SOURCES =                                                  \
+libudisks2_btrfs_la_SOURCES =                                              \
 	$(BUILT_SOURCES)                                                       \
-	$(top_srcdir)/modules/udisksmoduleiface.h                              \
-	$(top_srcdir)/modules/udisksmoduleifacetypes.h                         \
-	$(top_srcdir)/modules/udisksmoduleobject.h                             \
-	$(top_srcdir)/modules/udisksmoduleobject.c                             \
+	../udisksmoduleiface.h                                                 \
+	../udisksmoduleifacetypes.h                                            \
+	../udisksmoduleobject.h                                                \
+	../udisksmoduleobject.c                                                \
 	udiskslinuxfilesystembtrfs.h                                           \
 	udiskslinuxfilesystembtrfs.c                                           \
 	udiskslinuxmanagerbtrfs.h                                              \

--- a/modules/iscsi/Makefile.am
+++ b/modules/iscsi/Makefile.am
@@ -56,10 +56,10 @@ libudisks2_iscsiinclude_HEADERS =                                              \
 
 libudisks2_iscsi_la_SOURCES =                                                  \
 	$(BUILT_SOURCES)                                                       \
-	$(top_srcdir)/modules/udisksmoduleiface.h                              \
-	$(top_srcdir)/modules/udisksmoduleifacetypes.h                         \
-	$(top_srcdir)/modules/udisksmoduleobject.h                             \
-	$(top_srcdir)/modules/udisksmoduleobject.c                             \
+	../udisksmoduleiface.h                                                 \
+	../udisksmoduleifacetypes.h                                            \
+	../udisksmoduleobject.h                                                \
+	../udisksmoduleobject.c                                                \
 	udiskslinuxmanageriscsiinitiator.h                                     \
 	udiskslinuxmanageriscsiinitiator.c                                     \
 	udisksiscsistate.h                                                     \

--- a/modules/lsm/Makefile.am
+++ b/modules/lsm/Makefile.am
@@ -64,10 +64,10 @@ libudisks2_lsminclude_HEADERS= \
 
 libudisks2_lsm_la_SOURCES = \
 	$(BUILT_SOURCES) \
-	$(top_srcdir)/modules/udisksmoduleiface.h \
-	$(top_srcdir)/modules/udisksmoduleifacetypes.h \
-	$(top_srcdir)/modules/udisksmoduleobject.h \
-	$(top_srcdir)/modules/udisksmoduleobject.c \
+	../udisksmoduleiface.h \
+	../udisksmoduleifacetypes.h \
+	../udisksmoduleobject.h \
+	../udisksmoduleobject.c \
 	lsm_types.h \
 	lsm_module_iface.c \
 	lsm_data.h lsm_data.c \

--- a/modules/lvm2/Makefile.am
+++ b/modules/lvm2/Makefile.am
@@ -8,7 +8,7 @@ MODULE_SO = libudisks2_lvm2.so
 
 NULL =
 
-CPPFLAGS =                                                                     \
+CPPFLAGS =                                                                 \
 	-I$(top_builddir) -I$(top_srcdir)                                      \
 	-DPACKAGE_LIBEXEC_DIR=\""$(libexecdir)"\"                              \
 	-DPACKAGE_SYSCONF_DIR=\""$(sysconfdir)"\"                              \
@@ -28,19 +28,11 @@ CPPFLAGS =                                                                     \
 	$(WARN_CFLAGS)                                                         \
 	$(NULL)
 
-$(dbus_built_sources): $(LVM2_MODULE_DIR)/data/org.freedesktop.UDisks2.lvm2.xml Makefile.am
-	$(AM_V_GEN) gdbus-codegen                                              \
-	        --interface-prefix org.freedesktop.UDisks2.                    \
-	        --c-namespace UDisks                                           \
-	        --generate-c-code udisks-lvm2-generated                        \
-	        --generate-docbook udisks-generated-doc                        \
-	        $<
-
-dbus_built_sources =                                                           \
+dbus_built_sources =                                                       \
 	udisks-lvm2-generated.h    udisks-lvm2-generated.c                     \
 	$(NULL)
 
-BUILT_SOURCES =                                                                \
+BUILT_SOURCES =                                                            \
 	$(dbus_built_sources)                                                  \
 	$(NULL)
 
@@ -49,18 +41,17 @@ libudisks2_lvm2_LTLIBRARIES=libudisks2_lvm2.la
 
 libudisks2_lvm2includedir=$(includedir)/udisks2/udisks
 
-libudisks2_lvm2include_HEADERS =                                               \
+libudisks2_lvm2include_HEADERS =                                           \
 	$(top_srcdir)/modules/udisksmoduleiface.h                              \
 	$(top_srcdir)/modules/udisksmoduleifacetypes.h                         \
 	$(top_srcdir)/modules/udisksmoduleobject.h                             \
 	$(NULL)
 
-libudisks2_lvm2_la_SOURCES =                                                   \
+libudisks2_lvm2_la_SOURCES =                                               \
 	$(BUILT_SOURCES)                                                       \
-	$(top_srcdir)/modules/udisksmoduleiface.h                              \
-	$(top_srcdir)/modules/udisksmoduleifacetypes.h                         \
-	$(top_srcdir)/modules/udisksmoduleobject.h                             \
-	$(top_srcdir)/modules/udisksmoduleobject.c                             \
+	../udisksmoduleiface.h                                                 \
+	../udisksmoduleifacetypes.h                                            \
+	../udisksmoduleobject.h                                                \
 	udiskslvm2types.h                                                      \
 	udiskslvm2moduleiface.c                                                \
 	udiskslinuxlogicalvolume.h          udiskslinuxlogicalvolume.c         \
@@ -78,19 +69,19 @@ libudisks2_lvm2_la_SOURCES =                                                   \
 	jobhelpers.h                        jobhelpers.c                       \
 	$(NULL)
 
-libudisks2_lvm2_la_CPPFLAGS =                                                  \
+libudisks2_lvm2_la_CPPFLAGS =                                              \
 	$(CPPFLAGS)                                                            \
 	-DG_LOG_DOMAIN=\"libudisks2-lvm2\"                                     \
 	$(NULL)
 
-libudisks2_lvm2_la_CFLAGS =                                                    \
+libudisks2_lvm2_la_CFLAGS =                                                \
 	$(GLIB_CFLAGS)                                                         \
 	$(GIO_CFLAGS)                                                          \
 	$(GUDEV_CFLAGS)                                                        \
 	$(POLKIT_GOBJECT_1_CFLAGS)                                             \
 	$(NULL)
 
-libudisks2_lvm2_la_LDFLAGS =                                                   \
+libudisks2_lvm2_la_LDFLAGS =                                               \
 	-export_dynamic                                                        \
 	-avoid-version                                                         \
 	-module                                                                \
@@ -99,18 +90,19 @@ libudisks2_lvm2_la_LDFLAGS =                                                   \
 	 '^udisks_.*|g_io_module_load|g_io_module_unload|g_io_module_query'    \
 	$(NULL)
 
-libudisks2_lvm2_la_LIBADD =                                                    \
+libudisks2_lvm2_la_LIBADD =                                                \
 	$(GLIB_LIBS)                                                           \
 	$(GIO_LIBS)                                                            \
 	$(GUDEV_LIBS)                                                          \
 	$(POLKIT_GOBJECT_1_LIBS)                                               \
+	../../src/libudisks-daemon.la                 \
 	$(NULL)
 
 # ------------------------------------------------------------------------------
 
 CLEANFILES = udisks-generated-doc-*.xml udisks-generated.[ch]
 
-EXTRA_DIST =                                                                   \
+EXTRA_DIST =                                                               \
 	$(NULL)
 
 include ../Makefile.uninstalled

--- a/modules/lvm2/udiskslinuxlogicalvolume.c
+++ b/modules/lvm2/udiskslinuxlogicalvolume.c
@@ -113,8 +113,10 @@ udisks_linux_logical_volume_new (void)
 /**
  * udisks_linux_logical_volume_update:
  * @logical_volume: A #UDisksLinuxLogicalVolume.
- * @vg: LVM volume group
- * @lv: LVM logical volume
+ * @group_object: *UDisksLinuxVolumeGroupObject
+ * @lv_info: *BDLVMLVdata
+ * @meta_lv_info: *BDLVMLVdata
+ * @needs_polling_ret: bool
  *
  * Updates the interface.
  */

--- a/modules/lvm2/udiskslinuxvolumegroup.c
+++ b/modules/lvm2/udiskslinuxvolumegroup.c
@@ -129,8 +129,8 @@ udisks_linux_volume_group_new (void)
 
 /**
  * udisks_linux_volume_group_update:
- * @volume_group: A #UDisksLinuxVolumeGroup.
- * @object: The enclosing #UDisksLinuxVolumeGroupObject instance.
+ * @vg_info: *BDLVMVGdata.
+ * @needs_polling_ret: *gboolean.
  *
  * Updates the interface.
  */

--- a/modules/lvm2/udiskslvm2dbusutil.c
+++ b/modules/lvm2/udiskslvm2dbusutil.c
@@ -151,9 +151,20 @@ UDisksLogicalVolume *
 udisks_object_get_logical_volume (UDisksObject *object)
 {
   GDBusInterface *ret;
+  g_warning ("MYDEBUG: Get logical volume called");
   ret = g_dbus_object_get_interface (G_DBUS_OBJECT (object), "org.freedesktop.UDisks2.LogicalVolume");
   if (ret == NULL)
     return NULL;
+
+  if (UDISKS_IS_LOGICAL_VOLUME(ret))
+  {
+    g_warning ("MYDEBUG: checked");
+  } 
+  else 
+  {
+    g_warning ("MYDEBUG: check failed");
+  }
+
   return UDISKS_LOGICAL_VOLUME (ret);
 }
 

--- a/modules/udisksmoduleiface.h
+++ b/modules/udisksmoduleiface.h
@@ -40,15 +40,15 @@ G_MODULE_EXPORT gpointer udisks_module_init (UDisksDaemon *daemon);
 /* Corresponds with the UDisksModuleTeardownFunc type */
 G_MODULE_EXPORT void udisks_module_teardown (UDisksDaemon *daemon);
 
-/**
- * UDisks module setup entry functions:
- *   Functions below are module entry functions that return an array of setup
- *   functions (or structures containing group of setup functions). See
- *   udisksmoduleifacetypes.h for detailed description.
- *
- *   Setup functions are queried by UDisksModuleManager only once (typically on
- *   startup or on demand). Modules are never unloaded for safety reasons.
- */
+/*
+ UDisks2 module setup entry functions
+ Functions below are module entry functions that return an array of setup
+ functions (or structures containing group of setup functions). See
+ udisksmoduleifacetypes.h for detailed description.
+
+ Setup functions are queried by UDisksModuleManager only once (typically on
+ startup or on demand). Modules are never unloaded for safety reasons.
+*/
 
 /* Corresponds with the UDisksModuleIfaceSetupFunc type */
 G_MODULE_EXPORT UDisksModuleInterfaceInfo **udisks_module_get_block_object_iface_setup_entries (void);

--- a/modules/zram/Makefile.am
+++ b/modules/zram/Makefile.am
@@ -62,10 +62,10 @@ libudisks2_zraminclude_HEADERS =                                               \
 
 libudisks2_zram_la_SOURCES =                                                   \
 	$(BUILT_SOURCES)                                                       \
-	$(top_srcdir)/modules/udisksmoduleiface.h                              \
-	$(top_srcdir)/modules/udisksmoduleifacetypes.h                         \
-	$(top_srcdir)/modules/udisksmoduleobject.h                             \
-	$(top_srcdir)/modules/udisksmoduleobject.c                             \
+	../udisksmoduleiface.h                                                 \
+	../udisksmoduleifacetypes.h                                            \
+	../udisksmoduleobject.h                                                \
+	../udisksmoduleobject.c                                                \
 	udiskslinuxblockzram.c                                                 \
 	udiskslinuxblockzram.h                                                 \
 	udiskslinuxmanagerzram.h                                               \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -88,8 +88,8 @@ libudisks_daemon_la_SOURCES =                                                  \
 	udisksata.h                    udisksata.c                             \
 	udisksmodulemanager.h          udisksmodulemanager.c                   \
 	udisksconfigmanager.h          udisksconfigmanager.c                   \
-	$(top_srcdir)/modules/udisksmoduleobject.h                             \
-	$(top_srcdir)/modules/udisksmoduleobject.c                             \
+	../modules/udisksmoduleobject.h                                        \
+	../modules/udisksmoduleobject.c                                        \
 	$(BUILT_SOURCES)                                                       \
 	$(NULL)
 

--- a/udisks/Makefile.am
+++ b/udisks/Makefile.am
@@ -9,98 +9,88 @@ moduleconfdir = $(sysconfdir)/udisks2/
 moduleconf_DATA = udisks2.conf
 
 AM_CPPFLAGS = \
-	-I$(top_builddir) -I$(top_srcdir)	 		\
-	-DPACKAGE_LIBEXEC_DIR=\""$(libexecdir)"\" 		\
-	-DPACKAGE_SYSCONF_DIR=\""$(sysconfdir)"\" 		\
-	-DPACKAGE_DATA_DIR=\""$(datadir)"\" 			\
-	-DPACKAGE_BIN_DIR=\""$(bindir)"\" 			\
-	-DPACKAGE_LOCALSTATE_DIR=\""$(localstatedir)"\" 	\
-	-DPACKAGE_LOCALE_DIR=\""$(localedir)"\" 		\
-	-DPACKAGE_LIB_DIR=\""$(libdir)"\" 			\
-	-D_POSIX_PTHREAD_SEMANTICS -D_REENTRANT			\
-	-DUDISKS_COMPILATION					\
-	$(GLIB_CFLAGS) 						\
-	$(GIO_CFLAGS)						\
-	$(WARN_CFLAGS)						\
+	-I$(top_builddir) -I$(top_srcdir)               \
+	-DPACKAGE_LIBEXEC_DIR=\""$(libexecdir)"\"       \
+	-DPACKAGE_SYSCONF_DIR=\""$(sysconfdir)"\"       \
+	-DPACKAGE_DATA_DIR=\""$(datadir)"\"             \
+	-DPACKAGE_BIN_DIR=\""$(bindir)"\"               \
+	-DPACKAGE_LOCALSTATE_DIR=\""$(localstatedir)"\" \
+	-DPACKAGE_LOCALE_DIR=\""$(localedir)"\"         \
+	-DPACKAGE_LIB_DIR=\""$(libdir)"\"               \
+	-D_POSIX_PTHREAD_SEMANTICS -D_REENTRANT         \
+	-DUDISKS_COMPILATION                            \
+	$(GLIB_CFLAGS)                                  \
+	$(GIO_CFLAGS)                                   \
+	$(WARN_CFLAGS)                                  \
 	$(NULL)
 
-$(dbus_built_sources) : Makefile.am $(top_srcdir)/data/org.freedesktop.UDisks2.xml
-	gdbus-codegen							                \
-		--interface-prefix org.freedesktop.UDisks2.                          	\
-		--c-namespace UDisks							\
-		--c-generate-object-manager						\
-		--generate-c-code udisks-generated                             		\
-		--generate-docbook udisks-generated-doc					\
-		$(top_srcdir)/data/org.freedesktop.UDisks2.xml         			\
-		$(NULL)
-
 udisksenumtypes.h: udisksenums.h udisksenumtypes.h.template
-	( top_builddir=`cd $(top_builddir) && pwd`; 						\
-	 cd $(srcdir) && glib-mkenums --template udisksenumtypes.h.template udisksenums.h ) | 	\
-	   sed 's,U_TYPE_DISKS,UDISKS_TYPE,' | sed 's,u_disks,udisks,' > 			\
+	( top_builddir=`cd $(top_builddir) && pwd`;                                             \
+	 cd $(srcdir) && glib-mkenums --template udisksenumtypes.h.template udisksenums.h ) |   \
+	   sed 's,U_TYPE_DISKS,UDISKS_TYPE,' | sed 's,u_disks,udisks,' >                        \
 	   udisksenumtypes.h.tmp && mv udisksenumtypes.h.tmp udisksenumtypes.h
 
 udisksenumtypes.c: udisksenums.h udisksenumtypes.c.template
-	( top_builddir=`cd $(top_builddir) && pwd`; 						\
-	 cd $(srcdir) && glib-mkenums --template udisksenumtypes.c.template udisksenums.h ) | 	\
-	   sed 's,U_TYPE_DISKS,UDISKS_TYPE,' | sed 's,u_disks,udisks,' > 			\
+	( top_builddir=`cd $(top_builddir) && pwd`;                                             \
+	 cd $(srcdir) && glib-mkenums --template udisksenumtypes.c.template udisksenums.h ) |   \
+	   sed 's,U_TYPE_DISKS,UDISKS_TYPE,' | sed 's,u_disks,udisks,' >                        \
 	   udisksenumtypes.c.tmp && mv udisksenumtypes.c.tmp udisksenumtypes.c
 
-enum_built_sources =									\
-	udisksenumtypes.h			udisksenumtypes.c			\
+enum_built_sources =                                \
+	udisksenumtypes.h			udisksenumtypes.c   \
 	$(NULL)
 
-dbus_built_sources =									\
-	udisks-generated.h			udisks-generated.c			\
+dbus_built_sources =                                \
+	udisks-generated.h			udisks-generated.c  \
 	$(NULL)
 
 udisksversion.h: $(top_srcdir)/udisks/udisksversion.h.in
 	   sed -e 's/@MAJOR_VERSION@/$(UDISKS_MAJOR_VERSION)/' -e 's/@MINOR_VERSION@/$(UDISKS_MINOR_VERSION)/' -e 's/@MICRO_VERSION@/$(UDISKS_MICRO_VERSION)/' $(top_srcdir)/udisks/udisksversion.h.in > udisksversion.h.tmp && mv udisksversion.h.tmp udisksversion.h
 
-BUILT_SOURCES =										\
-	$(enum_built_sources)								\
-	$(dbus_built_sources)								\
-	udisksversion.h									\
+BUILT_SOURCES =                                     \
+	$(enum_built_sources)                           \
+	$(dbus_built_sources)                           \
+	udisksversion.h                                 \
 	$(NULL)
 
 lib_LTLIBRARIES=libudisks2.la
 
 libudisks2includedir=$(includedir)/udisks2/udisks
 
-libudisks2include_HEADERS=								\
-	udisks.h									\
-	udisksclient.h									\
-	udisksobjectinfo.h								\
-	udisksenums.h									\
-	udisksenumtypes.h								\
-	udiskserror.h									\
-	udiskstypes.h									\
-	udisks-generated.h								\
-	udisksversion.h									\
+libudisks2include_HEADERS=                          \
+	udisks.h                                        \
+	udisksclient.h                                  \
+	udisksobjectinfo.h                              \
+	udisksenums.h                                   \
+	udisksenumtypes.h                               \
+	udiskserror.h                                   \
+	udiskstypes.h                                   \
+	udisks-generated.h                              \
+	udisksversion.h                                 \
 	$(NULL)
 
-libudisks2_la_SOURCES =									\
-	$(BUILT_SOURCES)								\
-	udisksclient.h				udisksclient.c				\
-	udisksobjectinfo.h			udisksobjectinfo.c			\
-	udisksenums.h									\
-	udiskserror.h				udiskserror.c				\
-	udiskstypes.h									\
+libudisks2_la_SOURCES =                             \
+	$(BUILT_SOURCES)                                \
+	udisksclient.h				udisksclient.c      \
+	udisksobjectinfo.h			udisksobjectinfo.c  \
+	udisksenums.h                                   \
+	udiskserror.h				udiskserror.c       \
+	udiskstypes.h                                   \
 	$(NULL)
 
-libudisks2_la_CPPFLAGS = 				\
-	-DG_LOG_DOMAIN=\"libudisks2\"			\
-	$(AM_CPPFLAGS)					\
+libudisks2_la_CPPFLAGS =                            \
+	-DG_LOG_DOMAIN=\"libudisks2\"                   \
+	$(AM_CPPFLAGS)                                  \
 	$(NULL)
 
-libudisks2_la_CFLAGS = 					\
-	$(GLIB_CFLAGS)					\
-	$(GIO_CFLAGS)					\
+libudisks2_la_CFLAGS =                              \
+	$(GLIB_CFLAGS)                                  \
+	$(GIO_CFLAGS)                                   \
 	$(NULL)
 
-libudisks2_la_LIBADD = 					\
-	$(GLIB_LIBS)					\
-	$(GIO_LIBS)					\
+libudisks2_la_LIBADD =                              \
+	$(GLIB_LIBS)                                    \
+	$(GIO_LIBS)                                     \
 	$(NULL)
 
 # ----------------------------------------------------------------------------------------------------
@@ -110,52 +100,52 @@ pkgconfig_DATA = udisks2.pc
 
 # ----------------------------------------------------------------------------------------------------
 
-if HAVE_INTROSPECTION
-
-INTROSPECTION_GIRS = UDisks-2.0.gir
-
-girdir = $(INTROSPECTION_GIRDIR)
-gir_DATA = UDisks-2.0.gir
-
-typelibsdir = $(INTROSPECTION_TYPELIBDIR)
-typelibs_DATA = UDisks-2.0.typelib
-
-UDisks_2_0_gir_SCANNERFLAGS = 			\
-	--c-include='udisks/udisks.h' 		\
-	--warn-all                              \
-        --namespace UDisks                      \
-        --identifier-prefix UDisks              \
-        --symbol-prefix udisks                  \
-	--warn-all				\
-	$(NULL)
-
-UDisks_2_0_gir_CFLAGS = 			\
-        $(libudisks2_la_CFLAGS)        		\
-        -DUDISKS_COMPILATION                   	\
-	-I$(top_srcdir)				\
-	-I$(top_builddir)			\
-	$(NULL)
-
-UDisks-2.0.gir: libudisks2.la
-UDisks_2_0_gir_INCLUDES = Gio-2.0
-UDisks_2_0_gir_LIBS = libudisks2.la
-UDisks_2_0_gir_FILES = $(libudisks2_la_SOURCES)
-UDisks_2_0_gir_EXPORT_PACKAGES = udisks2
-
-include $(INTROSPECTION_MAKEFILE)
-
-endif # HAVE_INTROSPECTION
+#if HAVE_INTROSPECTION
+#
+#INTROSPECTION_GIRS = UDisks-2.0.gir
+#
+#girdir = $(INTROSPECTION_GIRDIR)
+#gir_DATA = UDisks-2.0.gir
+#
+#typelibsdir = $(INTROSPECTION_TYPELIBDIR)
+#typelibs_DATA = UDisks-2.0.typelib
+#
+#UDisks_2_0_gir_SCANNERFLAGS =                       \
+#	--c-include='udisks/udisks.h'                   \
+#	--warn-all                                      \
+#        --namespace UDisks                          \
+#        --identifier-prefix UDisks                  \
+#        --symbol-prefix udisks                      \
+#	--warn-all                                      \
+#	$(NULL)
+#
+#UDisks_2_0_gir_CFLAGS =                             \
+#        $(libudisks2_la_CFLAGS)                     \
+#        -DUDISKS_COMPILATION                        \
+#	-I$(top_srcdir)                                 \
+#	-I$(top_builddir)                               \
+#	$(NULL)
+#
+#UDisks-2.0.gir: libudisks2.la
+#UDisks_2_0_gir_INCLUDES = Gio-2.0
+#UDisks_2_0_gir_LIBS = libudisks2.la
+#UDisks_2_0_gir_FILES = $(libudisks2_la_SOURCES)
+#UDisks_2_0_gir_EXPORT_PACKAGES = udisks2
+#
+#include $(INTROSPECTION_MAKEFILE)
+#
+#endif # HAVE_INTROSPECTION
 
 # ----------------------------------------------------------------------------------------------------
 
 CLEANFILES = udisks-generated-doc-*.xml udisks-generated.[ch] $(gir_DATA) $(typelibs_DATA)
 
-EXTRA_DIST = 						\
+EXTRA_DIST =                                        \
 	udisks2.conf.in                                 \
-	udisks2.pc.in					\
-	udisksversion.h.in				\
-	udisksenumtypes.h.template			\
-	udisksenumtypes.c.template			\
+	udisks2.pc.in                                   \
+	udisksversion.h.in                              \
+	udisksenumtypes.h.template                      \
+	udisksenumtypes.c.template                      \
 	$(NULL)
 
 dist-hook :

--- a/udisks/udisks-pygi-example.py
+++ b/udisks/udisks-pygi-example.py
@@ -1,13 +1,11 @@
 #!/usr/bin/python3
 #
-# very simple example
-#
-# To run this example out of the development tree you will need the daemon
-# running and you will need to setup a couple environment variables.  Assuming
+# To run this out of the development tree you will need the daemon
+# running and you will need to setup a couple environment variables. Assuming
 # you are in the root of the source tree do something like:
 #
-# export GI_TYPELIB_PATH=`pwd`/udisks
-# export LD_LIBRARY_PATH=`pwd`/udisks/.libs
+# export GI_TYPELIB_PATH=/usr/lib64/girepository-1.0
+# export LD_LIBRARY_PATH=/usr/lib64/udisks2/modules
 #
 
 import gi
@@ -15,11 +13,23 @@ gi.require_version('UDisks', '2.0')
 from gi.repository import UDisks
 
 client = UDisks.Client.new_sync(None)
-manager = client.get_object_manager()
-objects = manager.get_objects()
-for o in objects:
-    print('%s:' % o.get_object_path())
-    ifaces = o.get_interfaces()
-    for i in ifaces:
-        print(' IFace %s' % i.get_interface_name())
-    print('')
+
+manager = client.get_manager()
+manager.call_enable_modules_sync(True, None)
+
+lvmo = client.get_object("/org/freedesktop/UDisks2/lvm/lvmempty/lvm1")
+sdao = client.get_object("/org/freedesktop/UDisks2/block_devices/sda")
+
+#from gi.repository import GLib
+#sdao.get_block().call_rescan(GLib.Variant("a{sv}", {}))
+
+#import pdb; pdb.set_trace()
+
+lvmo.get_logical_volume()
+#lvmo.get_logical_volume().call_rename_sync('(sa{sv})', "lvm3", {})
+#lvmo.get_logical_volume().call_activate_sync()
+
+# call using DBus
+#lvm_iface = lvmo.get_interface("org.freedesktop.UDisks2.LogicalVolume")
+#lvm_iface.Rename('(sa{sv})', "lvm1", {}, dbus_interface="org.freedesktop.UDisks2.LogicalVolume")
+


### PR DESCRIPTION
Modified makefiles so generated files are created first.
This enables g-ir-scanner to be run.

Note: not to be merged yet. But some review would be nice.