### PR TITLE
Skip PolicyKit integration tests on Fedora 26

### DIFF
--- a/src/tests/integration-test
+++ b/src/tests/integration-test
@@ -82,6 +82,19 @@ BROKEN_PERMISSIONS_FS = ['ntfs', 'exfat']
 
 no_options = GLib.Variant('a{sv}', {})
 
+def get_distro_version():
+    # 3rd to 6th fields from e.g. "CPE OS Name: cpe:/o:fedoraproject:fedora:27" or "CPE OS Name: cpe:/o:centos:centos:7"
+    out = subprocess.check_output('hostnamectl status | grep "CPE OS Name"', shell=True).decode().strip()
+    try:
+        _project, distro, version = tuple(out.split(":")[3:6])
+    except ValueError:
+        print('Failed to get distribution and version from "%s". Aborting.' % out)
+        sys.exit(1)
+
+    return (distro, version)
+
+DISTRO_VER = get_distro_version()
+
 
 # ----------------------------------------------------------------------------
 
@@ -1605,6 +1618,12 @@ signal.signal(signal.SIGALRM, handler)
 
 class Polkit(UDisksTestCase, test_polkitd.PolkitTestCase):
     """Check operation with polkit."""
+
+    def setUp(self):
+        if DISTRO_VER == ("fedora", "26"):
+            self.skipTest("Skipping hanging PolicyKit tests on Fedora 26")
+
+        UDisksTestCase.setUp(self)
 
     def test_internal_fs_forbidden(self):
         """Create FS on internal drive (forbidden)"""


### PR DESCRIPTION
For some reason the tests quite often end up just hanging in some
uninterrupted state on Fedora 26.