### PR TITLE
integration-test: Wait longer after the scsi debug CD format

### DIFF
--- a/src/tests/integration-test
+++ b/src/tests/integration-test
@@ -1032,6 +1032,7 @@ class FS(UDisksTestCase):
             subprocess.call(['udevadm', 'trigger', '--action=change',
                              '--sysname-match=' + os.path.basename(self.cd_device)])
             self.sync()
+            time.sleep(5)
             self.sync()
             cd_fs = self.udisks_filesystem(cd=True)
 


### PR DESCRIPTION
Try give udisks more time to recognize new filesystem on the CD
after the scsi debug device format change.

----
This should fix failing tests on CentOS 7. Running `udev settle` twice is apparently not enough after triggering the udev change event for the CD.