### PR TITLE
Add a property with the cleartext device path for unlockdev LUKS

### DIFF
--- a/data/org.freedesktop.UDisks2.xml
+++ b/data/org.freedesktop.UDisks2.xml
@@ -2040,6 +2040,11 @@
     -->
     <property name="MetadataSize" type="t" access="read"/>
 
+    <!-- CleartextDevice:
+         For an unlocked device, the object path of its cleartext device.
+    -->
+    <property name="CleartextDevice" type="o" access="read"/>
+
     <!--
         Unlock:
         @passphrase: The passphrase to use.

--- a/src/tests/dbus-tests/test_70_encrypted.py
+++ b/src/tests/dbus-tests/test_70_encrypted.py
@@ -117,8 +117,14 @@ class UdisksEncryptedTest(udiskstestcase.UdisksTestCase):
         _ret, luks_uuid = self.run_command('lsblk -d -no UUID /dev/%s' % dm_name)
         self.assertTrue(os.path.exists('/dev/disk/by-uuid/%s' % luks_uuid))
 
+        dbus_cleartext = self.get_property(disk, '.Encrypted', 'CleartextDevice')
+        dbus_cleartext.assertEqual(self.path_prefix +'/block_devices/' + obj_name)
+
         disk.Lock(self.no_options, dbus_interface=self.iface_prefix + '.Encrypted')
         self.assertFalse(os.path.exists('/dev/disk/by-uuid/%s' % luks_uuid))
+
+        dbus_cleartext = self.get_property(disk, '.Encrypted', 'CleartextDevice')
+        dbus_cleartext.assertEqual('/')
 
         # check that luks device disappears after lock
         udisks = self.get_object('')
@@ -142,6 +148,9 @@ class UdisksEncryptedTest(udiskstestcase.UdisksTestCase):
                            dbus_interface=self.iface_prefix + '.Encrypted')
         self.assertIsNotNone(luks)
         self.assertTrue(os.path.exists('/dev/disk/by-uuid/%s' % luks_uuid))
+
+        dbus_cleartext = self.get_property(disk, '.Encrypted', 'CleartextDevice')
+        dbus_cleartext.assertEqual(luks)
 
     @unittest.skipUnless("JENKINS_HOME" in os.environ, "skipping test that modifies system configuration")
     def test_open_crypttab(self):

--- a/src/udiskslinuxblockobject.c
+++ b/src/udiskslinuxblockobject.c
@@ -221,6 +221,7 @@ udisks_linux_block_object_constructed (GObject *_object)
 {
   UDisksLinuxBlockObject *object = UDISKS_LINUX_BLOCK_OBJECT (_object);
   GString *str;
+  UDisksBlock *block = NULL;
 
   object->mount_monitor = udisks_daemon_get_mount_monitor (object->daemon);
   g_signal_connect (object->mount_monitor,
@@ -240,6 +241,10 @@ udisks_linux_block_object_constructed (GObject *_object)
   udisks_safe_append_to_object_path (str, g_udev_device_get_name (object->device->udev_device));
   g_dbus_object_skeleton_set_object_path (G_DBUS_OBJECT_SKELETON (object), str->str);
   g_string_free (str, TRUE);
+
+  block = udisks_object_peek_block (UDISKS_OBJECT (object));
+  if (block && g_strcmp0 (udisks_block_get_crypto_backing_device (block), "/") != 0)
+    udisks_linux_block_object_uevent (object, "change", NULL);
 
   if (G_OBJECT_CLASS (udisks_linux_block_object_parent_class)->constructed != NULL)
     G_OBJECT_CLASS (udisks_linux_block_object_parent_class)->constructed (_object);


### PR DESCRIPTION
New 'CleartextDevice' property for the 'Encrypted' interface.

Fixes #456 