### PR TITLE
Use different options for file systems mounted at shared locations

### DIFF
--- a/src/tests/dbus-tests/udiskstestcase.py
+++ b/src/tests/dbus-tests/udiskstestcase.py
@@ -10,6 +10,10 @@ from datetime import datetime
 from systemd import journal
 from monotonic import monotonic
 
+import gi
+gi.require_version('GUdev', '1.0')
+from gi.repository import GUdev
+
 test_devs = None
 FLIGHT_RECORD_FILE = "flight_record.log"
 
@@ -387,6 +391,27 @@ class UdisksTestCase(unittest.TestCase):
 
         return dbus.Array([dbus.Byte(ord(c)) for c in string],
                           signature=dbus.Signature('y'), variant_level=1)
+
+    @classmethod
+    def set_udev_property(self, device, prop, value):
+        udev = GUdev.Client()
+        dev = udev.query_by_device_file(device)
+        serial = dev.get_property("ID_SERIAL")
+
+        try:
+            os.makedirs("/run/udev/rules.d/")
+        except OSError:
+            # already exists
+            pass
+
+        self.write_file("/run/udev/rules.d/99-udisks_test.rules",
+                        'ENV{ID_SERIAL}=="%s", ENV{%s}="%s"\n' % (serial, prop, value))
+        self.run_command("udevadm control --reload")
+        uevent_path = os.path.join(dev.get_sysfs_path(), "uevent")
+        self.write_file(uevent_path, "change\n")
+        self.udev_settle()
+        os.unlink("/run/udev/rules.d/99-udisks_test.rules")
+        self.run_command("udevadm control --reload")
 
 class FlightRecorder(object):
     """Context manager for recording data/logs

--- a/src/tests/dbus-tests/udiskstestcase.py
+++ b/src/tests/dbus-tests/udiskstestcase.py
@@ -413,6 +413,19 @@ class UdisksTestCase(unittest.TestCase):
         os.unlink("/run/udev/rules.d/99-udisks_test.rules")
         self.run_command("udevadm control --reload")
 
+    @classmethod
+    def assertHasIface(self, obj, iface):
+        obj_intro = dbus.Interface(obj, "org.freedesktop.DBus.Introspectable")
+        intro_data = obj_intro.Introspect()
+
+        for _ in range(20):
+            if ('interface name="%s"' % iface) in intro_data:
+                return
+            time.sleep(0.5)
+
+        raise AssertionError("Object '%s' has no interface '%s'" % (obj.object_path, iface))
+
+
 class FlightRecorder(object):
     """Context manager for recording data/logs
 

--- a/src/tests/dbus-tests/udiskstestcase.py
+++ b/src/tests/dbus-tests/udiskstestcase.py
@@ -273,6 +273,7 @@ class UdisksTestCase(unittest.TestCase):
                     with CmdFlightRecorder("udevadm monitor", ["udevadm", "monitor"], record):
                         super(UdisksTestCase, self).run(*args)
             record_f.write("".join(record))
+        self.udev_settle()
 
     @classmethod
     def get_object(self, path_suffix):

--- a/src/udiskslinuxfilesystem.c
+++ b/src/udiskslinuxfilesystem.c
@@ -360,12 +360,10 @@ find_mount_options_for_fs (const gchar *fstype)
     {
       fsmo = fs_mount_options + n;
       if (g_strcmp0 (fsmo->fstype, fstype) == 0)
-        goto out;
+        return fsmo;
     }
 
-  fsmo = NULL;
- out:
-  return fsmo;
+  return NULL;
 }
 
 static gid_t

--- a/src/udiskslinuxfilesystem.c
+++ b/src/udiskslinuxfilesystem.c
@@ -291,45 +291,45 @@ typedef struct
 /* ---------------------- vfat -------------------- */
 
 static const gchar *vfat_defaults[] = { "uid=", "gid=", "shortname=mixed", "utf8=1", "showexec", "flush", NULL };
-static const gchar *vfat_allow[] = { "flush", "utf8=", "shortname=", "umask=", "dmask=", "fmask=", "codepage=", "iocharset=", "usefree", "showexec", NULL };
-static const gchar *vfat_allow_uid_self[] = { "uid=", NULL };
-static const gchar *vfat_allow_gid_self[] = { "gid=", NULL };
+static const gchar *vfat_allow[] = { "flush", "utf8", "shortname", "umask", "dmask", "fmask", "codepage", "iocharset", "usefree", "showexec", NULL };
+static const gchar *vfat_allow_uid_self[] = { "uid", NULL };
+static const gchar *vfat_allow_gid_self[] = { "gid", NULL };
 
 /* ---------------------- ntfs -------------------- */
 /* this is assuming that ntfs-3g is used */
 
 static const gchar *ntfs_defaults[] = { "uid=", "gid=", NULL };
-static const gchar *ntfs_allow[] = { "umask=", "dmask=", "fmask=", "locale=", "norecover", "ignore_case", "windows_names", "compression", "nocompression", "big_writes", NULL };
-static const gchar *ntfs_allow_uid_self[] = { "uid=", NULL };
-static const gchar *ntfs_allow_gid_self[] = { "gid=", NULL };
+static const gchar *ntfs_allow[] = { "umask", "dmask", "fmask", "locale", "norecover", "ignore_case", "windows_names", "compression", "nocompression", "big_writes", NULL };
+static const gchar *ntfs_allow_uid_self[] = { "uid", NULL };
+static const gchar *ntfs_allow_gid_self[] = { "gid", NULL };
 
 /* ---------------------- iso9660 -------------------- */
 
 static const gchar *iso9660_defaults[] = { "uid=", "gid=", "iocharset=utf8", "mode=0400", "dmode=0500", NULL };
-static const gchar *iso9660_allow[] = { "norock", "nojoliet", "iocharset=", "mode=", "dmode=", NULL };
-static const gchar *iso9660_allow_uid_self[] = { "uid=", NULL };
-static const gchar *iso9660_allow_gid_self[] = { "gid=", NULL };
+static const gchar *iso9660_allow[] = { "norock", "nojoliet", "iocharset", "mode", "dmode", NULL };
+static const gchar *iso9660_allow_uid_self[] = { "uid", NULL };
+static const gchar *iso9660_allow_gid_self[] = { "gid", NULL };
 
 /* ---------------------- udf -------------------- */
 
 static const gchar *udf_defaults[] = { "uid=", "gid=", "iocharset=utf8", NULL };
-static const gchar *udf_allow[] = { "iocharset=", "umask=", NULL };
-static const gchar *udf_allow_uid_self[] = { "uid=", NULL };
-static const gchar *udf_allow_gid_self[] = { "gid=", NULL };
+static const gchar *udf_allow[] = { "iocharset", "umask", NULL };
+static const gchar *udf_allow_uid_self[] = { "uid", NULL };
+static const gchar *udf_allow_gid_self[] = { "gid", NULL };
 
 /* ---------------------- exfat -------------------- */
 
 static const gchar *exfat_defaults[] = { "uid=", "gid=", "iocharset=utf8", "namecase=0", "errors=remount-ro", NULL };
-static const gchar *exfat_allow[] = { "dmask=", "errors=", "fmask=", "iocharset=", "namecase=", "umask=", NULL };
-static const gchar *exfat_allow_uid_self[] = { "uid=", NULL };
-static const gchar *exfat_allow_gid_self[] = { "gid=", NULL };
+static const gchar *exfat_allow[] = { "dmask", "errors", "fmask", "iocharset", "namecase", "umask", NULL };
+static const gchar *exfat_allow_uid_self[] = { "uid", NULL };
+static const gchar *exfat_allow_gid_self[] = { "gid", NULL };
 
 /* ---------------------- hfs+ -------------------- */
 
 static const gchar *hfsplus_defaults[] = { "uid=", "gid=", "nls=utf8", NULL };
-static const gchar *hfsplus_allow[] = { "creator=", "type=", "umask=", "session=", "part=", "decompose", "nodecompose", "force", "nls=", NULL };
-static const gchar *hfsplus_allow_uid_self[] = { "uid=", NULL };
-static const gchar *hfsplus_allow_gid_self[] = { "gid=", NULL };
+static const gchar *hfsplus_allow[] = { "creator", "type", "umask", "session", "part", "decompose", "nodecompose", "force", "nls", NULL };
+static const gchar *hfsplus_allow_uid_self[] = { "uid", NULL };
+static const gchar *hfsplus_allow_gid_self[] = { "gid", NULL };
 
 /* ------------------------------------------------ */
 /* TODO: support context= */
@@ -440,62 +440,30 @@ is_uid_in_gid (uid_t uid,
 static gboolean
 is_mount_option_allowed (const FSMountOptions *fsmo,
                          const gchar          *option,
+                         const gchar          *value,
                          uid_t                 caller_uid)
 {
   int n;
   gchar *endp;
   uid_t uid;
   gid_t gid;
-  gboolean allowed;
-  const gchar *ep;
-  gsize ep_len;
-
-  allowed = FALSE;
 
   /* first run through the allowed mount options */
   if (fsmo != NULL)
     {
       for (n = 0; fsmo->allow != NULL && fsmo->allow[n] != NULL; n++)
         {
-          ep = strstr (fsmo->allow[n], "=");
-          if (ep != NULL && ep[1] == '\0')
+          if (strcmp (fsmo->allow[n], option) == 0)
             {
-              ep_len = ep - fsmo->allow[n] + 1;
-              if (strncmp (fsmo->allow[n], option, ep_len) == 0)
-                {
-                  allowed = TRUE;
-                  goto out;
-                }
-            }
-          else
-            {
-              if (strcmp (fsmo->allow[n], option) == 0)
-                {
-                  allowed = TRUE;
-                  goto out;
-                }
+              return TRUE;
             }
         }
     }
   for (n = 0; any_allow[n] != NULL; n++)
     {
-      ep = strstr (any_allow[n], "=");
-      if (ep != NULL && ep[1] == '\0')
+      if (strcmp (any_allow[n], option) == 0)
         {
-          ep_len = ep - any_allow[n] + 1;
-          if (strncmp (any_allow[n], option, ep_len) == 0)
-            {
-              allowed = TRUE;
-              goto out;
-            }
-        }
-      else
-        {
-          if (strcmp (any_allow[n], option) == 0)
-            {
-              allowed = TRUE;
-              goto out;
-            }
+          return TRUE;
         }
     }
 
@@ -507,15 +475,14 @@ is_mount_option_allowed (const FSMountOptions *fsmo,
       for (n = 0; fsmo->allow_uid_self != NULL && fsmo->allow_uid_self[n] != NULL; n++)
         {
           const gchar *r_mount_option = fsmo->allow_uid_self[n];
-          if (g_str_has_prefix (option, r_mount_option))
+          if (g_strcmp0 (option, r_mount_option) == 0)
             {
-              uid = strtol (option + strlen (r_mount_option), &endp, 10);
+              uid = strtol (value, &endp, 10);
               if (*endp != '\0')
                 continue;
               if (uid == caller_uid)
                 {
-                  allowed = TRUE;
-                  goto out;
+                  return TRUE;
                 }
             }
         }
@@ -528,36 +495,35 @@ is_mount_option_allowed (const FSMountOptions *fsmo,
       for (n = 0; fsmo->allow_gid_self != NULL && fsmo->allow_gid_self[n] != NULL; n++)
         {
           const gchar *r_mount_option = fsmo->allow_gid_self[n];
-          if (g_str_has_prefix (option, r_mount_option))
+          if (g_strcmp0 (option, r_mount_option) == 0)
             {
-              gid = strtol (option + strlen (r_mount_option), &endp, 10);
+              gid = strtol (value, &endp, 10);
               if (*endp != '\0')
                 continue;
               if (is_uid_in_gid (caller_uid, gid))
                 {
-                  allowed = TRUE;
-                  goto out;
+                  return TRUE;
                 }
             }
         }
     }
 
- out:
-  return allowed;
+  return FALSE;
 }
 
-static gchar **
+static GHashTable *
 prepend_default_mount_options (const FSMountOptions *fsmo,
                                uid_t                 caller_uid,
                                GVariant             *given_options)
 {
-  GPtrArray *options;
+  GHashTable *options;
   gint n;
   gchar *s;
   gid_t gid;
   const gchar *option_string;
 
-  options = g_ptr_array_new ();
+  options = g_hash_table_new_full (g_str_hash, g_str_equal,
+                                   g_free, g_free);
   if (fsmo != NULL)
     {
       const gchar *const *defaults = fsmo->defaults;
@@ -565,25 +531,33 @@ prepend_default_mount_options (const FSMountOptions *fsmo,
       for (n = 0; defaults != NULL && defaults[n] != NULL; n++)
         {
           const gchar *option = defaults[n];
+          const gchar *eq = strchr (option, '=');
 
-          if (strcmp (option, "uid=") == 0)
+          if (eq != NULL)
             {
-              s = g_strdup_printf ("uid=%u", caller_uid);
-              g_ptr_array_add (options, s);
-            }
-          else if (strcmp (option, "gid=") == 0)
-            {
-              gid = find_primary_gid (caller_uid);
-              if (gid != (gid_t) - 1)
+              const gchar *value = eq + 1;
+              gsize opt_len = eq - option;
+              if (strncmp (option, "uid", opt_len) == 0)
                 {
-                  s = g_strdup_printf ("gid=%u", gid);
-                  g_ptr_array_add (options, s);
+                  s = g_strdup_printf ("%u", caller_uid);
+                  g_hash_table_insert (options, g_strdup ("uid"), s);
+                }
+              else if (strncmp (option, "gid", opt_len) == 0)
+                {
+                  gid = find_primary_gid (caller_uid);
+                  if (gid != (gid_t) - 1)
+                    {
+                      s = g_strdup_printf ("%u", gid);
+                      g_hash_table_insert (options, g_strdup ("gid"), s);
+                    }
+                }
+              else
+                {
+                  g_hash_table_insert (options, g_strndup (option, opt_len), g_strdup (value));
                 }
             }
           else
-            {
-              g_ptr_array_add (options, g_strdup (option));
-            }
+            g_hash_table_insert (options, g_strdup (option), NULL);
         }
     }
 
@@ -594,12 +568,24 @@ prepend_default_mount_options (const FSMountOptions *fsmo,
       gchar **split_option_string;
       split_option_string = g_strsplit (option_string, ",", -1);
       for (n = 0; split_option_string[n] != NULL; n++)
-        g_ptr_array_add (options, split_option_string[n]); /* steals string */
+        {
+          gchar *option = split_option_string[n];
+          const gchar *eq = strchr (option, '=');
+
+          if (eq != NULL)
+            {
+              const gchar *value = eq + 1;
+              gsize opt_len = eq - option;
+              g_hash_table_insert (options, g_strndup (option, opt_len), g_strdup (value));
+              g_free (option);
+            }
+          else
+            g_hash_table_insert (options, option, NULL); /* steals 'option' */
+        }
       g_free (split_option_string);
     }
-  g_ptr_array_add (options, NULL);
 
-  return (char **) g_ptr_array_free (options, FALSE);
+  return options;
 }
 
 /* ---------------------------------------------------------------------------------------------------- */
@@ -704,12 +690,12 @@ calculate_mount_options (UDisksDaemon  *daemon,
                          GError       **error)
 {
   const FSMountOptions *fsmo;
-  gchar **options_to_use;
+  GHashTable *options_to_use = NULL;
+  GHashTableIter iter;
   gchar *options_to_use_str;
+  gchar *key, *value;
   GString *str;
-  guint n;
 
-  options_to_use = NULL;
   options_to_use_str = NULL;
 
   fsmo = find_mount_options_for_fs (fs_type);
@@ -721,41 +707,54 @@ calculate_mount_options (UDisksDaemon  *daemon,
 
   /* validate mount options */
   str = g_string_new ("uhelper=udisks2,nodev,nosuid");
-  for (n = 0; options_to_use[n] != NULL; n++)
+  g_hash_table_iter_init (&iter, options_to_use);
+  while (g_hash_table_iter_next (&iter, (gpointer*) &key, (gpointer*) &value))
     {
-      const gchar *option = options_to_use[n];
-
       /* avoid attacks like passing "shortname=lower,uid=0" as a single mount option */
-      if (strstr (option, ",") != NULL)
+      if (strstr (key, ",") != NULL)
         {
           g_set_error (error,
                        UDISKS_ERROR,
                        UDISKS_ERROR_OPTION_NOT_PERMITTED,
                        "Malformed mount option `%s'",
-                       option);
+                       key);
           g_string_free (str, TRUE);
           goto out;
         }
 
       /* first check if the mount option is allowed */
-      if (!is_mount_option_allowed (fsmo, option, caller_uid))
+      if (!is_mount_option_allowed (fsmo, key, value, caller_uid))
         {
-          g_set_error (error,
-                       UDISKS_ERROR,
-                       UDISKS_ERROR_OPTION_NOT_PERMITTED,
-                       "Mount option `%s' is not allowed",
-                       option);
+          if (value == NULL)
+            {
+              g_set_error (error,
+                           UDISKS_ERROR,
+                           UDISKS_ERROR_OPTION_NOT_PERMITTED,
+                           "Mount option `%s' is not allowed",
+                           key);
+            }
+          else
+            {
+              g_set_error (error,
+                           UDISKS_ERROR,
+                           UDISKS_ERROR_OPTION_NOT_PERMITTED,
+                           "Mount option `%s=%s' is not allowed",
+                           key, value);
+            }
           g_string_free (str, TRUE);
           goto out;
         }
 
       g_string_append_c (str, ',');
-      g_string_append (str, option);
+      if (value == NULL)
+        g_string_append (str, key);
+      else
+        g_string_append_printf (str, "%s=%s", key, value);
     }
   options_to_use_str = g_string_free (str, FALSE);
 
  out:
-  g_strfreev (options_to_use);
+  g_hash_table_destroy (options_to_use);
 
   g_assert (options_to_use_str == NULL || g_utf8_validate (options_to_use_str, -1, NULL));
 


### PR DESCRIPTION
The first patch is just a cosmetic change. The second patch makes sure the same mount option is not specified multiple times which could lead to hard-to-define/undefined results (which value wins?). By using defaults first and then possibly overriding them with user-specified values, we make sure the latter win.

The third patch implements what has been requested in #413 -- using better values for ``mode`` and ``dmode`` mount options if a file system using these is mounted at a shared location. Please see the commit for details.