### PR TITLE
Stop skipping tests that use SCSI debug devices on CentOS 7

### DIFF
--- a/src/tests/dbus-tests/test_40_drive.py
+++ b/src/tests/dbus-tests/test_40_drive.py
@@ -46,7 +46,6 @@ class UdisksDriveTest(udiskstestcase.UdisksTestCase):
             self.udev_settle()
             self.run_command('modprobe -r scsi_debug')
 
-    @udiskstestcase.skip_on(("centos", "enterprise_linux"), reason="SCSI debug bug causing kernel panic on CentOS/RHEL 7")
     def test_10_eject(self):
         ''' Test of Drive.Eject method '''
 
@@ -60,7 +59,6 @@ class UdisksDriveTest(udiskstestcase.UdisksTestCase):
         drive = self.get_drive(dev)
         drive.Eject(self.no_options)
 
-    @udiskstestcase.skip_on(("centos", "enterprise_linux"), reason="SCSI debug bug causing kernel panic on CentOS/RHEL 7")
     def test_20_poweroff(self):
         ''' Test of Drive.PowerOff method '''
         for dev in (self.vdevs[0], self.cd_dev):
@@ -73,7 +71,6 @@ class UdisksDriveTest(udiskstestcase.UdisksTestCase):
                                        'Failed: No usb device'):
                 drive.PowerOff(self.no_options)
 
-    @udiskstestcase.skip_on(("centos", "enterprise_linux"), reason="SCSI debug bug causing kernel panic on CentOS/RHEL 7")
     def test_30_setconfiguration(self):
         ''' Test of Drive.SetConfiguration method '''
         # set configuration value to some improbable value
@@ -84,7 +81,6 @@ class UdisksDriveTest(udiskstestcase.UdisksTestCase):
         conf_value.assertIsNotNone()
         self.assertEqual(str(conf_value.value['ata-pm-standby']), '286')
 
-    @udiskstestcase.skip_on(("centos", "enterprise_linux"), reason="SCSI debug bug causing kernel panic on CentOS/RHEL 7")
     def test_40_properties(self):
         ''' Test of Drive properties values '''
 

--- a/src/tests/dbus-tests/test_40_drive.py
+++ b/src/tests/dbus-tests/test_40_drive.py
@@ -91,7 +91,7 @@ class UdisksDriveTest(udiskstestcase.UdisksTestCase):
         def read_sys_file(value):
             return self.read_file(os.path.join(sys_dir, value)).strip()
 
-        serial = read_sys_file('wwid').rsplit(None, 1)[-1]  # get the last word in the file
+        serial = self.get_udev_property(self.cd_dev, 'ID_SCSI_SERIAL')
         ret_code, wwn = self.run_command('lsblk -d -no WWN %s' % self.cd_dev)
         self.assertEqual(ret_code, 0)
 

--- a/src/tests/dbus-tests/udiskstestcase.py
+++ b/src/tests/dbus-tests/udiskstestcase.py
@@ -415,6 +415,12 @@ class UdisksTestCase(unittest.TestCase):
         self.run_command("udevadm control --reload")
 
     @classmethod
+    def get_udev_property(self, device, prop):
+        udev = GUdev.Client()
+        dev = udev.query_by_device_file(device)
+        return dev.get_property(prop)
+
+    @classmethod
     def assertHasIface(self, obj, iface):
         obj_intro = dbus.Interface(obj, "org.freedesktop.DBus.Introspectable")
         intro_data = obj_intro.Introspect()


### PR DESCRIPTION
The bug causing kernel panics is already fixed.