### PR TITLE
allow building without mdraid & crypto

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -566,24 +566,35 @@ if test "x$have_swap" = "xno"; then
 fi
 
 # libblockdev mdraid
-SAVE_CFLAGS=$CFLAGS
-SAVE_LDFLAGS=$LDFLAGS
+have_mdraid=no
+AC_ARG_ENABLE(mdraid,
+              AS_HELP_STRING([--enable-mdraid], [enable BLOCKDEV MDRAID support]),
+	      [],
+	      [enable_mdraid=yes])
+if test "x$enable_mdraid" = "xyes"; then
+  SAVE_CFLAGS=$CFLAGS
+  SAVE_LDFLAGS=$LDFLAGS
 
-CFLAGS="$GLIB_CFLAGS"
-LDFLAGS="$GLIB_LIBS"
-AC_MSG_CHECKING([libblockdev-mdraid presence])
-AC_TRY_COMPILE([#include <blockdev/mdraid.h>], [],
-               [AC_MSG_RESULT([yes])
-               have_mdraid=yes],
-               [AC_MSG_RESULT([no])
-               have_mdraid=no])
+  CFLAGS="$GLIB_CFLAGS"
+  LDFLAGS="$GLIB_LIBS"
+  AC_MSG_CHECKING([libblockdev-mdraid presence])
+  AC_TRY_COMPILE([#include <blockdev/mdraid.h>], [],
+                 [AC_MSG_RESULT([yes])
+                 have_mdraid=yes],
+                 [AC_MSG_RESULT([no])
+                 have_mdraid=no])
 
-CFLAGS=$SAVE_CFLAGS
-LDFLAGS=$SAVE_LDFLAGS
+  CFLAGS=$SAVE_CFLAGS
+  LDFLAGS=$SAVE_LDFLAGS
 
-if test "x$have_mdraid" = "xno"; then
-  AC_MSG_ERROR([BLOCKDEV MDRAID support requested but header or library not found])
+  if test "x$have_mdraid" = "xno"; then
+    AC_MSG_ERROR([BLOCKDEV MDRAID support requested but header or library not found])
+  fi
+
+  AC_DEFINE([HAVE_MDRAID], 1, [Define to 1 to enable BLOCKDEV MDRAID])
 fi
+
+AM_CONDITIONAL(HAVE_MDRAID, test "x$have_mdraid" = "xyes")
 
 # libblockdev fs
 SAVE_CFLAGS=$CFLAGS

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -67,6 +67,7 @@ libudisks_daemon_la_SOURCES =                                                  \
 	udiskslinuxdriveata.h          udiskslinuxdriveata.c                   \
 	udiskslinuxmdraidobject.h      udiskslinuxmdraidobject.c               \
 	udiskslinuxmdraidhelpers.h     udiskslinuxmdraidhelpers.c              \
+	udiskslinuxmdraidprovider.h    udiskslinuxmdraidprovider.c             \
 	udiskslinuxmdraid.h            udiskslinuxmdraid.c                     \
 	udiskslinuxmanager.h           udiskslinuxmanager.c                    \
 	udiskslinuxfsinfo.h            udiskslinuxfsinfo.c                     \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -65,10 +65,6 @@ libudisks_daemon_la_SOURCES =                                                  \
 	udiskslinuxdriveobject.h       udiskslinuxdriveobject.c                \
 	udiskslinuxdrive.h             udiskslinuxdrive.c                      \
 	udiskslinuxdriveata.h          udiskslinuxdriveata.c                   \
-	udiskslinuxmdraidobject.h      udiskslinuxmdraidobject.c               \
-	udiskslinuxmdraidhelpers.h     udiskslinuxmdraidhelpers.c              \
-	udiskslinuxmdraidprovider.h    udiskslinuxmdraidprovider.c             \
-	udiskslinuxmdraid.h            udiskslinuxmdraid.c                     \
 	udiskslinuxmanager.h           udiskslinuxmanager.c                    \
 	udiskslinuxfsinfo.h            udiskslinuxfsinfo.c                     \
 	udisksbasejob.h                udisksbasejob.c                         \
@@ -93,6 +89,14 @@ libudisks_daemon_la_SOURCES =                                                  \
 	$(top_srcdir)/modules/udisksmoduleobject.c                             \
 	$(BUILT_SOURCES)                                                       \
 	$(NULL)
+
+if HAVE_MDRAID
+libudisks_daemon_la_SOURCES += \
+	udiskslinuxmdraidobject.h      udiskslinuxmdraidobject.c               \
+	udiskslinuxmdraidhelpers.h     udiskslinuxmdraidhelpers.c              \
+	udiskslinuxmdraidprovider.h    udiskslinuxmdraidprovider.c             \
+	udiskslinuxmdraid.h            udiskslinuxmdraid.c
+endif
 
 if HAVE_LIBMOUNT
 libudisks_daemon_la_SOURCES +=                                           \

--- a/src/udisksdaemon.c
+++ b/src/udisksdaemon.c
@@ -272,14 +272,19 @@ udisks_daemon_constructed (GObject *object)
   BDPluginSpec part_plugin = {BD_PLUGIN_PART, NULL};
   BDPluginSpec swap_plugin = {BD_PLUGIN_SWAP, NULL};
   BDPluginSpec loop_plugin = {BD_PLUGIN_LOOP, NULL};
+#ifdef HAVE_MDRAID
   BDPluginSpec mdraid_plugin = {BD_PLUGIN_MDRAID, NULL};
+#endif
   BDPluginSpec fs_plugin = {BD_PLUGIN_FS, NULL};
   BDPluginSpec crypto_plugin = {BD_PLUGIN_CRYPTO, NULL};
 
   /* The core daemon needs the part, swap, loop, mdraid, fs and crypto plugins.
      Additional plugins are required by various modules, but they make sure
      plugins are loaded themselves. */
-  BDPluginSpec *plugins[] = {&part_plugin, &swap_plugin, &loop_plugin, &mdraid_plugin,
+  BDPluginSpec *plugins[] = {&part_plugin, &swap_plugin, &loop_plugin,
+#ifdef HAVE_MDRAID
+                             &mdraid_plugin,
+#endif
                              &fs_plugin, &crypto_plugin, NULL};
   BDPluginSpec **plugin_p = NULL;
   error = NULL;
@@ -1804,13 +1809,17 @@ udisks_daemon_get_parent_for_tracking (UDisksDaemon  *daemon,
 
   UDisksObject *object = NULL;
   UDisksObject *crypto_object = NULL;
+#ifdef HAVE_MDRAID
   UDisksObject *mdraid_object = NULL;
+#endif
   UDisksObject *table_object = NULL;
   GList *track_parent_funcs;
 
   UDisksBlock *block;
   UDisksBlock *crypto_block;
+#ifdef HAVE_MDRAID
   UDisksMDRaid *mdraid;
+#endif
   UDisksPartition *partition;
   UDisksBlock *table_block;
 
@@ -1833,6 +1842,7 @@ udisks_daemon_get_parent_for_tracking (UDisksDaemon  *daemon,
             }
         }
 
+#ifdef HAVE_MDRAID
       mdraid_object = udisks_daemon_find_object (daemon, udisks_block_get_mdraid (block));
       if (mdraid_object)
         {
@@ -1844,6 +1854,7 @@ udisks_daemon_get_parent_for_tracking (UDisksDaemon  *daemon,
               goto out;
             }
         }
+#endif
 
       partition = udisks_object_peek_partition (object);
       if (partition)
@@ -1869,7 +1880,9 @@ udisks_daemon_get_parent_for_tracking (UDisksDaemon  *daemon,
  out:
   g_clear_object (&object);
   g_clear_object (&crypto_object);
+#ifdef HAVE_MDRAID
   g_clear_object (&mdraid_object);
+#endif
   g_clear_object (&table_object);
 
   if (parent_path)

--- a/src/udisksdaemontypes.h
+++ b/src/udisksdaemontypes.h
@@ -50,11 +50,13 @@ typedef struct _UDisksLinuxDrive UDisksLinuxDrive;
 struct _UDisksLinuxDriveAta;
 typedef struct _UDisksLinuxDriveAta UDisksLinuxDriveAta;
 
+#ifdef HAVE_MDRAID
 struct _UDisksLinuxMDRaidObject;
 typedef struct _UDisksLinuxMDRaidObject UDisksLinuxMDRaidObject;
 
 struct _UDisksLinuxMDRaid;
 typedef struct _UDisksLinuxMDRaid UDisksLinuxMDRaid;
+#endif
 
 struct _UDisksBaseJob;
 typedef struct _UDisksBaseJob UDisksBaseJob;

--- a/src/udisksdaemonutil.c
+++ b/src/udisksdaemonutil.c
@@ -568,6 +568,7 @@ udisks_daemon_util_setup_by_user (UDisksDaemon *daemon,
       g_object_unref (crypto_object);
     }
 
+#ifdef HAVE_MDRAID
   /* MDRaid devices */
   if (g_strcmp0 (udisks_block_get_mdraid (block), "/") != 0)
     {
@@ -581,6 +582,7 @@ udisks_daemon_util_setup_by_user (UDisksDaemon *daemon,
             }
         }
     }
+#endif
 
  out:
   g_clear_object (&partition);
@@ -1597,6 +1599,7 @@ udisks_daemon_util_uninhibit_system_sync (UDisksInhibitCookie *cookie)
 #endif
 }
 
+#ifdef HAVE_MDRAID
 /**
  * udisks_daemon_util_get_free_mdraid_device:
  *
@@ -1629,6 +1632,7 @@ udisks_daemon_util_get_free_mdraid_device (void)
  out:
   return ret;
 }
+#endif
 
 
 /**

--- a/src/udiskslinuxblock.c
+++ b/src/udiskslinuxblock.c
@@ -57,7 +57,9 @@
 #include "udisksbasejob.h"
 #include "udiskssimplejob.h"
 #include "udiskslinuxdriveata.h"
+#ifdef HAVE_MDRAID
 #include "udiskslinuxmdraidobject.h"
+#endif
 #include "udiskslinuxdevice.h"
 #include "udiskslinuxpartition.h"
 #include "udiskslinuxencrypted.h"
@@ -255,6 +257,8 @@ find_drive (GDBusObjectManagerServer  *object_manager,
 
 /* ---------------------------------------------------------------------------------------------------- */
 
+#ifdef HAVE_MDRAID
+
 static UDisksLinuxMDRaidObject *
 find_mdraid (GDBusObjectManagerServer  *object_manager,
              const gchar               *md_uuid)
@@ -326,6 +330,8 @@ update_mdraid (UDisksLinuxBlock         *block,
   udisks_block_set_mdraid (iface, objpath_mdraid);
   udisks_block_set_mdraid_member (iface, objpath_mdraid_member);
 }
+
+#endif /* HAVE_MDRAID */
 
 /* ---------------------------------------------------------------------------------------------------- */
 
@@ -1212,7 +1218,9 @@ udisks_linux_block_update (UDisksLinuxBlock       *block,
 #ifdef HAVE_LIBMOUNT
   update_userspace_mount_options (block, daemon);
 #endif
+#ifdef HAVE_MDRAID
   update_mdraid (block, device, drive, object_manager);
+#endif /* HAVE_MDRAID */
 
  out:
   if (device != NULL)

--- a/src/udiskslinuxmanager.c
+++ b/src/udiskslinuxmanager.c
@@ -35,7 +35,9 @@
 
 #include <blockdev/loop.h>
 #include <blockdev/fs.h>
+#ifdef HAVE_MDRAID
 #include <blockdev/mdraid.h>
+#endif
 
 #include "udiskslogging.h"
 #include "udiskslinuxmanager.h"
@@ -450,6 +452,8 @@ handle_loop_setup (UDisksManager          *object,
 
 /* ---------------------------------------------------------------------------------------------------- */
 
+#ifdef HAVE_MDRAID
+
 typedef struct
 {
   gint md_num;
@@ -848,6 +852,8 @@ handle_mdraid_create (UDisksManager         *_object,
   return TRUE; /* returning TRUE means that we handled the method invocation */
 }
 
+#endif /* HAVE_MDRAID */
+
 /* ---------------------------------------------------------------------------------------------------- */
 
 static void
@@ -1161,7 +1167,9 @@ static void
 manager_iface_init (UDisksManagerIface *iface)
 {
   iface->handle_loop_setup = handle_loop_setup;
+#ifdef HAVE_MDRAID
   iface->handle_mdraid_create = handle_mdraid_create;
+#endif /* HAVE_MDRAID */
   iface->handle_enable_modules = handle_enable_modules;
   iface->handle_can_format = handle_can_format;
   iface->handle_can_resize = handle_can_resize;

--- a/src/udiskslinuxmdraid.c
+++ b/src/udiskslinuxmdraid.c
@@ -32,7 +32,9 @@
 #include <glib/gstdio.h>
 
 #include <blockdev/fs.h>
+#ifdef HAVE_MDRAID
 #include <blockdev/mdraid.h>
+#endif
 
 #include "udiskslogging.h"
 #include "udiskslinuxprovider.h"

--- a/src/udiskslinuxmdraidprovider.c
+++ b/src/udiskslinuxmdraidprovider.c
@@ -1,0 +1,173 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*-
+ *
+ * Copyright (C) 2007-2010 David Zeuthen <zeuthen@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ */
+
+#include "config.h"
+
+#include "udiskslinuxmdraidprovider.h"
+#include "udiskslinuxmdraidobject.h"
+#include "udiskslinuxdevice.h"
+#include "udisksdaemon.h"
+#include "udiskslogging.h"
+
+/* called with lock held */
+
+static void
+maybe_remove_mdraid_object (UDisksDaemon              *daemon,
+                            UDisksLinuxMDRaidProvider *provider,
+                            UDisksLinuxMDRaidObject   *object)
+{
+  gchar *object_uuid = NULL;
+
+  /* remove the object only if there are no devices left */
+  if (udisks_linux_mdraid_object_have_devices (object))
+    goto out;
+
+  object_uuid = g_strdup (udisks_linux_mdraid_object_get_uuid (object));
+  g_dbus_object_manager_server_unexport (udisks_daemon_get_object_manager (daemon),
+                                         g_dbus_object_get_object_path (G_DBUS_OBJECT (object)));
+  g_warn_if_fail (g_hash_table_remove (provider->uuid_to_mdraid, object_uuid));
+
+ out:
+  g_free (object_uuid);
+}
+
+static void
+handle_block_uevent_for_mdraid_with_uuid (UDisksDaemon              *daemon,
+                                          UDisksLinuxMDRaidProvider *provider,
+                                          const gchar               *action,
+                                          UDisksLinuxDevice         *device,
+                                          const gchar               *uuid,
+                                          gboolean                   is_member)
+{
+  UDisksLinuxMDRaidObject *object;
+  const gchar *sysfs_path;
+
+  sysfs_path = g_udev_device_get_sysfs_path (device->udev_device);
+
+  /* if uuid is NULL or bogus, consider it a remove event */
+  if (uuid == NULL || g_strcmp0 (uuid, "00000000:00000000:00000000:00000000") == 0)
+    action = "remove";
+  else
+    {
+      /* sometimes the bogus UUID looks legit, but it is still bogus. */
+      if (!is_member)
+        {
+          UDisksLinuxMDRaidObject *candidate = g_hash_table_lookup (provider->sysfs_path_to_mdraid, sysfs_path);
+          if (candidate != NULL &&
+              g_strcmp0 (uuid, udisks_linux_mdraid_object_get_uuid (candidate)) != 0)
+            {
+              udisks_debug ("UUID of %s became bogus (changed from %s to %s)",
+                            sysfs_path, udisks_linux_mdraid_object_get_uuid (candidate), uuid);
+              action = "remove";
+            }
+        }
+    }
+
+  if (g_strcmp0 (action, "remove") == 0)
+    {
+      /* first check if this device was a member */
+      object = g_hash_table_lookup (provider->sysfs_path_to_mdraid_members, sysfs_path);
+      if (object != NULL)
+        {
+          udisks_linux_mdraid_object_uevent (object, action, device, TRUE /* is_member */);
+          g_warn_if_fail (g_hash_table_remove (provider->sysfs_path_to_mdraid_members, sysfs_path));
+          maybe_remove_mdraid_object (daemon, provider, object);
+        }
+
+      /* then check if the device was the raid device */
+      object = g_hash_table_lookup (provider->sysfs_path_to_mdraid, sysfs_path);
+      if (object != NULL)
+        {
+          udisks_linux_mdraid_object_uevent (object, action, device, FALSE /* is_member */);
+          g_warn_if_fail (g_hash_table_remove (provider->sysfs_path_to_mdraid, sysfs_path));
+          maybe_remove_mdraid_object (daemon, provider, object);
+        }
+    }
+  else
+    {
+      if (uuid == NULL)
+        goto out;
+
+      object = g_hash_table_lookup (provider->uuid_to_mdraid, uuid);
+      if (object != NULL)
+        {
+          if (is_member)
+            {
+              if (g_hash_table_lookup (provider->sysfs_path_to_mdraid_members, sysfs_path) == NULL)
+                g_hash_table_insert (provider->sysfs_path_to_mdraid_members, g_strdup (sysfs_path), object);
+            }
+          else
+            {
+              if (g_hash_table_lookup (provider->sysfs_path_to_mdraid, sysfs_path) == NULL)
+                g_hash_table_insert (provider->sysfs_path_to_mdraid, g_strdup (sysfs_path), object);
+            }
+          udisks_linux_mdraid_object_uevent (object, action, device, is_member);
+        }
+      else
+        {
+          object = udisks_linux_mdraid_object_new (daemon, uuid);
+          udisks_linux_mdraid_object_uevent (object, action, device, is_member);
+          g_dbus_object_manager_server_export_uniquely (udisks_daemon_get_object_manager (daemon),
+                                                        G_DBUS_OBJECT_SKELETON (object));
+          g_hash_table_insert (provider->uuid_to_mdraid, g_strdup (uuid), object);
+          if (is_member)
+            g_hash_table_insert (provider->sysfs_path_to_mdraid_members, g_strdup (sysfs_path), object);
+          else
+            g_hash_table_insert (provider->sysfs_path_to_mdraid, g_strdup (sysfs_path), object);
+        }
+    }
+
+ out:
+  ;
+}
+
+void
+handle_block_uevent_for_mdraid (UDisksDaemon              *daemon,
+                                UDisksLinuxMDRaidProvider *provider,
+                                const gchar               *action,
+                                UDisksLinuxDevice         *device)
+{
+  const gchar *uuid;
+  const gchar *member_uuid;
+
+  /* For nested RAID levels, a device can be both a member of one
+   * array and the RAID device for another. Therefore we need to
+   * consider both UUIDs.
+   *
+   * For removal, we also need to consider the case where there is no
+   * UUID.
+   */
+  uuid = g_udev_device_get_property (device->udev_device, "UDISKS_MD_UUID");
+  if (! uuid)
+    uuid = g_udev_device_get_property (device->udev_device, "STORAGED_MD_UUID");
+
+  member_uuid = g_udev_device_get_property (device->udev_device, "UDISKS_MD_MEMBER_UUID");
+  if (! member_uuid)
+    member_uuid = g_udev_device_get_property (device->udev_device, "STORAGED_MD_MEMBER_UUID");
+
+  if (uuid != NULL)
+    handle_block_uevent_for_mdraid_with_uuid (daemon, provider, action, device, uuid, FALSE);
+
+  if (member_uuid != NULL)
+    handle_block_uevent_for_mdraid_with_uuid (daemon, provider, action, device, member_uuid, TRUE);
+
+  if (uuid == NULL && member_uuid == NULL)
+    handle_block_uevent_for_mdraid_with_uuid (daemon, provider, action, device, NULL, FALSE);
+}

--- a/src/udiskslinuxmdraidprovider.h
+++ b/src/udiskslinuxmdraidprovider.h
@@ -1,0 +1,69 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*-
+ *
+ * Copyright (C) 2007-2010 David Zeuthen <zeuthen@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ */
+
+#ifndef __UDISKS_LINUX_MDRAID_PROVIDER_H__
+#define __UDISKS_LINUX_MDRAID_PROVIDER_H__
+
+#include "udisksdaemontypes.h"
+
+G_BEGIN_DECLS
+
+typedef struct _UDisksLinuxMDRaidProvider UDisksLinuxMDRaidProvider;
+
+struct _UDisksLinuxMDRaidProvider
+{
+  /* maps from array UUID and sysfs_path to UDisksLinuxMDRaidObject instances */
+  GHashTable *uuid_to_mdraid;
+  GHashTable *sysfs_path_to_mdraid;
+  GHashTable *sysfs_path_to_mdraid_members;
+};
+
+static inline void udisks_linux_mdraid_provider_start(UDisksLinuxMDRaidProvider *provider)
+{
+  provider->uuid_to_mdraid = g_hash_table_new_full (g_str_hash,
+                                                    g_str_equal,
+                                                    g_free,
+                                                    (GDestroyNotify) g_object_unref);
+  provider->sysfs_path_to_mdraid = g_hash_table_new_full (g_str_hash,
+                                                          g_str_equal,
+                                                          g_free,
+                                                          NULL);
+  provider->sysfs_path_to_mdraid_members = g_hash_table_new_full (g_str_hash,
+                                                                  g_str_equal,
+                                                                  g_free,
+                                                                  NULL);
+}
+
+static inline void udisks_linux_mdraid_provider_finalize(UDisksLinuxMDRaidProvider *provider)
+{
+  g_hash_table_unref (provider->uuid_to_mdraid);
+  g_hash_table_unref (provider->sysfs_path_to_mdraid);
+  g_hash_table_unref (provider->sysfs_path_to_mdraid_members);
+}
+
+void
+handle_block_uevent_for_mdraid (UDisksDaemon              *daemon,
+                                UDisksLinuxMDRaidProvider *provider,
+                                const gchar               *action,
+                                UDisksLinuxDevice         *device);
+
+G_END_DECLS
+
+#endif /* __UDISKS_LINUX_MDRAID_PROVIDER_H__ */

--- a/src/udiskslinuxprovider.c
+++ b/src/udiskslinuxprovider.c
@@ -29,8 +29,10 @@
 #include "udiskslinuxprovider.h"
 #include "udiskslinuxblockobject.h"
 #include "udiskslinuxdriveobject.h"
+#ifdef HAVE_MDRAID
 #include "udiskslinuxmdraidobject.h"
 #include "udiskslinuxmdraidprovider.h"
+#endif
 #include "udiskslinuxmanager.h"
 #include "udisksstate.h"
 #include "udiskslinuxdevice.h"
@@ -75,7 +77,9 @@ struct _UDisksLinuxProvider
   GHashTable *vpd_to_drive;
   GHashTable *sysfs_path_to_drive;
 
+#ifdef HAVE_MDRAID
   UDisksLinuxMDRaidProvider mdraid;
+#endif
 
   /* maps from UDisksModuleObjectNewFuncs to nested hashtables containing object
    * skeleton instances as keys and GLists of consumed sysfs path as values */
@@ -168,7 +172,9 @@ udisks_linux_provider_finalize (GObject *object)
   g_hash_table_unref (provider->sysfs_to_block);
   g_hash_table_unref (provider->vpd_to_drive);
   g_hash_table_unref (provider->sysfs_path_to_drive);
+#ifdef HAVE_MDRAID
   udisks_linux_mdraid_provider_finalize (&provider->mdraid);
+#endif
   g_hash_table_unref (provider->module_funcs_to_instances);
   g_object_unref (provider->gudev_client);
 
@@ -641,7 +647,9 @@ udisks_linux_provider_start (UDisksProvider *_provider)
                                                          g_str_equal,
                                                          g_free,
                                                          NULL);
+#ifdef HAVE_MDRAID
   udisks_linux_mdraid_provider_start(&provider->mdraid);
+#endif
   provider->module_funcs_to_instances = g_hash_table_new_full (g_direct_hash,
                                                                g_direct_equal,
                                                                NULL,
@@ -1113,7 +1121,9 @@ handle_block_uevent (UDisksLinuxProvider *provider,
     {
       handle_block_uevent_for_block (provider, action, device);
       handle_block_uevent_for_drive (provider, action, device);
+#ifdef HAVE_MDRAID
       handle_block_uevent_for_mdraid (daemon, &provider->mdraid, action, device);
+#endif /* HAVE_MDRAID */
       handle_block_uevent_for_modules (provider, action, device);
     }
   else
@@ -1132,7 +1142,9 @@ handle_block_uevent (UDisksLinuxProvider *provider,
       else
         {
           handle_block_uevent_for_modules (provider, action, device);
+#ifdef HAVE_MDRAID
           handle_block_uevent_for_mdraid (daemon, &provider->mdraid, action, device);
+#endif /* HAVE_MDRAID */
           handle_block_uevent_for_drive (provider, action, device);
           handle_block_uevent_for_block (provider, action, device);
         }

--- a/src/udiskslinuxprovider.c
+++ b/src/udiskslinuxprovider.c
@@ -30,6 +30,7 @@
 #include "udiskslinuxblockobject.h"
 #include "udiskslinuxdriveobject.h"
 #include "udiskslinuxmdraidobject.h"
+#include "udiskslinuxmdraidprovider.h"
 #include "udiskslinuxmanager.h"
 #include "udisksstate.h"
 #include "udiskslinuxdevice.h"
@@ -74,10 +75,7 @@ struct _UDisksLinuxProvider
   GHashTable *vpd_to_drive;
   GHashTable *sysfs_path_to_drive;
 
-  /* maps from array UUID and sysfs_path to UDisksLinuxMDRaidObject instances */
-  GHashTable *uuid_to_mdraid;
-  GHashTable *sysfs_path_to_mdraid;
-  GHashTable *sysfs_path_to_mdraid_members;
+  UDisksLinuxMDRaidProvider mdraid;
 
   /* maps from UDisksModuleObjectNewFuncs to nested hashtables containing object
    * skeleton instances as keys and GLists of consumed sysfs path as values */
@@ -170,9 +168,7 @@ udisks_linux_provider_finalize (GObject *object)
   g_hash_table_unref (provider->sysfs_to_block);
   g_hash_table_unref (provider->vpd_to_drive);
   g_hash_table_unref (provider->sysfs_path_to_drive);
-  g_hash_table_unref (provider->uuid_to_mdraid);
-  g_hash_table_unref (provider->sysfs_path_to_mdraid);
-  g_hash_table_unref (provider->sysfs_path_to_mdraid_members);
+  udisks_linux_mdraid_provider_finalize (&provider->mdraid);
   g_hash_table_unref (provider->module_funcs_to_instances);
   g_object_unref (provider->gudev_client);
 
@@ -645,18 +641,7 @@ udisks_linux_provider_start (UDisksProvider *_provider)
                                                          g_str_equal,
                                                          g_free,
                                                          NULL);
-  provider->uuid_to_mdraid = g_hash_table_new_full (g_str_hash,
-                                                    g_str_equal,
-                                                    g_free,
-                                                    (GDestroyNotify) g_object_unref);
-  provider->sysfs_path_to_mdraid = g_hash_table_new_full (g_str_hash,
-                                                          g_str_equal,
-                                                          g_free,
-                                                          NULL);
-  provider->sysfs_path_to_mdraid_members = g_hash_table_new_full (g_str_hash,
-                                                                  g_str_equal,
-                                                                  g_free,
-                                                                  NULL);
+  udisks_linux_mdraid_provider_start(&provider->mdraid);
   provider->module_funcs_to_instances = g_hash_table_new_full (g_direct_hash,
                                                                g_direct_equal,
                                                                NULL,
@@ -822,156 +807,6 @@ perform_initial_housekeeping_for_drive (GTask           *task,
                       error->message, g_quark_to_string (error->domain), error->code);
       g_clear_error (&error);
     }
-}
-
-/* ---------------------------------------------------------------------------------------------------- */
-
-/* called with lock held */
-
-static void
-maybe_remove_mdraid_object (UDisksLinuxProvider     *provider,
-                            UDisksLinuxMDRaidObject *object)
-{
-  gchar *object_uuid = NULL;
-  UDisksDaemon *daemon = NULL;
-
-  /* remove the object only if there are no devices left */
-  if (udisks_linux_mdraid_object_have_devices (object))
-    goto out;
-
-  daemon = udisks_provider_get_daemon (UDISKS_PROVIDER (provider));
-
-  object_uuid = g_strdup (udisks_linux_mdraid_object_get_uuid (object));
-  g_dbus_object_manager_server_unexport (udisks_daemon_get_object_manager (daemon),
-                                         g_dbus_object_get_object_path (G_DBUS_OBJECT (object)));
-  g_warn_if_fail (g_hash_table_remove (provider->uuid_to_mdraid, object_uuid));
-
- out:
-  g_free (object_uuid);
-}
-
-static void
-handle_block_uevent_for_mdraid_with_uuid (UDisksLinuxProvider *provider,
-                                          const gchar         *action,
-                                          UDisksLinuxDevice   *device,
-                                          const gchar         *uuid,
-                                          gboolean             is_member)
-{
-  UDisksLinuxMDRaidObject *object;
-  UDisksDaemon *daemon;
-  const gchar *sysfs_path;
-
-  daemon = udisks_provider_get_daemon (UDISKS_PROVIDER (provider));
-  sysfs_path = g_udev_device_get_sysfs_path (device->udev_device);
-
-  /* if uuid is NULL or bogus, consider it a remove event */
-  if (uuid == NULL || g_strcmp0 (uuid, "00000000:00000000:00000000:00000000") == 0)
-    action = "remove";
-  else
-    {
-      /* sometimes the bogus UUID looks legit, but it is still bogus. */
-      if (!is_member)
-        {
-          UDisksLinuxMDRaidObject *candidate = g_hash_table_lookup (provider->sysfs_path_to_mdraid, sysfs_path);
-          if (candidate != NULL &&
-              g_strcmp0 (uuid, udisks_linux_mdraid_object_get_uuid (candidate)) != 0)
-            {
-              udisks_debug ("UUID of %s became bogus (changed from %s to %s)",
-                            sysfs_path, udisks_linux_mdraid_object_get_uuid (candidate), uuid);
-              action = "remove";
-            }
-        }
-    }
-
-  if (g_strcmp0 (action, "remove") == 0)
-    {
-      /* first check if this device was a member */
-      object = g_hash_table_lookup (provider->sysfs_path_to_mdraid_members, sysfs_path);
-      if (object != NULL)
-        {
-          udisks_linux_mdraid_object_uevent (object, action, device, TRUE /* is_member */);
-          g_warn_if_fail (g_hash_table_remove (provider->sysfs_path_to_mdraid_members, sysfs_path));
-          maybe_remove_mdraid_object (provider, object);
-        }
-
-      /* then check if the device was the raid device */
-      object = g_hash_table_lookup (provider->sysfs_path_to_mdraid, sysfs_path);
-      if (object != NULL)
-        {
-          udisks_linux_mdraid_object_uevent (object, action, device, FALSE /* is_member */);
-          g_warn_if_fail (g_hash_table_remove (provider->sysfs_path_to_mdraid, sysfs_path));
-          maybe_remove_mdraid_object (provider, object);
-        }
-    }
-  else
-    {
-      if (uuid == NULL)
-        goto out;
-
-      object = g_hash_table_lookup (provider->uuid_to_mdraid, uuid);
-      if (object != NULL)
-        {
-          if (is_member)
-            {
-              if (g_hash_table_lookup (provider->sysfs_path_to_mdraid_members, sysfs_path) == NULL)
-                g_hash_table_insert (provider->sysfs_path_to_mdraid_members, g_strdup (sysfs_path), object);
-            }
-          else
-            {
-              if (g_hash_table_lookup (provider->sysfs_path_to_mdraid, sysfs_path) == NULL)
-                g_hash_table_insert (provider->sysfs_path_to_mdraid, g_strdup (sysfs_path), object);
-            }
-          udisks_linux_mdraid_object_uevent (object, action, device, is_member);
-        }
-      else
-        {
-          object = udisks_linux_mdraid_object_new (daemon, uuid);
-          udisks_linux_mdraid_object_uevent (object, action, device, is_member);
-          g_dbus_object_manager_server_export_uniquely (udisks_daemon_get_object_manager (daemon),
-                                                        G_DBUS_OBJECT_SKELETON (object));
-          g_hash_table_insert (provider->uuid_to_mdraid, g_strdup (uuid), object);
-          if (is_member)
-            g_hash_table_insert (provider->sysfs_path_to_mdraid_members, g_strdup (sysfs_path), object);
-          else
-            g_hash_table_insert (provider->sysfs_path_to_mdraid, g_strdup (sysfs_path), object);
-        }
-    }
-
- out:
-  ;
-}
-
-static void
-handle_block_uevent_for_mdraid (UDisksLinuxProvider *provider,
-                                const gchar         *action,
-                                UDisksLinuxDevice   *device)
-{
-  const gchar *uuid;
-  const gchar *member_uuid;
-
-  /* For nested RAID levels, a device can be both a member of one
-   * array and the RAID device for another. Therefore we need to
-   * consider both UUIDs.
-   *
-   * For removal, we also need to consider the case where there is no
-   * UUID.
-   */
-  uuid = g_udev_device_get_property (device->udev_device, "UDISKS_MD_UUID");
-  if (! uuid)
-    uuid = g_udev_device_get_property (device->udev_device, "STORAGED_MD_UUID");
-
-  member_uuid = g_udev_device_get_property (device->udev_device, "UDISKS_MD_MEMBER_UUID");
-  if (! member_uuid)
-    member_uuid = g_udev_device_get_property (device->udev_device, "STORAGED_MD_MEMBER_UUID");
-
-  if (uuid != NULL)
-    handle_block_uevent_for_mdraid_with_uuid (provider, action, device, uuid, FALSE);
-
-  if (member_uuid != NULL)
-    handle_block_uevent_for_mdraid_with_uuid (provider, action, device, member_uuid, TRUE);
-
-  if (uuid == NULL && member_uuid == NULL)
-    handle_block_uevent_for_mdraid_with_uuid (provider, action, device, NULL, FALSE);
 }
 
 /* ---------------------------------------------------------------------------------------------------- */
@@ -1261,6 +1096,10 @@ handle_block_uevent (UDisksLinuxProvider *provider,
                      const gchar         *action,
                      UDisksLinuxDevice   *device)
 {
+  UDisksDaemon *daemon;
+
+  daemon = udisks_provider_get_daemon (UDISKS_PROVIDER (provider));
+
   /* We use the sysfs block device for all of
    *
    *  - UDisksLinuxDriveObject
@@ -1274,7 +1113,7 @@ handle_block_uevent (UDisksLinuxProvider *provider,
     {
       handle_block_uevent_for_block (provider, action, device);
       handle_block_uevent_for_drive (provider, action, device);
-      handle_block_uevent_for_mdraid (provider, action, device);
+      handle_block_uevent_for_mdraid (daemon, &provider->mdraid, action, device);
       handle_block_uevent_for_modules (provider, action, device);
     }
   else
@@ -1293,7 +1132,7 @@ handle_block_uevent (UDisksLinuxProvider *provider,
       else
         {
           handle_block_uevent_for_modules (provider, action, device);
-          handle_block_uevent_for_mdraid (provider, action, device);
+          handle_block_uevent_for_mdraid (daemon, &provider->mdraid, action, device);
           handle_block_uevent_for_drive (provider, action, device);
           handle_block_uevent_for_block (provider, action, device);
         }

--- a/src/udisksstate.c
+++ b/src/udisksstate.c
@@ -184,9 +184,11 @@ static void      udisks_state_check_unlocked_crypto_dev (UDisksState          *s
 static void      udisks_state_check_loop          (UDisksState          *state,
                                                    gboolean              check_only,
                                                    GArray               *devs_to_clean);
+#ifdef HAVE_MDRAID
 static void      udisks_state_check_mdraid        (UDisksState          *state,
                                                    gboolean              check_only,
                                                    GArray               *devs_to_clean);
+#endif
 static GVariant *udisks_state_get                 (UDisksState          *state,
                                                    const gchar          *key,
                                                    const GVariantType   *type,
@@ -433,9 +435,11 @@ udisks_state_check_in_thread (UDisksState *state)
                            TRUE, /* check_only */
                            devs_to_clean);
 
+#ifdef HAVE_MDRAID
   udisks_state_check_mdraid (state,
                              TRUE, /* check_only */
                              devs_to_clean);
+#endif
 
   /* Then go through all mounted filesystems and pass the
    * devices that we intend to clean...
@@ -452,9 +456,11 @@ udisks_state_check_in_thread (UDisksState *state)
                            FALSE, /* check_only */
                            NULL);
 
+#ifdef HAVE_MDRAID
   udisks_state_check_mdraid (state,
                              FALSE, /* check_only */
                              NULL);
+#endif
 
   g_array_unref (devs_to_clean);
 
@@ -1813,6 +1819,7 @@ udisks_state_has_loop (UDisksState   *state,
 
 /* ---------------------------------------------------------------------------------------------------- */
 
+#ifdef HAVE_MDRAID
 /* returns TRUE if the entry should be kept */
 static gboolean
 udisks_state_check_mdraid_entry (UDisksState  *state,
@@ -2092,6 +2099,7 @@ udisks_state_has_mdraid (UDisksState   *state,
   g_mutex_unlock (&state->lock);
   return ret;
 }
+#endif
 
 /* ---------------------------------------------------------------------------------------------------- */
 


### PR DESCRIPTION
This makes the two plugins optional and allows building a smaller udisks binary with fewer dependencies, which may be useful for small systems.