### PR TITLE
lvm2: Don't match prefixes in cmp_int_lv_name

### DIFF
--- a/modules/lvm2/udiskslinuxvolumegroupobject.c
+++ b/modules/lvm2/udiskslinuxvolumegroupobject.c
@@ -530,7 +530,7 @@ cmp_int_lv_name (const gchar *int_lv_name, const gchar *lv_name)
 
   if (*c == ']')
     c++;
-  if (*c == '\0')
+  if (*c == '\0' && lv_name[c - int_lv_name] == '\0')
     return TRUE;
 
   return FALSE;


### PR DESCRIPTION
Once the whole internal name has matched, the other name must also be
at the end.  Otherwise we might find "lvol0" when looking for
"lvol0_meta", for example.

The symptom is that the size of a pool is reported as twice its data
size, instead of data plus metadata size, which funnily is exactly the
same symptom fixed by 043edcb.  Deja vu...