### PR TITLE
 Return from 'vg_task_func' if 'bd_lvm_vgs' failed

### DIFF
--- a/modules/lvm2/jobhelpers.c
+++ b/modules/lvm2/jobhelpers.c
@@ -283,8 +283,11 @@ void vgs_task_func (GTask        *task,
   VGsPVsData *ret = g_new0 (VGsPVsData, 1);
 
   ret->vgs = bd_lvm_vgs (&error);
-  if (!ret->vgs)
+  if (!ret->vgs) {
+    vgs_pvs_data_free (ret);
     g_task_return_error (task, error);
+    return;
+  }
 
   ret->pvs = bd_lvm_pvs (&error);
   if (!ret->pvs) {

--- a/modules/lvm2/udiskslinuxvolumegroupobject.c
+++ b/modules/lvm2/udiskslinuxvolumegroupobject.c
@@ -568,6 +568,7 @@ update_vg (GObject      *source_obj,
           udisks_warning ("Failed to update LVM volume group %s: %s",
                           udisks_linux_volume_group_object_get_name (object),
                           error->message);
+          g_clear_error (&error);
         }
       else
         {
@@ -715,9 +716,12 @@ poll_vg_update (GObject      *source_obj,
   if (!lvs)
     {
       if (error)
-        udisks_warning ("Failed to poll LVM volume group %s: %s",
-                        udisks_linux_volume_group_object_get_name (object),
-                        error->message);
+        {
+          udisks_warning ("Failed to poll LVM volume group %s: %s",
+                          udisks_linux_volume_group_object_get_name (object),
+                          error->message);
+          g_clear_error (&error);
+        }
       else
         /* this should never happen */
         udisks_warning ("Failed to poll LVM volume group %s: no error reported",

--- a/modules/lvm2/udiskslvm2moduleiface.c
+++ b/modules/lvm2/udiskslvm2moduleiface.c
@@ -150,7 +150,10 @@ lvm_update_vgs (GObject      *source_obj,
   if (!data)
     {
       if (error)
-        udisks_warning ("LVM2 plugin: %s", error->message);
+        {
+          udisks_warning ("LVM2 plugin: %s", error->message);
+          g_clear_error (&error);
+        }
       else
         /* this should never happen */
         udisks_warning ("LVM2 plugin: failure but no error when getting VGs!");


### PR DESCRIPTION
Two small fixes for LVM plugin. I discovered the problem when both `bd_lvm_vgs` and `bd_lvm_pvs` failed and because both functions use the same GError udisks complained about overwriting it.

```
GError set over the top of a previous GError or uninitialized memory.
This indicates a bug in someone's code. You must ensure an error is NULL before it's set.
The overwriting error message was: Failed to fork (Cannot allocate memory)
```

We also use only the message from these errors in a warning, so we need to clear the error too.