### PR TITLE
Update the Partitions property on partition "add" event

### DIFF
--- a/src/tests/dbus-tests/test_60_partitioning.py
+++ b/src/tests/dbus-tests/test_60_partitioning.py
@@ -469,6 +469,10 @@ class UdisksPartitionTest(udiskstestcase.UdisksTestCase):
         # make sure partition is not in the system
         self.assertFalse(os.path.isdir(part_syspath))
 
+        # partitions property of the disk should be updated too
+        dbus_parts = self.get_property(disk, '.PartitionTable', 'Partitions')
+        dbus_parts.assertFalse()
+
     def test_dos_flags(self):
         disk = self.get_object('/block_devices/' + os.path.basename(self.vdevs[0]))
         self.assertIsNotNone(disk)

--- a/src/udiskslinuxblockobject.c
+++ b/src/udiskslinuxblockobject.c
@@ -222,6 +222,7 @@ udisks_linux_block_object_constructed (GObject *_object)
   UDisksLinuxBlockObject *object = UDISKS_LINUX_BLOCK_OBJECT (_object);
   GString *str;
   UDisksBlock *block = NULL;
+  UDisksPartition *partition = NULL;
 
   object->mount_monitor = udisks_daemon_get_mount_monitor (object->daemon);
   g_signal_connect (object->mount_monitor,
@@ -244,6 +245,13 @@ udisks_linux_block_object_constructed (GObject *_object)
 
   block = udisks_object_peek_block (UDISKS_OBJECT (object));
   if (block && g_strcmp0 (udisks_block_get_crypto_backing_device (block), "/") != 0)
+    udisks_linux_block_object_uevent (object, "change", NULL);
+
+  /* run update for partitions again -- it sets the "Partitions" property
+   * on the PartitionTable interface and we need the object path for that
+   */
+  partition = udisks_object_peek_partition (UDISKS_OBJECT (object));
+  if (partition)
     udisks_linux_block_object_uevent (object, "change", NULL);
 
   if (G_OBJECT_CLASS (udisks_linux_block_object_parent_class)->constructed != NULL)


### PR DESCRIPTION
We are currently updating the "Partitions" property of the
"PartitionTable" interface only as a result of a change event on
the disk. This works when actually creating the partition but not
when "adding" a disk that already has partitions (e.g. plugging in
a USB flash drive). This adds a special update call when handling
the "add" event for a new partition.

Fixes: #570 