### PR TITLE
Increase timeout for waiting for cleartext object after unlocking

### DIFF
--- a/src/udiskslinuxencrypted.c
+++ b/src/udiskslinuxencrypted.c
@@ -526,7 +526,7 @@ handle_unlock (UDisksEncrypted        *encrypted,
                                                          wait_for_cleartext_object,
                                                          g_strdup (g_dbus_object_get_object_path (G_DBUS_OBJECT (object))),
                                                          g_free,
-                                                         10, /* timeout_seconds */
+                                                         20, /* timeout_seconds */
                                                          &error);
   if (cleartext_object == NULL)
     {


### PR DESCRIPTION
Unlocking TCRYPT volumes can take a lot longer than unlocking LUKS
volumes, so the 10 second timeout is not enough in some cases.