### PR TITLE
Fix directory we use for temporary mounts

### DIFF
--- a/src/udiskslinuxfilesystemhelpers.c
+++ b/src/udiskslinuxfilesystemhelpers.c
@@ -105,7 +105,7 @@ gboolean take_filesystem_ownership (const gchar *device,
       else
         {
           /* device is not mounted, we need to mount it */
-          mountpoint = g_mkdtemp (g_strdup (PACKAGE_LOCALSTATE_DIR "/run/udisks2/temp-mount-XXXXXX"));
+          mountpoint = g_mkdtemp (g_strdup ("/run/udisks2/temp-mount-XXXXXX"));
           if (mountpoint == NULL)
             {
               g_set_error (error, UDISKS_ERROR, UDISKS_ERROR_FAILED,


### PR DESCRIPTION
We create only "/run/udisks2" directory without the localstate
directory prefix, so we shouldn't use it.

Fixes #504 