### PR TITLE
configure: remove redundant xsltproc check

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -90,11 +90,6 @@ CC_CHECK_CFLAGS_APPEND([                          \
         -D_FILE_OFFSET_BITS=64                    \
 ])
 
-AC_PATH_PROG([XSLTPROC], [xsltproc])
-if test -z "$XSLTPROC"; then
-  AC_MSG_ERROR([xsltproc is needed])
-fi
-
 if test -z "$enable_modules"; then
   enable_modules=no
 fi


### PR DESCRIPTION
This is also checked inside the enable_man conditional.  Remove this
redundant check so that we don't require xsltproc when --disable-man is
specified.