### PR TITLE
Add 'no-discard' option to formatting methods

### DIFF
--- a/data/org.freedesktop.UDisks2.xml
+++ b/data/org.freedesktop.UDisks2.xml
@@ -1404,6 +1404,10 @@
         this allows a deeper check of the parameters even when
         <parameter>no-block</parameter> is %TRUE.
 
+        If the option <parameter>no-discard</parameter> is set to
+        %TRUE then Udisks tells the formatting utility not to issue
+        BLKDISCARD ioctls.
+
         If the option <parameter>config-items</parameter> is set, it
         should be an array of configuration items suitable for
         org.freedesktop.UDisks2.Block.AddConfigurationItem.  They will

--- a/src/tests/integration-test
+++ b/src/tests/integration-test
@@ -825,6 +825,8 @@ class FS(UDisksTestCase):
             self._do_udisks_check(fs_type, 'test%stst' % fs_type)
             # also test fs_create with an empty label
             self._do_udisks_check(fs_type, '')
+            # also test fs_create with the no-discard option
+            self._do_udisks_check(fs_type, '', True)
 
     def _do_cli_check(self, fs_type, label=None):
         """udisks correctly picks up file system changes from command line tools"""
@@ -890,15 +892,17 @@ class FS(UDisksTestCase):
         subprocess.call(['umount', mount_a])
         self.assertProperty(fs, 'mount-points', [])
 
-    def _do_udisks_check(self, fs_type, label=None):
+    def _do_udisks_check(self, fs_type, label=None, no_discard=None):
         """udisks API correctly changes file system"""
 
+
         # create fs
+        options = { }
         if label is not None:
-            options = GLib.Variant('a{sv}', {'label': GLib.Variant('s', label)})
-        else:
-            options = no_options
-        self.fs_create(None, fs_type, options)
+            options['label'] = GLib.Variant('s', label);
+        if no_discard is not None:
+            options['no-discard'] = GLib.Variant('b', no_discard);
+        self.fs_create(None, fs_type, GLib.Variant('a{sv}', options))
 
         # properties
         b_id = self.blkid()

--- a/src/udiskslinuxfsinfo.c
+++ b/src/udiskslinuxfsinfo.c
@@ -70,8 +70,9 @@ const FSInfo _fs_info[] =
       NULL,
       TRUE,  /* supports_online_label_rename */
       TRUE,  /* supports_owners */
-      "mkfs.ext2 -F -L $LABEL $DEVICE",
-      "mkfs.ext2 -n -F -L $LABEL $DEVICE",
+      "mkfs.ext2 -F -L $LABEL $OPTIONS $DEVICE",
+      "mkfs.ext2 -n -F -L $LABEL $OPTIONS $DEVICE",
+      "-E nodiscard", /* option_no_discard */
     },
     {
       FS_EXT3,
@@ -79,8 +80,9 @@ const FSInfo _fs_info[] =
       NULL,
       TRUE,  /* supports_online_label_rename */
       TRUE,  /* supports_owners */
-      "mkfs.ext3 -F -L $LABEL $DEVICE",
-      "mkfs.ext3 -n -F -L $LABEL $DEVICE",
+      "mkfs.ext3 -F -L $LABEL $OPTIONS $DEVICE",
+      "mkfs.ext3 -n -F -L $LABEL $OPTIONS $DEVICE",
+      "-E nodiscard", /* option_no_discard */
     },
     {
       FS_EXT4,
@@ -88,8 +90,9 @@ const FSInfo _fs_info[] =
       NULL,
       TRUE,  /* supports_online_label_rename */
       TRUE,  /* supports_owners */
-      "mkfs.ext4 -F -L $LABEL $DEVICE",
-      "mkfs.ext4 -n -F -L $LABEL $DEVICE",
+      "mkfs.ext4 -F -L $LABEL $OPTIONS $DEVICE",
+      "mkfs.ext4 -n -F -L $LABEL $OPTIONS $DEVICE",
+      "-E nodiscard", /* option_no_discard */
     },
     {
       FS_VFAT,
@@ -99,6 +102,7 @@ const FSInfo _fs_info[] =
       FALSE, /* supports_owners */
       "mkfs.vfat -I -n $LABEL $DEVICE",
       NULL,
+      NULL, /* option_no_discard */
     },
     {
       FS_NTFS,
@@ -108,6 +112,7 @@ const FSInfo _fs_info[] =
       FALSE, /* supports_owners */
       "mkntfs -f -F -L $LABEL $DEVICE",
       "mkntfs -n -f -F -L $LABEL $DEVICE",
+      NULL, /* option_no_discard */
     },
     {
       FS_EXFAT,
@@ -117,6 +122,7 @@ const FSInfo _fs_info[] =
       FALSE, /* supports_owners */
       "mkexfatfs -n $LABEL $DEVICE",
       NULL,
+      NULL, /* option_no_discard */
     },
     {
       FS_XFS,
@@ -124,8 +130,9 @@ const FSInfo _fs_info[] =
       "xfs_admin -L -- $DEVICE",
       FALSE, /* supports_online_label_rename */
       TRUE,  /* supports_owners */
-      "mkfs.xfs -f -L $LABEL $DEVICE",
-      "mkfs.xfs -N -f -L $LABEL $DEVICE"
+      "mkfs.xfs -f -L $LABEL $OPTIONS $DEVICE",
+      "mkfs.xfs -N -f -L $LABEL $OPTIONS $DEVICE",
+      "-K" /* option_no_discard */
     },
     {
       FS_REISERFS,
@@ -135,6 +142,7 @@ const FSInfo _fs_info[] =
       TRUE,  /* supports_owners */
       "mkfs.reiserfs -q -l $LABEL $DEVICE",
       NULL,
+      NULL, /* option_no_discard */
     },
     {
       FS_NILFS2,
@@ -144,6 +152,7 @@ const FSInfo _fs_info[] =
       TRUE,  /* supports_owners */
       "mkfs.nilfs2 -L $LABEL $DEVICE",
       NULL,
+      NULL, /* option_no_discard */
     },
     {
       FS_BTRFS,
@@ -151,8 +160,9 @@ const FSInfo _fs_info[] =
       NULL,
       FALSE, /* supports_online_label_rename */
       TRUE,  /* supports_owners */
-      "mkfs.btrfs -L $LABEL $DEVICE",
+      "mkfs.btrfs -L $LABEL $OPTIONS $DEVICE",
       NULL,
+      "-K", /* option_no_discard */
     },
     {
       FS_MINIX,
@@ -161,6 +171,7 @@ const FSInfo _fs_info[] =
       FALSE, /* supports_online_label_rename */
       FALSE, /* supports_owners */
       "mkfs.minix $DEVICE",
+      NULL,
       NULL,
     },
     {
@@ -171,6 +182,7 @@ const FSInfo _fs_info[] =
       TRUE,  /* supports_owners */
       "mkudffs --utf8 --media-type=hd --udfrev=0x201 --blocksize=$BLOCKSIZE --vid $LABEL --lvid $LABEL $DEVICE",
       NULL,
+      NULL,
     },
     {
       FS_F2FS,
@@ -179,6 +191,7 @@ const FSInfo _fs_info[] =
       FALSE, /* supports_online_label_rename */
       TRUE,  /* supports_owners */
       "mkfs.f2fs -l $LABEL $DEVICE",
+      NULL,
       NULL,
     },
     /* swap space */

--- a/src/udiskslinuxfsinfo.h
+++ b/src/udiskslinuxfsinfo.h
@@ -35,6 +35,7 @@ typedef struct
   gboolean     supports_owners;
   const gchar *command_create_fs;  /* should have $DEVICE and $LABEL */
   const gchar *command_validate_create_fs;  /* should have $DEVICE and $LABEL */
+  const gchar *option_no_discard;
 } FSInfo;
 
 const FSInfo  *get_fs_info (const gchar *fstype);


### PR DESCRIPTION
It unfortunately seems to be necessary to use this option in certain
situations.  See https://bugzilla.redhat.com/show_bug.cgi?id=1516041
for example.