### PR TITLE
Set Job Progress property for FS check, repair, resize

### DIFF
--- a/src/udisksdaemon.h
+++ b/src/udisksdaemon.h
@@ -173,6 +173,9 @@ gboolean                 udisks_daemon_launch_threaded_job_sync (UDisksDaemon   
                                                                  GCancellable          *cancellable,
                                                                  GError               **error);
 
+void                     udisks_bd_thread_set_progress_for_job  (UDisksJob             *job);
+void                     udisks_bd_thread_disable_progress      (void);
+
 /* Return value and *uuid_ret must be freed with g_free.  If return
    value is NULL, *uuid has not been changed.
  */

--- a/src/udiskslinuxfilesystem.c
+++ b/src/udiskslinuxfilesystem.c
@@ -2248,7 +2248,7 @@ handle_resize (UDisksFilesystem      *filesystem,
       goto out;
     }
 
-  /* TODO: implement progress parsing for udisks_job_set_progress(_valid) */
+  udisks_bd_thread_set_progress_for_job (UDISKS_JOB (job));
   if (! bd_fs_resize (udisks_block_get_device (block), size, &error))
     {
       g_dbus_method_invocation_return_error (invocation,
@@ -2265,6 +2265,7 @@ handle_resize (UDisksFilesystem      *filesystem,
   udisks_simple_job_complete (UDISKS_SIMPLE_JOB (job), TRUE, NULL);
 
  out:
+  udisks_bd_thread_disable_progress ();
   g_clear_object (&object);
   g_free (required_utility);
   g_clear_error (&error);
@@ -2406,7 +2407,7 @@ handle_repair (UDisksFilesystem      *filesystem,
       goto out;
     }
 
-  /* TODO: implement progress parsing for udisks_job_set_progress(_valid) */
+  udisks_bd_thread_set_progress_for_job (UDISKS_JOB (job));
   ret = bd_fs_repair (udisks_block_get_device (block), &error);
   if (error)
     {
@@ -2424,6 +2425,7 @@ handle_repair (UDisksFilesystem      *filesystem,
   udisks_simple_job_complete (UDISKS_SIMPLE_JOB (job), TRUE, NULL);
 
  out:
+  udisks_bd_thread_disable_progress ();
   g_clear_object (&object);
   g_free (required_utility);
   g_clear_error (&error);
@@ -2565,7 +2567,7 @@ handle_check (UDisksFilesystem      *filesystem,
       goto out;
     }
 
-  /* TODO: implement progress parsing for udisks_job_set_progress(_valid) */
+  udisks_bd_thread_set_progress_for_job (UDISKS_JOB (job));
   ret = bd_fs_check (udisks_block_get_device (block), &error);
   if (error)
     {
@@ -2583,6 +2585,7 @@ handle_check (UDisksFilesystem      *filesystem,
   udisks_simple_job_complete (UDISKS_SIMPLE_JOB (job), TRUE, NULL);
 
  out:
+  udisks_bd_thread_disable_progress ();
   g_clear_object (&object);
   g_free (required_utility);
   g_clear_error (&error);


### PR DESCRIPTION
If the libblockdev functions for FS check, repair or
resize support progress reporting, the Progress
property of a UDisksJob is set up and updated on
each report of the progress function.
The current job which is to be updated is managed
per thread and the progress function is also only
set up in libblockdev for the current thread.
The local progress report spans only the invokation
of the single libblockdev operation that the DBus
method handler calls in its dedicated thread.

Requires merging of https://github.com/storaged-project/libblockdev/pull/353