### PR TITLE
core: Add o.fd.U.Encrypted.MetadataSize property

### DIFF
--- a/data/org.freedesktop.UDisks2.xml
+++ b/data/org.freedesktop.UDisks2.xml
@@ -2014,6 +2014,13 @@
     -->
     <property name="ChildConfiguration" type="a(sa{sv})" access="read"/>
 
+    <!-- MetadataSize: The amount of space needed by the encryption header.
+         The size of the cleartext device will ususally be org.freedesktop.UDisks2.Block.Size -
+         org.freedesktop.UDisks2.Encrypted.MetadataSize, unless either the block device or the
+         cleartext device have been resized.
+    -->
+    <property name="MetadataSize" type="t" access="read"/>
+
     <!--
         Unlock:
         @passphrase: The passphrase to use.

--- a/src/tests/dbus-tests/test_70_encrypted.py
+++ b/src/tests/dbus-tests/test_70_encrypted.py
@@ -48,6 +48,9 @@ class UdisksEncryptedTest(udiskstestcase.UdisksTestCase):
         device = self.get_property(disk, '.Block', 'Device')
         device.assertEqual(self.str_to_ay(self.vdevs[0]))  # device is an array of byte
 
+        metadata_size = self.get_property(disk, '.Encrypted', 'MetadataSize')
+        metadata_size.assertEqual(2*1024*1024)
+
         # check system values
         _ret, sys_type = self.run_command('lsblk -d -no FSTYPE %s' % self.vdevs[0])
         self.assertEqual(sys_type, 'crypto_LUKS')

--- a/src/udiskslinuxencrypted.c
+++ b/src/udiskslinuxencrypted.c
@@ -129,6 +129,11 @@ void
 udisks_linux_encrypted_update (UDisksLinuxEncrypted   *encrypted,
                                UDisksLinuxBlockObject *object)
 {
+  // XXX - Right now, all objects with the Encrypted interface are
+  // LUKS, but when this changes, this code needs to be updated
+  // accordingly.
+  udisks_encrypted_set_metadata_size (UDISKS_ENCRYPTED (encrypted), BD_CRYPTO_LUKS_METADATA_SIZE);
+
   update_child_configuration (encrypted, object);
 }
 


### PR DESCRIPTION
This allows the client to detect crypto devices that could be resized
to fill more of their block device.