### PR TITLE
Fix string format vulnerability

### DIFF
--- a/src/udiskslogging.c
+++ b/src/udiskslogging.c
@@ -60,7 +60,7 @@ udisks_log (UDisksLogLevel     level,
 
 #if GLIB_CHECK_VERSION(2, 50, 0)
   g_log_structured ("udisks", (GLogLevelFlags) level,
-                    "MESSAGE", message, "THREAD_ID", "%d", (gint) syscall (SYS_gettid),
+                    "MESSAGE", "%s", message, "THREAD_ID", "%d", (gint) syscall (SYS_gettid),
                     "CODE_FUNC", function, "CODE_FILE", location);
 #else
   g_log ("udisks", level, "[%d]: %s [%s, %s()]", (gint) syscall (SYS_gettid), message, location, function);


### PR DESCRIPTION
If the message in g_log_structured itself
contained format sequences like %d or %n they
were applied again, leading to leaked stack contents
and possibly memory corruption. It can be triggered
e.g. by a volume label containing format sequences.

Print the message argument itself into a "%s" string
to avoid intepreting format sequences.

https://github.com/storaged-project/udisks/issues/578