### PR TITLE
tests: Pass absolute path to targetcli_config.json

### DIFF
--- a/src/tests/integration-test
+++ b/src/tests/integration-test
@@ -1710,9 +1710,12 @@ def setup_lio():
                  re.match(r'sd[a-z]+$', dev)}
 
     # create fake SCSI hard drives
+    our_path = os.path.abspath(__file__)
+    our_dir = os.path.dirname(our_path)
+    json_path = os.path.join(our_dir, 'dbus-tests', 'targetcli_config.json')
     assert subprocess.call(
         ["targetcli",
-         "restoreconfig dbus-tests/targetcli_config.json"]) == 0
+         "restoreconfig %s" % json_path]) == 0
     time.sleep(0.1)
 
     devs = {dev for dev in os.listdir("/dev") if


### PR DESCRIPTION
If the integration tests are run from a different directory, we will
fail to find targetcli_config.json with an error like

```
======================================================================
ERROR: setUpClass (__main__.MDRaid)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "src/tests/integration-test", line 1795, in setUpClass
    cls.devices = setup_lio()
  File "src/tests/integration-test", line 1725, in setup_lio
    assert len(vdevs) >= 4
AssertionError
```

let's calculate the absolute path relative to the integration-test
executable itself.

The problem was initially debugged and fixed in Ubuntu by Sebastien
Bacher (@seb128), with many thanks.