### PR TITLE
udiskstestcase.py: Use 'monotic' from 'time' on python >= 3.3

### DIFF
--- a/src/tests/dbus-tests/udiskstestcase.py
+++ b/src/tests/dbus-tests/udiskstestcase.py
@@ -8,7 +8,11 @@ import time
 import sys
 from datetime import datetime
 from systemd import journal
-from monotonic import monotonic
+
+if sys.version_info.major == 3 and sys.version_info.minor >= 3:
+    from time import monotonic
+else:
+    from monotonic import monotonic
 
 import gi
 gi.require_version('GUdev', '1.0')


### PR DESCRIPTION
monotnonic package is not available on some systems because on
Python 3.3 or newer it is only an alias for 'time.monotonic'
from the standard library.