### PR TITLE
Only check mount point prefix in the iso9660 tests

### DIFF
--- a/src/tests/dbus-tests/test_80_filesystem.py
+++ b/src/tests/dbus-tests/test_80_filesystem.py
@@ -825,7 +825,7 @@ class UdisksISO9660TestCase(udiskstestcase.UdisksTestCase):
         dbus_mounts = self.get_property(disk, '.Filesystem', 'MountPoints')
         dbus_mounts.assertLen(1)  # just one mountpoint
         mnt = self.ay_to_str(dbus_mounts.value[0])
-        self.assertEqual(mnt.split("/")[-1], "TEST_iso9660")
+        self.assertStartswith(mnt.split("/")[-1], "TEST_iso9660")
         self.assertTrue(os.path.ismount(mnt))
 
         # default modes should be used
@@ -863,7 +863,7 @@ class UdisksISO9660TestCase(udiskstestcase.UdisksTestCase):
         dbus_mounts = self.get_property(disk, '.Filesystem', 'MountPoints')
         dbus_mounts.assertLen(1)  # just one mountpoint
         mnt = self.ay_to_str(dbus_mounts.value[0])
-        self.assertEqual(mnt.split("/")[-1], "TEST_iso9660")
+        self.assertStartswith(mnt.split("/")[-1], "TEST_iso9660")
         self.assertTrue(os.path.ismount(mnt))
 
         # specified modes should be used
@@ -900,7 +900,7 @@ class UdisksISO9660TestCase(udiskstestcase.UdisksTestCase):
         dbus_mounts = self.get_property(disk, '.Filesystem', 'MountPoints')
         dbus_mounts.assertLen(1)  # just one mountpoint
         mnt = self.ay_to_str(dbus_mounts.value[0])
-        self.assertEqual(mnt.split("/")[-1], "TEST_iso9660")
+        self.assertStartswith(mnt.split("/")[-1], "TEST_iso9660")
         self.assertTrue(os.path.ismount(mnt))
 
         # modes for shared mounts should be used
@@ -940,7 +940,7 @@ class UdisksISO9660TestCase(udiskstestcase.UdisksTestCase):
         dbus_mounts = self.get_property(disk, '.Filesystem', 'MountPoints')
         dbus_mounts.assertLen(1)  # just one mountpoint
         mnt = self.ay_to_str(dbus_mounts.value[0])
-        self.assertEqual(mnt.split("/")[-1], "TEST_iso9660")
+        self.assertStartswith(mnt.split("/")[-1], "TEST_iso9660")
         self.assertTrue(os.path.ismount(mnt))
 
         # the specified modes should be used even for a shared mount

--- a/src/tests/dbus-tests/udiskstestcase.py
+++ b/src/tests/dbus-tests/udiskstestcase.py
@@ -426,6 +426,10 @@ class UdisksTestCase(unittest.TestCase):
 
         raise AssertionError("Object '%s' has no interface '%s'" % (obj.object_path, iface))
 
+    def assertStartswith(self, val, prefix):
+        if not val.startswith(prefix):
+            raise AssertionError("'%s' does not start with '%s'" % (val, prefix))
+
 
 class FlightRecorder(object):
     """Context manager for recording data/logs


### PR DESCRIPTION
The mount point cleanup is done asynchronously so there's no
guarantee that the mount point from the previous test is going to
be cleaned up when some test is running. And if not, a new one
with a number suffix will be created. Which is totally fine and
expected, but we need to take that into account in the checks.