### PR TITLE
Register system inhibitor for all jobs

### DIFF
--- a/src/udiskslinuxblock.c
+++ b/src/udiskslinuxblock.c
@@ -2789,7 +2789,6 @@ udisks_linux_block_handle_format (UDisksBlock             *block,
   const gchar *label = NULL;
   gchar *device_name = NULL;
   gboolean was_partitioned = FALSE;
-  UDisksInhibitCookie *inhibit_cookie = NULL;
   gboolean no_block = FALSE;
   gboolean update_partition_type = FALSE;
   gboolean dry_run_first = FALSE;
@@ -2933,8 +2932,6 @@ udisks_linux_block_handle_format (UDisksBlock             *block,
                                                     N_("Authentication is required to modify the system configuration"),
                                                     invocation))
     goto out;
-
-  inhibit_cookie = udisks_daemon_util_inhibit_system_sync (N_("Formatting Device"));
 
   was_partitioned = (udisks_object_peek_partition_table (object) != NULL);
 
@@ -3285,7 +3282,6 @@ udisks_linux_block_handle_format (UDisksBlock             *block,
     complete (complete_user_data);
 
  out:
-  udisks_daemon_util_uninhibit_system_sync (inhibit_cookie);
   g_free (device_name);
   g_free (mapped_name);
   g_free (command);

--- a/src/udiskslinuxdriveata.c
+++ b/src/udiskslinuxdriveata.c
@@ -2201,7 +2201,6 @@ handle_security_erase_unit (UDisksDriveAta        *_drive,
   uid_t caller_uid;
   gid_t caller_gid;
   gboolean enhanced = FALSE;
-  UDisksInhibitCookie *inhibit_cookie = NULL;
 
   object = udisks_daemon_util_dup_object (drive, &error);
   if (object == NULL)
@@ -2256,8 +2255,6 @@ handle_security_erase_unit (UDisksDriveAta        *_drive,
                                                     invocation))
     goto out;
 
-  inhibit_cookie = udisks_daemon_util_inhibit_system_sync (N_("Formatting Device"));
-
   if (!udisks_linux_drive_ata_secure_erase_sync (drive, caller_uid, enhanced, &error))
     {
       g_dbus_method_invocation_return_gerror (invocation, error);
@@ -2267,10 +2264,7 @@ handle_security_erase_unit (UDisksDriveAta        *_drive,
 
   udisks_linux_block_object_reread_partition_table (UDISKS_LINUX_BLOCK_OBJECT (block_object));
 
-  udisks_drive_ata_complete_security_erase_unit (_drive, invocation);
-
  out:
-  udisks_daemon_util_uninhibit_system_sync (inhibit_cookie);
   g_clear_object (&block_object);
   g_clear_object (&object);
   return TRUE; /* returning TRUE means that we handled the method invocation */

--- a/udisks/udisksclient.c
+++ b/udisks/udisksclient.c
@@ -2459,29 +2459,24 @@ udisks_client_get_partition_type_and_subtype_for_display (UDisksClient  *client,
 /* ---------------------------------------------------------------------------------------------------- */
 
 /**
- * udisks_client_get_job_description:
- * @client: A #UDisksClient.
- * @job: A #UDisksJob.
+ * udisks_client_get_job_description_from_operation:
+ * @operation: A job operation name.
  *
- * Gets a human-readable and localized text string describing the
- * operation of @job.
+ * Gets a human-readable and localized text string describing a
+ * a job @operation.
  *
- * For known job types, see the documentation for the
+ * For known job operation types, see the documentation for the
  * <link linkend="gdbus-property-org-freedesktop-UDisks2-Job.Operation">Job:Operation</link>
  * D-Bus property.
  *
  * Returns: A string that should be freed with g_free().
  */
 gchar *
-udisks_client_get_job_description (UDisksClient   *client,
-                                   UDisksJob      *job)
+udisks_client_get_job_description_from_operation (const gchar *operation)
 {
   static gsize once = 0;
   static GHashTable *hash = NULL;
-  const gchar *operation = NULL;
   gchar *ret = NULL;
-
-  g_return_val_if_fail (UDISKS_IS_CLIENT (client), NULL);
 
   if (g_once_init_enter (&once))
     {
@@ -2519,13 +2514,35 @@ udisks_client_get_job_description (UDisksClient   *client,
       g_once_init_leave (&once, (gsize) 1);
     }
 
-  operation = udisks_job_get_operation (job);
   if (operation != NULL)
     ret = g_strdup (g_hash_table_lookup (hash, operation));
   if (ret == NULL)
-    ret = g_strdup_printf (C_("unknown-job", "Unknown (%s)"), udisks_job_get_operation (job));
+    ret = g_strdup_printf (C_("unknown-job", "Unknown (%s)"), operation == NULL ? "(null)" : operation);
 
   return ret;
+}
+
+/**
+ * udisks_client_get_job_description:
+ * @client: A #UDisksClient.
+ * @job: A #UDisksJob.
+ *
+ * Gets a human-readable and localized text string describing the
+ * operation of @job.
+ *
+ * For known job types, see the documentation for the
+ * <link linkend="gdbus-property-org-freedesktop-UDisks2-Job.Operation">Job:Operation</link>
+ * D-Bus property.
+ *
+ * Returns: A string that should be freed with g_free().
+ */
+gchar *
+udisks_client_get_job_description (UDisksClient   *client,
+                                   UDisksJob      *job)
+{
+  g_return_val_if_fail (UDISKS_IS_CLIENT (client), NULL);
+
+  return udisks_client_get_job_description_from_operation (udisks_job_get_operation (job));
 }
 
 /* ---------------------------------------------------------------------------------------------------- */

--- a/udisks/udisksclient.h
+++ b/udisks/udisksclient.h
@@ -150,6 +150,8 @@ const gchar        *udisks_client_get_partition_table_subtype_for_display (UDisk
                                                                            const gchar   *partition_table_type,
                                                                            const gchar   *partition_table_subtype);
 
+gchar *udisks_client_get_job_description_from_operation (const gchar *operation);
+
 gchar *udisks_client_get_job_description (UDisksClient   *client,
                                           UDisksJob      *job);
 


### PR DESCRIPTION
Fixes https://github.com/storaged-project/udisks/issues/516

Only the format and secure erase jobs were
covered with a systemd logind inhibitor
to prevent automatic or user-triggered suspend.

Move the inhibitor management to the job construction
and deconstruction code.