### PR TITLE
Fix DM_MULTIPATH_DEVICE_PATH in udev rules

### DIFF
--- a/data/80-udisks2.rules
+++ b/data/80-udisks2.rules
@@ -10,7 +10,7 @@
 # Skip probing if not a block device or if requested by other rules
 #
 SUBSYSTEM!="block", GOTO="udisks_probe_end"
-ENV{DM_MULTIPATH_DEVICE_PATH}=="?*", GOTO="udisks_probe_end"
+ENV{DM_MULTIPATH_DEVICE_PATH}=="1", GOTO="udisks_probe_end"
 ENV{DM_UDEV_DISABLE_OTHER_RULES_FLAG}=="?*", GOTO="udisks_probe_end"
 
 # MD-RAID (aka Linux Software RAID) members


### PR DESCRIPTION
As we worked out in
https://bugzilla.redhat.com/show_bug.cgi?id=1628774 , with
multipath-tools 0.7.7 or higher, DM_MULTIPATH_DEVICE_PATH gets
set to the value 0 for non-multipath devices in some cases.
Before 0.7.7, it was always either set to 1 or not set at all.
Now it can be set to 0, checks like this:

ENV{DM_MULTIPATH_DEVICE_PATH}=="?*"

don't work right any more, because that check will actually
match if the value is 0 (it will only not match if the var is
not set at all, or is set to an empty string). Instead we should
just check if it is set to exactly 1, otherwise assume the device
isn't multipath.

The impact of this is I think quite limited: we only skip two
rules if this check matches, and they only affect mdraid devices.
On installed systems without any multipath devices, the bug
should not happen, because there should be no /etc/multipath.conf
and when that file doesn't exist, the multipath rules skip out
early and don't wind up setting the value to 0 ever. I think the
only cases affected by this are 'generic' environments like live
images and installers, and installed systems with multipath
devices. In both these cases there will be a /etc/multipath.conf
file, so for some devices, the multipath rules will get far
enough to set the value to 0. The consequence will be that the
UDISKS_MD_* values that these two rules try to set will not get
set for devices they *should* get set for. I'm not sure what the
further consequences of that are, if any.

Signed-off-by: Adam Williamson <awilliam@redhat.com>