### PR TITLE
core: Add o.fd.U.Filesystem.Size property

### DIFF
--- a/data/org.freedesktop.UDisks2.xml
+++ b/data/org.freedesktop.UDisks2.xml
@@ -1886,6 +1886,15 @@
       <arg name="options" direction="in" type="a{sv}"/>
     </method>
 
+    <!-- Size: The size of the filesystem.  This is the amount of
+         bytes used on the block device.  If this is smaller than
+         org.freedesktop.Udisks2.Block.Size, then the filesystem can
+         be made larger with Resize.
+
+         If the size is unknown, the property is zero.
+    -->
+    <property name="Size" type="t" access="read"/>
+
     <!--
         Resize:
         @size: The target size in bytes, 0 for maximum.


### PR DESCRIPTION
This allows the client to detect filesystems that could be resized to
fill more of their block device.