### PR TITLE
Fix _udisks_state_has_loop_list_visitor()

### DIFF
--- a/src/udisksstate.c
+++ b/src/udisksstate.c
@@ -1760,6 +1760,7 @@ _udisks_state_has_loop_list_visitor (GVariant *child, gpointer compare_data,
             {
               *out_uid = g_variant_get_uint32 (lookup_value);
               g_variant_unref (lookup_value);
+              ret = TRUE;
             }
         }
     }


### PR DESCRIPTION
It needs to return TRUE if the conditions are met.

Thanks F-i-f at GitHub for reporting this and providing a patch!

Fixes: GH-519