### PR TITLE
Add utab monitor

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -170,6 +170,17 @@ PKG_CHECK_MODULES(LIBATASMART, [libatasmart >= 0.17])
 AC_SUBST(LIBATASMART_CFLAGS)
 AC_SUBST(LIBATASMART_LIBS)
 
+PKG_CHECK_MODULES(LIBMOUNT, [mount >= 2.30],
+                  [have_libmount=yes],
+                  [have_libmount=no])
+AM_CONDITIONAL(HAVE_LIBMOUNT, test x$have_libmount = xyes)
+if test "x$have_libmount" = "xyes"; then
+  AC_DEFINE([HAVE_LIBMOUNT], 1, [Define to 1 if libmount >= 2.30 is available])
+fi
+AC_SUBST(HAVE_LIBMOUNT)
+AC_SUBST(LIBMOUNT_CFLAGS)
+AC_SUBST(LIBMOUNT_LIBS)
+
 PKG_CHECK_MODULES(LIBSYSTEMD_LOGIN, [libsystemd >= 209], [have_libsystemd_login=yes],
                   [PKG_CHECK_MODULES(LIBSYSTEMD_LOGIN, [libsystemd-login >= 44 libsystemd-daemon],
                   [have_libsystemd_login=yes],
@@ -731,6 +742,7 @@ echo "
         use /media for mounting:    ${fhs_media}
         acl support:                ${have_acl}
         libblockdev_part support:   ${have_libblockdev_part}
+        using libmount:             ${have_libmount}
 
         compiler:                   ${CC}
         cflags:                     ${CFLAGS}

--- a/data/org.freedesktop.UDisks2.xml
+++ b/data/org.freedesktop.UDisks2.xml
@@ -1250,6 +1250,7 @@
     -->
     <property name="HintSymbolicIconName" type="s" access="read"/>
 
+    <!-- UserspaceMountOptions: List of userspace mount options. -->
     <property name="UserspaceMountOptions" type="as" access="read"/>
 
     <!--

--- a/data/org.freedesktop.UDisks2.xml
+++ b/data/org.freedesktop.UDisks2.xml
@@ -1250,6 +1250,8 @@
     -->
     <property name="HintSymbolicIconName" type="s" access="read"/>
 
+    <property name="UserspaceMountOptions" type="as" access="read"/>
+
     <!--
         AddConfigurationItem:
         @item: The configuration item to add.

--- a/doc/udisks2-docs.xml.in.in
+++ b/doc/udisks2-docs.xml.in.in
@@ -431,6 +431,7 @@
       <xi:include href="xml/udisksmountmonitor.xml"/>
       <xi:include href="xml/udisksfstabmonitor.xml"/>
       <xi:include href="xml/udiskscrypttabmonitor.xml"/>
+      <xi:include href="xml/udisksutabmonitor.xml"/>
     </chapter>
     <chapter id="ref-daemon-jobs">
       <title>Jobs</title>

--- a/doc/udisks2-sections.txt.in.in
+++ b/doc/udisks2-sections.txt.in.in
@@ -1434,6 +1434,27 @@ udisks_crypttab_monitor_get_type
 </SECTION>
 
 <SECTION>
+<FILE>udisksutabmonitor</FILE>
+<TITLE>UDisksUtabMonitor</TITLE>
+UDisksUtabEntry
+udisks_utab_entry_get_source
+udisks_utab_entry_get_opts
+UDisksUtabMonitor
+udisks_utab_monitor_new
+udisks_utab_monitor_get_entries
+<SUBSECTION Standard>
+UDISKS_TYPE_UTAB_ENTRY
+UDISKS_UTAB_ENTRY
+UDISKS_IS_UTAB_ENTRY
+UDISKS_TYPE_UTAB_MONITOR
+UDISKS_UTAB_MONITOR
+UDISKS_IS_UTAB_MONITOR
+<SUBSECTION Private>
+udisks_utab_entry_get_type
+udisks_utab_monitor_get_type
+</SECTION>
+
+<SECTION>
 <FILE>UDisksPartition</FILE>
 UDisksPartition
 UDisksPartitionIface

--- a/doc/uml/classes.txt
+++ b/doc/uml/classes.txt
@@ -10,6 +10,7 @@ class UdisksDaemon {
     UdisksMountMonitor     *udisks_daemon_get_mount_monitor()
     UdisksFstabMonitor     *udisks_daemon_get_fstab_monitor()
     UdisksCrypttabMonitor  *udisks_daemon_get_crypttab_monitor()
+    UdisksUtabMonitor      *udisks_daemon_get_utab_monitor()
     UdisksLinuxProvider    *udisks_daemon_get_linux_provider()
     PolkitAuthority          *udisks_daemon_get_authority()
     UdisksState            *udisks_daemon_get_state()

--- a/packaging/udisks2.spec
+++ b/packaging/udisks2.spec
@@ -44,6 +44,7 @@ BuildRequires: libblockdev-swap-devel   >= %{libblockdev_version}
 BuildRequires: libblockdev-mdraid-devel >= %{libblockdev_version}
 BuildRequires: libblockdev-fs-devel     >= %{libblockdev_version}
 BuildRequires: libblockdev-crypto-devel >= %{libblockdev_version}
+BuildRequires: libmount-devel
 
 Requires: libblockdev        >= %{libblockdev_version}
 Requires: libblockdev-part   >= %{libblockdev_version}
@@ -74,6 +75,8 @@ Requires: dosfstools
 Requires: gdisk
 # For ejecting removable disks
 Requires: eject
+# For utab monitor
+Requires: libmount
 
 Requires: lib%{name}%{?_isa} = %{version}-%{release}
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -101,6 +101,7 @@ libudisks_daemon_la_CFLAGS =                                                   \
 	$(GMODULE_CFLAGS)                                                      \
 	$(GUDEV_CFLAGS)                                                        \
 	$(LIBATASMART_CFLAGS)                                                  \
+	$(LIBMOUNT_CFLAGS)                                                     \
 	$(POLKIT_GOBJECT_1_CFLAGS)                                             \
 	$(ACL_CFLAGS)                                                          \
 	$(LIBSYSTEMD_LOGIN_CFLAGS)                                             \
@@ -117,6 +118,7 @@ libudisks_daemon_la_LIBADD =                                                   \
 	$(BLOCKDEV_LIBS)                                                       \
 	-lbd_utils                                                             \
 	$(LIBATASMART_LIBS)                                                    \
+	$(LIBMOUNT_LIBS)                                                       \
 	$(POLKIT_GOBJECT_1_LIBS)                                               \
 	$(ACL_LIBS)                                                            \
 	$(LIBSYSTEMD_LOGIN_LIBS)                                               \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -93,6 +93,12 @@ libudisks_daemon_la_SOURCES =                                                  \
 	$(BUILT_SOURCES)                                                       \
 	$(NULL)
 
+if HAVE_LIBMOUNT
+libudisks_daemon_la_SOURCES +=                                           \
+	udisksutabentry.h              udisksutabentry.c                       \
+	udisksutabmonitor.h            udisksutabmonitor.c
+endif # HAVE_LIBMOUNT
+
 libudisks_daemon_la_CFLAGS =                                                   \
 	-I$(top_srcdir)                                                        \
 	-DG_LOG_DOMAIN=\"udisks\"                                              \

--- a/src/udisksdaemon.c
+++ b/src/udisksdaemon.c
@@ -44,6 +44,10 @@
 #include "udisksmodulemanager.h"
 #include "udisksconfigmanager.h"
 
+#ifdef HAVE_LIBMOUNT
+#include "udisksutabmonitor.h"
+#endif
+
 /**
  * SECTION:udisksdaemon
  * @title: UDisksDaemon
@@ -78,6 +82,10 @@ struct _UDisksDaemon
   UDisksFstabMonitor *fstab_monitor;
 
   UDisksCrypttabMonitor *crypttab_monitor;
+
+#ifdef HAVE_LIBMOUNT
+  UDisksUtabMonitor *utab_monitor;
+#endif
 
   UDisksModuleManager *module_manager;
 
@@ -128,6 +136,9 @@ udisks_daemon_finalize (GObject *object)
   g_object_unref (daemon->mount_monitor);
   g_object_unref (daemon->fstab_monitor);
   g_object_unref (daemon->crypttab_monitor);
+#ifdef HAVE_LIBMOUNT
+  g_object_unref (daemon->utab_monitor);
+#endif
 
   g_clear_object (&daemon->module_manager);
 
@@ -343,6 +354,9 @@ udisks_daemon_constructed (GObject *object)
 
   daemon->fstab_monitor = udisks_fstab_monitor_new ();
   daemon->crypttab_monitor = udisks_crypttab_monitor_new ();
+#ifdef HAVE_LIBMOUNT
+  daemon->utab_monitor = udisks_utab_monitor_new ();
+#endif
 
   /* now add providers */
   daemon->linux_provider = udisks_linux_provider_new (daemon);

--- a/src/udisksdaemon.c
+++ b/src/udisksdaemon.c
@@ -584,6 +584,23 @@ udisks_daemon_get_crypttab_monitor (UDisksDaemon *daemon)
   return daemon->crypttab_monitor;
 }
 
+#ifdef HAVE_LIBMOUNT
+/**
+ * udisks_daemon_get_utab_monitor:
+ * @daemon: A #UDisksDaemon
+ *
+ * Gets the utab monitor used by @daemon.
+ *
+ * Returns: A #UDisksUtabMonitor. Do not free, the object is owned by @daemon.
+ */
+UDisksUtabMonitor *
+udisks_daemon_get_utab_monitor (UDisksDaemon *daemon)
+{
+  g_return_val_if_fail (UDISKS_IS_DAEMON (daemon), NULL);
+  return daemon->utab_monitor;
+}
+#endif
+
 /**
  * udisks_daemon_get_linux_provider:
  * @daemon: A #UDisksDaemon.

--- a/src/udisksdaemon.h
+++ b/src/udisksdaemon.h
@@ -21,6 +21,7 @@
 #ifndef __UDISKS_DAEMON_H__
 #define __UDISKS_DAEMON_H__
 
+#include "config.h"
 #include "udisksdaemontypes.h"
 
 G_BEGIN_DECLS
@@ -39,6 +40,9 @@ GDBusObjectManagerServer *udisks_daemon_get_object_manager    (UDisksDaemon    *
 UDisksMountMonitor       *udisks_daemon_get_mount_monitor     (UDisksDaemon    *daemon);
 UDisksFstabMonitor       *udisks_daemon_get_fstab_monitor     (UDisksDaemon    *daemon);
 UDisksCrypttabMonitor    *udisks_daemon_get_crypttab_monitor  (UDisksDaemon    *daemon);
+#ifdef HAVE_LIBMOUNT
+UDisksUtabMonitor        *udisks_daemon_get_utab_monitor      (UDisksDaemon    *daemon);
+#endif
 UDisksLinuxProvider      *udisks_daemon_get_linux_provider    (UDisksDaemon    *daemon);
 PolkitAuthority          *udisks_daemon_get_authority         (UDisksDaemon    *daemon);
 UDisksState              *udisks_daemon_get_state             (UDisksDaemon    *daemon);

--- a/src/udisksdaemontypes.h
+++ b/src/udisksdaemontypes.h
@@ -20,6 +20,8 @@
 #ifndef __UDISKS_DAEMON_TYPES_H__
 #define __UDISKS_DAEMON_TYPES_H__
 
+#include "config.h"
+
 #include <gio/gio.h>
 #include <polkit/polkit.h>
 #include <udisks/udisks.h>
@@ -101,6 +103,14 @@ typedef struct _UDisksCrypttabMonitor UDisksCrypttabMonitor;
 
 struct _UDisksCrypttabEntry;
 typedef struct _UDisksCrypttabEntry UDisksCrypttabEntry;
+
+#ifdef HAVE_LIBMOUNT
+struct _UDisksUtabMonitor;
+typedef struct _UDisksUtabMonitor UDisksUtabMonitor;
+
+struct _UDisksUtabEntry;
+typedef struct _UDisksUtabEntry UDisksUtabEntry;
+#endif
 
 struct _UDisksLinuxPartition;
 typedef struct _UDisksLinuxPartition UDisksLinuxPartition;

--- a/src/udiskslinuxfilesystem.c
+++ b/src/udiskslinuxfilesystem.c
@@ -508,6 +508,11 @@ is_mount_option_allowed (const FSMountOptions *fsmo,
         }
     }
 
+  if (g_str_has_prefix (option, "x-"))
+    {
+      return TRUE;
+    }
+
   return FALSE;
 }
 

--- a/src/udisksprivate.h
+++ b/src/udisksprivate.h
@@ -21,8 +21,13 @@
 #ifndef __UDISKS_PRIVATE_H__
 #define __UDISKS_PRIVATE_H__
 
+#include "config.h"
 #include "udisksdaemontypes.h"
 #include <mntent.h>
+
+#ifdef HAVE_LIBMOUNT
+#include <libmount/libmount.h>
+#endif
 
 G_BEGIN_DECLS
 
@@ -36,6 +41,10 @@ UDisksCrypttabEntry *_udisks_crypttab_entry_new (const gchar *name,
                                                  const gchar *device,
                                                  const gchar *passphrase,
                                                  const gchar *options);
+
+#ifdef HAVE_LIBMOUNT
+UDisksUtabEntry * _udisks_utab_entry_new (struct libmnt_fs *fs);
+#endif
 
 G_END_DECLS
 

--- a/src/udisksthreadedjob.c
+++ b/src/udisksthreadedjob.c
@@ -205,7 +205,7 @@ run_task_job (GTask            *task,
                                        &job->job_error);
     }
 
-  g_main_context_invoke (g_main_context_get_thread_default (), job_complete, job);
+  g_main_context_invoke (g_task_get_context (task), job_complete, job);
 }
 
 static void

--- a/src/udisksutabentry.c
+++ b/src/udisksutabentry.c
@@ -1,0 +1,120 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*-
+ *
+ * Copyright (C) 2017 Andrea Azzarone <andrea.azzarone@canonical.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ */
+
+#include <glib.h>
+#include <glib-object.h>
+
+#include "udisksutabentry.h"
+#include "udisksprivate.h"
+
+/**
+ * UDisksUtabEntry:
+ *
+ * The #UDisksUtabEntry structure contains only private data and should
+ * only be accessed using the provided API.
+ */
+struct _UDisksUtabEntry
+{
+  GObject parent_instance;
+
+  gchar *source;
+  gchar *opts;
+};
+
+typedef struct _UDisksUtabEntryClass UDisksUtabEntryClass;
+
+struct _UDisksUtabEntryClass
+{
+  GObjectClass parent_class;
+};
+
+G_DEFINE_TYPE (UDisksUtabEntry, udisks_utab_entry, G_TYPE_OBJECT);
+
+static void
+udisks_utab_entry_init (UDisksUtabEntry *entry)
+{
+  entry->source = NULL;
+  entry->opts = NULL;
+}
+
+static void
+udisks_utab_entry_finalize (GObject *object)
+{
+  UDisksUtabEntry *entry = UDISKS_UTAB_ENTRY (object);
+
+  g_free (entry->source);
+  g_free (entry->opts);
+
+  if (G_OBJECT_CLASS (udisks_utab_entry_parent_class)->finalize)
+    G_OBJECT_CLASS (udisks_utab_entry_parent_class)->finalize (object);
+}
+
+static void
+udisks_utab_entry_class_init (UDisksUtabEntryClass *klass)
+{
+  GObjectClass *gobject_class;
+
+  gobject_class = G_OBJECT_CLASS (klass);
+  gobject_class->finalize = udisks_utab_entry_finalize;
+}
+
+
+UDisksUtabEntry *
+_udisks_utab_entry_new (struct libmnt_fs *fs)
+{
+  UDisksUtabEntry *entry;
+
+  entry = UDISKS_UTAB_ENTRY (g_object_new (UDISKS_TYPE_UTAB_ENTRY, NULL));
+
+  entry->source = g_strdup (mnt_fs_get_source (fs));
+  entry->opts = g_strdup (mnt_fs_get_user_options (fs));
+
+  return entry;
+}
+
+/**
+ * udisks_utab_entry_get_source:
+ * @entry: A #UDisksUtabEntry.
+ *
+ * Gets the source field of @entry.
+ *
+ * Returns: The source field.
+ */
+const gchar *
+udisks_utab_entry_get_source (UDisksUtabEntry *entry)
+{
+  g_return_val_if_fail (UDISKS_IS_UTAB_ENTRY (entry), NULL);
+  return entry->source;
+}
+
+/**
+ * udisks_utab_entry_get_opts:
+ * @entry: A #UDisksUtabEntry.
+ *
+ * Gets the opts field of @entry.
+ *
+ * Returns: The opts field.
+ */
+const gchar *
+udisks_utab_entry_get_opts (UDisksUtabEntry *entry)
+{
+  g_return_val_if_fail (UDISKS_IS_UTAB_ENTRY (entry), NULL);
+  return entry->opts;
+}

--- a/src/udisksutabentry.c
+++ b/src/udisksutabentry.c
@@ -34,8 +34,8 @@ struct _UDisksUtabEntry
 {
   GObject parent_instance;
 
-  gchar *source;
-  gchar *opts;
+  gchar  *source;
+  gchar **opts;
 };
 
 typedef struct _UDisksUtabEntryClass UDisksUtabEntryClass;
@@ -60,7 +60,7 @@ udisks_utab_entry_finalize (GObject *object)
   UDisksUtabEntry *entry = UDISKS_UTAB_ENTRY (object);
 
   g_free (entry->source);
-  g_free (entry->opts);
+  g_strfreev (entry->opts);
 
   if (G_OBJECT_CLASS (udisks_utab_entry_parent_class)->finalize)
     G_OBJECT_CLASS (udisks_utab_entry_parent_class)->finalize (object);
@@ -84,7 +84,7 @@ _udisks_utab_entry_new (struct libmnt_fs *fs)
   entry = UDISKS_UTAB_ENTRY (g_object_new (UDISKS_TYPE_UTAB_ENTRY, NULL));
 
   entry->source = g_strdup (mnt_fs_get_source (fs));
-  entry->opts = g_strdup (mnt_fs_get_user_options (fs));
+  entry->opts = g_strsplit (mnt_fs_get_user_options (fs), ",", -1);
 
   return entry;
 }
@@ -112,9 +112,9 @@ udisks_utab_entry_get_source (UDisksUtabEntry *entry)
  *
  * Returns: The opts field.
  */
-const gchar *
+const gchar * const *
 udisks_utab_entry_get_opts (UDisksUtabEntry *entry)
 {
   g_return_val_if_fail (UDISKS_IS_UTAB_ENTRY (entry), NULL);
-  return entry->opts;
+  return (const gchar * const *) entry->opts;
 }

--- a/src/udisksutabentry.h
+++ b/src/udisksutabentry.h
@@ -1,0 +1,40 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*-
+ *
+ * Copyright (C) 2017 Andrea Azzarone <andrea.azzarone@canonical.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ */
+
+#ifndef __UDISKS_UTAB_ENTRY_H__
+#define __UDISKS_UTAB_ENTRY_H__
+
+#include "udisksdaemontypes.h"
+
+G_BEGIN_DECLS
+
+#define UDISKS_TYPE_UTAB_ENTRY  (udisks_utab_entry_get_type ())
+#define UDISKS_UTAB_ENTRY(o)    (G_TYPE_CHECK_INSTANCE_CAST ((o), UDISKS_TYPE_UTAB_ENTRY, UDisksUtabEntry))
+#define UDISKS_IS_UTAB_ENTRY(o) (G_TYPE_CHECK_INSTANCE_TYPE ((o), UDISKS_TYPE_UTAB_ENTRY))
+
+GType        udisks_utab_entry_get_type   (void) G_GNUC_CONST;
+const gchar *udisks_utab_entry_get_source (UDisksUtabEntry *entry);
+const gchar *udisks_utab_entry_get_opts   (UDisksUtabEntry *entry);
+
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(UDisksUtabEntry, g_object_unref)
+
+G_END_DECLS
+
+#endif /* __UDISKS_UTAB_ENTRY_H__ */

--- a/src/udisksutabentry.h
+++ b/src/udisksutabentry.h
@@ -29,9 +29,9 @@ G_BEGIN_DECLS
 #define UDISKS_UTAB_ENTRY(o)    (G_TYPE_CHECK_INSTANCE_CAST ((o), UDISKS_TYPE_UTAB_ENTRY, UDisksUtabEntry))
 #define UDISKS_IS_UTAB_ENTRY(o) (G_TYPE_CHECK_INSTANCE_TYPE ((o), UDISKS_TYPE_UTAB_ENTRY))
 
-GType        udisks_utab_entry_get_type   (void) G_GNUC_CONST;
-const gchar *udisks_utab_entry_get_source (UDisksUtabEntry *entry);
-const gchar *udisks_utab_entry_get_opts   (UDisksUtabEntry *entry);
+GType                udisks_utab_entry_get_type   (void) G_GNUC_CONST;
+const gchar         *udisks_utab_entry_get_source (UDisksUtabEntry *entry);
+const gchar * const *udisks_utab_entry_get_opts   (UDisksUtabEntry *entry);
 
 G_DEFINE_AUTOPTR_CLEANUP_FUNC(UDisksUtabEntry, g_object_unref)
 

--- a/src/udisksutabmonitor.c
+++ b/src/udisksutabmonitor.c
@@ -1,0 +1,238 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*-
+ *
+ * Copyright (C) 2017 Andrea Azzarone <andrea.azzarone@canonical.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ */
+
+#include <libmount/libmount.h>
+
+#include <glib.h>
+#include <glib-object.h>
+
+#include "udisksutabmonitor.h"
+#include "udisksutabentry.h"
+#include "udisksprivate.h"
+
+/**
+ * SECTION:udisksutabmonitor
+ * @title: UDisksUtabMonitor
+ * @short_description: Monitors entries in the utab file
+ *
+ * This type is used for monitoring entries in the
+ * <filename>/run/mounts/utab</filename> file.
+ */
+
+/**
+ * UDisksUtabMonitor:
+ *
+ * The #UDisksUtabMonitor structure contains only private data and
+ * should only be accessed using the provided API.
+ */
+struct _UDisksUtabMonitor
+{
+  GObject parent_instance;
+
+  GIOChannel *utab_channel;
+  GSource *utab_watch_source;
+
+  struct libmnt_monitor *mn;
+
+  gboolean have_data;
+  GList *utab_entries;
+};
+
+typedef struct _UDisksUtabMonitorClass UDisksUtabMonitorClass;
+
+struct _UDisksUtabMonitorClass
+{
+  GObjectClass parent_class;
+};
+
+G_DEFINE_TYPE (UDisksUtabMonitor, udisks_utab_monitor, G_TYPE_OBJECT)
+
+static void udisks_utab_monitor_ensure (UDisksUtabMonitor *monitor);
+static void udisks_utab_monitor_invalidate (UDisksUtabMonitor *monitor);
+static void udisks_utab_monitor_constructed (GObject *object);
+
+static void
+udisks_utab_monitor_init (UDisksUtabMonitor *monitor)
+{
+  monitor->have_data = FALSE;
+  monitor->utab_entries = NULL;
+}
+
+static void
+udisks_utab_monitor_finalize (GObject *object)
+{
+  UDisksUtabMonitor *monitor = UDISKS_UTAB_MONITOR (object);
+
+  if (monitor->utab_channel != NULL)
+    g_io_channel_unref (monitor->utab_channel);
+  if (monitor->utab_watch_source != NULL)
+    g_source_destroy (monitor->utab_watch_source);
+  if (monitor->mn)
+    mnt_unref_monitor (monitor->mn);
+
+  if (G_OBJECT_CLASS (udisks_utab_monitor_parent_class)->finalize != NULL)
+    G_OBJECT_CLASS (udisks_utab_monitor_parent_class)->finalize (object);
+}
+
+
+static void
+udisks_utab_monitor_class_init (UDisksUtabMonitorClass *klass)
+{
+  GObjectClass *gobject_class = (GObjectClass *) klass;
+
+  gobject_class->finalize    = udisks_utab_monitor_finalize;
+  gobject_class->constructed = udisks_utab_monitor_constructed;
+}
+
+static gboolean
+fs_has_user_options (struct libmnt_fs *fs, void *user_data)
+{
+  return mnt_fs_get_user_options (fs) != NULL;
+}
+
+static void
+reload_utab_entries (UDisksUtabMonitor *monitor)
+{
+  udisks_utab_monitor_invalidate (monitor);
+  udisks_utab_monitor_ensure (monitor);
+}
+
+static gboolean
+utab_changed_event (GIOChannel *channel,
+                    GIOCondition cond,
+                    gpointer user_data)
+{
+  UDisksUtabMonitor *monitor = UDISKS_UTAB_MONITOR (user_data);
+  gboolean need_reload;
+  gint r;
+
+  if (cond & ~G_IO_IN)
+    return G_SOURCE_CONTINUE;
+
+  need_reload = FALSE;
+
+  do
+  {
+    const char *filename;
+    r = mnt_monitor_next_change (monitor->mn, &filename, NULL);
+
+    if (r == 0)
+      need_reload = TRUE;
+  } while (r == 0);
+
+  if (need_reload)
+    reload_utab_entries (monitor);
+
+  return G_SOURCE_CONTINUE;
+}
+
+static void
+udisks_utab_monitor_constructed (GObject *object)
+{
+  UDisksUtabMonitor *monitor = UDISKS_UTAB_MONITOR (object);
+
+  monitor->mn = mnt_new_monitor();
+  // Monitor only changes in /run/mount/utab
+  mnt_monitor_enable_userspace (monitor->mn, TRUE, NULL);
+
+  monitor->utab_channel = g_io_channel_unix_new (mnt_monitor_get_fd (monitor->mn));
+  monitor->utab_watch_source = g_io_create_watch (monitor->utab_channel, G_IO_IN);
+  g_source_set_callback (monitor->utab_watch_source, (GSourceFunc) utab_changed_event, monitor, NULL);
+  g_source_attach (monitor->utab_watch_source, g_main_context_get_thread_default ());
+  g_source_unref (monitor->utab_watch_source);
+
+  if (G_OBJECT_CLASS (udisks_utab_monitor_parent_class)->constructed != NULL)
+    (*G_OBJECT_CLASS (udisks_utab_monitor_parent_class)->constructed) (object);
+}
+
+/**
+ * udisks_utab_monitor_new:
+ *
+ * Creates a new #UDisksUtabMonitor object.
+ *
+ * Signals are emitted in the <link
+ * linkend="g-main-context-push-thread-default">thread-default main
+ * loop</link> that this function is called from.
+ *
+ * Returns: A #UDisksUtabMonitor. Free with g_object_unref().
+ */
+UDisksUtabMonitor *
+udisks_utab_monitor_new (void)
+{
+  return UDISKS_UTAB_MONITOR (g_object_new (UDISKS_TYPE_UTAB_MONITOR, NULL));
+}
+
+/**
+ * udisks_utab_monitor_get_entries:
+ * @monitor: A #UDisksUtabMonitor.
+ *
+ * Gets all /run/mounts/utab entries
+ *
+ * Returns: (transfer full) (element-type UDisksUtabEntry): A list of #UDisksUtabEntry objects that must be freed with g_list_free() after each element has been freed with g_object_unref().
+ */
+GList *
+udisks_utab_monitor_get_entries (UDisksUtabMonitor  *monitor)
+{
+  GList *ret;
+
+  g_return_val_if_fail (UDISKS_IS_UTAB_MONITOR (monitor), NULL);
+
+  udisks_utab_monitor_ensure (monitor);
+
+  ret = g_list_copy (monitor->utab_entries);
+  g_list_foreach (ret, (GFunc) g_object_ref, NULL);
+  return ret;
+}
+
+static void
+udisks_utab_monitor_ensure (UDisksUtabMonitor *monitor)
+{
+  struct libmnt_table *tb;
+  struct libmnt_iter *itr;
+  struct libmnt_fs *fs;
+  int r;
+
+  if (monitor->have_data)
+    return;
+
+  tb = mnt_new_table ();
+  r = mnt_table_parse_mtab (tb, NULL);
+
+  itr = mnt_new_iter (MNT_ITER_FORWARD);
+  while(mnt_table_find_next_fs (tb, itr, fs_has_user_options, NULL, &fs) == 0)
+  {
+    UDisksUtabEntry *entry;
+    entry = _udisks_utab_entry_new (fs);
+    monitor->utab_entries = g_list_prepend (monitor->utab_entries, entry);
+  }
+  mnt_free_iter (itr);
+
+  monitor->have_data = TRUE;
+}
+
+static void
+udisks_utab_monitor_invalidate (UDisksUtabMonitor *monitor)
+{
+  monitor->have_data = FALSE;
+
+  g_list_foreach (monitor->utab_entries, (GFunc) g_object_unref, NULL);
+  g_list_free (monitor->utab_entries);
+  monitor->utab_entries = NULL;
+}

--- a/src/udisksutabmonitor.c
+++ b/src/udisksutabmonitor.c
@@ -50,9 +50,7 @@ struct _UDisksUtabMonitor
   GSource *utab_watch_source;
 
   struct libmnt_monitor *mn;
-
-  gboolean have_data;
-  GList *utab_entries;
+  struct libmnt_table *current_tb;
 };
 
 typedef struct _UDisksUtabMonitorClass UDisksUtabMonitorClass;
@@ -60,7 +58,21 @@ typedef struct _UDisksUtabMonitorClass UDisksUtabMonitorClass;
 struct _UDisksUtabMonitorClass
 {
   GObjectClass parent_class;
+
+  void (*entry_added)   (UDisksUtabMonitor *monitor,
+                         UDisksUtabEntry   *entry);
+  void (*entry_removed) (UDisksUtabMonitor *monitor,
+                         UDisksUtabEntry   *entry);
 };
+
+enum
+{
+  ENTRY_ADDED_SIGNAL,
+  ENTRY_REMOVED_SIGNAL,
+  LAST_SIGNAL,
+};
+
+static guint signals[LAST_SIGNAL] = { 0 };
 
 G_DEFINE_TYPE (UDisksUtabMonitor, udisks_utab_monitor, G_TYPE_OBJECT)
 
@@ -71,8 +83,10 @@ static void udisks_utab_monitor_constructed (GObject *object);
 static void
 udisks_utab_monitor_init (UDisksUtabMonitor *monitor)
 {
-  monitor->have_data = FALSE;
-  monitor->utab_entries = NULL;
+  monitor->utab_channel = NULL;
+  monitor->utab_watch_source = NULL;
+  monitor->mn = NULL;
+  monitor->current_tb = NULL;
 }
 
 static void
@@ -86,6 +100,8 @@ udisks_utab_monitor_finalize (GObject *object)
     g_source_destroy (monitor->utab_watch_source);
   if (monitor->mn)
     mnt_unref_monitor (monitor->mn);
+  if (monitor->current_tb)
+    mnt_free_table (monitor->current_tb);
 
   if (G_OBJECT_CLASS (udisks_utab_monitor_parent_class)->finalize != NULL)
     G_OBJECT_CLASS (udisks_utab_monitor_parent_class)->finalize (object);
@@ -99,19 +115,135 @@ udisks_utab_monitor_class_init (UDisksUtabMonitorClass *klass)
 
   gobject_class->finalize    = udisks_utab_monitor_finalize;
   gobject_class->constructed = udisks_utab_monitor_constructed;
+
+  /**
+   * UDisksUtabMonitor::entry-added
+   * @monitor: A #UDisksUtabMonitor.
+   * @entry: The #UDisksUtabEntry that was added.
+   *
+   * Emitted when a utab entry is added.
+   *
+   * This signal is emitted in the
+   * <link linkend="g-main-context-push-thread-default">thread-default main loop</link>
+   * that @monitor was created in.
+   */
+  signals[ENTRY_ADDED_SIGNAL] = g_signal_new ("entry-added",
+                                              G_OBJECT_CLASS_TYPE (klass),
+                                              G_SIGNAL_RUN_LAST | G_SIGNAL_DETAILED,
+                                              G_STRUCT_OFFSET (UDisksUtabMonitorClass, entry_added),
+                                              NULL,
+                                              NULL,
+                                              g_cclosure_marshal_VOID__OBJECT,
+                                              G_TYPE_NONE,
+                                              1,
+                                              UDISKS_TYPE_UTAB_ENTRY);
+
+  /**
+   * UDisksFstabMonitor::entry-removed
+   * @monitor: A #UDisksUtabMonitor.
+   * @entry: The #UDisksUtabEntry that was removed.
+   *
+   * Emitted when a utab entry is removed.
+   *
+   * This signal is emitted in the
+   * <link linkend="g-main-context-push-thread-default">thread-default main loop</link>
+   * that @monitor was created in.
+   */
+  signals[ENTRY_REMOVED_SIGNAL] = g_signal_new ("entry-removed",
+                                                G_OBJECT_CLASS_TYPE (klass),
+                                                G_SIGNAL_RUN_LAST | G_SIGNAL_DETAILED,
+                                                G_STRUCT_OFFSET (UDisksUtabMonitorClass, entry_removed),
+                                                NULL,
+                                                NULL,
+                                                g_cclosure_marshal_VOID__OBJECT,
+                                                G_TYPE_NONE,
+                                                1,
+                                                UDISKS_TYPE_UTAB_ENTRY);
 }
 
 static gboolean
-fs_has_user_options (struct libmnt_fs *fs, void *user_data)
+fs_has_user_options (struct libmnt_fs *fs)
 {
   return mnt_fs_get_user_options (fs) != NULL;
+}
+
+static gboolean
+fs_has_user_options_match_func (struct libmnt_fs *fs, void *data)
+{
+  return fs_has_user_options (fs);
 }
 
 static void
 reload_utab_entries (UDisksUtabMonitor *monitor)
 {
+  struct libmnt_table *old_tb;
+  struct libmnt_tabdiff *diff = NULL;
+  struct libmnt_iter *itr;
+  struct libmnt_fs *old, *new;
+  int rc = -1, change;
+
+  udisks_utab_monitor_ensure (monitor);
+
+  old_tb = monitor->current_tb;
+  mnt_ref_table (old_tb);
+
   udisks_utab_monitor_invalidate (monitor);
   udisks_utab_monitor_ensure (monitor);
+
+  diff = mnt_new_tabdiff();
+  itr = mnt_new_iter(MNT_ITER_FORWARD);
+
+  if (!old_tb || !monitor->current_tb || !diff || !itr)
+    goto out;
+
+  rc = mnt_diff_tables (diff, old_tb, monitor->current_tb);
+
+  if (rc < 0)
+    goto out;
+
+  while (mnt_tabdiff_next_change (diff, itr, &old, &new, &change) == 0)
+    {
+      if (!fs_has_user_options (old) && !fs_has_user_options (new))
+        continue;
+
+      switch (change)
+        {
+          case MNT_TABDIFF_UMOUNT:
+            if (fs_has_user_options (old))
+              {
+                g_autoptr (UDisksUtabEntry) entry = _udisks_utab_entry_new (old);
+                g_signal_emit (monitor, signals[ENTRY_REMOVED_SIGNAL], 0, entry);
+              }
+            break;
+          case MNT_TABDIFF_REMOUNT:
+            if (fs_has_user_options (old))
+              {
+                g_autoptr (UDisksUtabEntry) entry = _udisks_utab_entry_new (old);
+                g_signal_emit (monitor, signals[ENTRY_REMOVED_SIGNAL], 0, entry);
+              }
+            if (fs_has_user_options (new))
+              {
+                g_autoptr (UDisksUtabEntry) entry = _udisks_utab_entry_new (new);
+                g_signal_emit (monitor, signals[ENTRY_ADDED_SIGNAL], 0, entry);
+              }
+            break;
+          case MNT_TABDIFF_MOUNT:
+              if (fs_has_user_options (new))
+              {
+                g_autoptr (UDisksUtabEntry) entry = _udisks_utab_entry_new (new);
+                g_signal_emit (monitor, signals[ENTRY_ADDED_SIGNAL], 0, entry);
+              }
+            break;
+          }
+    }
+
+out:
+  if (old_tb)
+    mnt_unref_table (old_tb);
+  if (diff)
+    mnt_free_tabdiff (diff);
+  if (itr)
+    mnt_free_iter (itr);
 }
 
 static gboolean
@@ -129,13 +261,12 @@ utab_changed_event (GIOChannel *channel,
   need_reload = FALSE;
 
   do
-  {
-    const char *filename;
-    r = mnt_monitor_next_change (monitor->mn, &filename, NULL);
+    {
+      r = mnt_monitor_next_change (monitor->mn, NULL, NULL);
 
-    if (r == 0)
-      need_reload = TRUE;
-  } while (r == 0);
+      if (r == 0)
+        need_reload = TRUE;
+    } while (r == 0);
 
   if (need_reload)
     reload_utab_entries (monitor);
@@ -185,54 +316,48 @@ udisks_utab_monitor_new (void)
  *
  * Gets all /run/mounts/utab entries
  *
- * Returns: (transfer full) (element-type UDisksUtabEntry): A list of #UDisksUtabEntry objects that must be freed with g_list_free() after each element has been freed with g_object_unref().
+ * Returns: (transfer full) (element-type UDisksUtabEntry): A list of #UDisksUtabEntry objects that must be freed with g_slist_free() after each element has been freed with g_object_unref().
  */
-GList *
+GSList *
 udisks_utab_monitor_get_entries (UDisksUtabMonitor  *monitor)
 {
-  GList *ret;
+  GSList *ret;
+  struct libmnt_iter *itr;
+  struct libmnt_fs *fs;
 
   g_return_val_if_fail (UDISKS_IS_UTAB_MONITOR (monitor), NULL);
 
   udisks_utab_monitor_ensure (monitor);
 
-  ret = g_list_copy (monitor->utab_entries);
-  g_list_foreach (ret, (GFunc) g_object_ref, NULL);
+  ret = NULL;
+  itr = mnt_new_iter (MNT_ITER_FORWARD);
+  while (mnt_table_find_next_fs (monitor->current_tb, itr, fs_has_user_options_match_func, NULL, &fs) == 0)
+    {
+      UDisksUtabEntry *entry;
+      entry = _udisks_utab_entry_new (fs);
+      ret = g_slist_prepend (ret, entry);
+    }
+  mnt_free_iter (itr);
+
   return ret;
 }
 
 static void
 udisks_utab_monitor_ensure (UDisksUtabMonitor *monitor)
 {
-  struct libmnt_table *tb;
-  struct libmnt_iter *itr;
-  struct libmnt_fs *fs;
-  int r;
-
-  if (monitor->have_data)
+  if (monitor->current_tb)
     return;
 
-  tb = mnt_new_table ();
-  r = mnt_table_parse_mtab (tb, NULL);
-
-  itr = mnt_new_iter (MNT_ITER_FORWARD);
-  while(mnt_table_find_next_fs (tb, itr, fs_has_user_options, NULL, &fs) == 0)
-  {
-    UDisksUtabEntry *entry;
-    entry = _udisks_utab_entry_new (fs);
-    monitor->utab_entries = g_list_prepend (monitor->utab_entries, entry);
-  }
-  mnt_free_iter (itr);
-
-  monitor->have_data = TRUE;
+  monitor->current_tb = mnt_new_table ();
+  mnt_table_parse_mtab (monitor->current_tb, NULL);
 }
 
 static void
 udisks_utab_monitor_invalidate (UDisksUtabMonitor *monitor)
 {
-  monitor->have_data = FALSE;
-
-  g_list_foreach (monitor->utab_entries, (GFunc) g_object_unref, NULL);
-  g_list_free (monitor->utab_entries);
-  monitor->utab_entries = NULL;
+  if (monitor->current_tb)
+    {
+      mnt_unref_table (monitor->current_tb);
+      monitor->current_tb = NULL;
+    }
 }

--- a/src/udisksutabmonitor.h
+++ b/src/udisksutabmonitor.h
@@ -31,7 +31,7 @@ G_BEGIN_DECLS
 
 GType              udisks_utab_monitor_get_type    (void) G_GNUC_CONST;
 UDisksUtabMonitor *udisks_utab_monitor_new         (void);
-GList             *udisks_utab_monitor_get_entries (UDisksUtabMonitor *monitor);
+GSList            *udisks_utab_monitor_get_entries (UDisksUtabMonitor *monitor);
 
 G_END_DECLS
 

--- a/src/udisksutabmonitor.h
+++ b/src/udisksutabmonitor.h
@@ -1,0 +1,38 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*-
+ *
+ * Copyright (C) 2017 Andrea Azzarone <andrea.azzarone@canonical.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ */
+
+#ifndef __UDISKS_UTAB_MONITOR_H__
+#define __UDISKS_UTAB_MONITOR_H__
+
+#include "udisksdaemontypes.h"
+
+G_BEGIN_DECLS
+
+#define UDISKS_TYPE_UTAB_MONITOR  (udisks_utab_monitor_get_type ())
+#define UDISKS_UTAB_MONITOR(o)    (G_TYPE_CHECK_INSTANCE_CAST ((o), UDISKS_TYPE_UTAB_MONITOR, UDisksUtabMonitor))
+#define UDISKS_IS_UTAB_MONITOR(o) (G_TYPE_CHECK_INSTANCE_TYPE ((o), UDISKS_TYPE_UTAB_MONITOR))
+
+GType              udisks_utab_monitor_get_type    (void) G_GNUC_CONST;
+UDisksUtabMonitor *udisks_utab_monitor_new         (void);
+GList             *udisks_utab_monitor_get_entries (UDisksUtabMonitor *monitor);
+
+G_END_DECLS
+
+#endif /* __UDISKS_UTAB_MONITOR_H__ */


### PR DESCRIPTION
Export the info stored in /run/mounts/utab using the org.freedesktop.UDisks2.Block.Configuration property. For the moment the code to get the mount user options (x-...) has not been moved to libblockdev. I suggest to do that in a later branch as at this point other things need to moved.