### PR TITLE
Add Apple APFS gpt partition type

### DIFF
--- a/udisks/udisksclient.c
+++ b/udisks/udisksclient.c
@@ -2235,6 +2235,7 @@ static const struct
   {"gpt", "microsoft", "de94bba4-06d1-4d40-a16a-bfd50179d6ac", NC_("part-type", "Microsoft Windows Recovery Environment"), 0},
   /* Apple OS X */
   {"gpt", "apple",     "48465300-0000-11aa-aa11-00306543ecac", NC_("part-type", "Apple HFS/HFS+"), 0},
+  {"gpt", "apple",     "7c3457ef-0000-11aa-aa11-00306543ecac", NC_("part-type", "Apple APFS"), 0},
   {"gpt", "apple",     "55465300-0000-11aa-aa11-00306543ecac", NC_("part-type", "Apple UFS"), 0},
   {"gpt", "apple",     "6a898cc3-1dd2-11b2-99a6-080020736631", NC_("part-type", "Apple ZFS"), 0}, /* same as ZFS */
   {"gpt", "apple",     "52414944-0000-11aa-aa11-00306543ecac", NC_("part-type", "Apple RAID"), F_RAID},


### PR DESCRIPTION
This adds the partition type (confirmed on Macbook Pro with Fedora 28 here) for Apple APFS partitions. It does not add any way to get the filesystem type though. I am not sure how to do that, or even if it is possible without adding APFS support to the kernel. I am not sure if there is an example of a filesystem that it would be useful to get information on but which is currently unsupported.

If there is anything I can do to add the apfs filesystem identification too then please point me in the direction. 'file' does support the magic at the beginning of the partition so it should be possible.