### PR TITLE
Add g_autoptr() for Client, PartitionTypeInfo, ObjectInfo

### DIFF
--- a/udisks/udisksclient.h
+++ b/udisks/udisksclient.h
@@ -155,6 +155,8 @@ gchar *udisks_client_get_job_description_from_operation (const gchar *operation)
 gchar *udisks_client_get_job_description (UDisksClient   *client,
                                           UDisksJob      *job);
 
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(UDisksClient, g_object_unref)
+
 /**
  * UDisksPartitionTypeInfo:
  * @table_type: A partition table type e.g. 'dos' or 'gpt'
@@ -182,6 +184,8 @@ struct _UDisksPartitionTypeInfo
 
 GType                udisks_partition_type_info_get_type   (void) G_GNUC_CONST;
 void                 udisks_partition_type_info_free       (UDisksPartitionTypeInfo  *info);
+
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(UDisksPartitionTypeInfo, udisks_partition_type_info_free)
 
 G_END_DECLS
 

--- a/udisks/udisksclient.h
+++ b/udisks/udisksclient.h
@@ -182,6 +182,7 @@ struct _UDisksPartitionTypeInfo
   UDisksPartitionTypeInfoFlags  flags;
 };
 
+#define UDISKS_TYPE_PARTITION_TYPE_INFO (udisks_partition_type_info_get_type ())
 GType                udisks_partition_type_info_get_type   (void) G_GNUC_CONST;
 void                 udisks_partition_type_info_free       (UDisksPartitionTypeInfo  *info);
 

--- a/udisks/udisksobjectinfo.c
+++ b/udisks/udisksobjectinfo.c
@@ -48,7 +48,7 @@
  * The value return by udisks_object_info_get_one_liner() is designed
  * to contain enough information such that it is all that needs to be
  * shown about the object. As a result for e.g.  block devices or
- * drives it contains the special device device
+ * drives it contains the special device file
  * e.g. <filename>/dev/sda</filename>.
  *
  * Since: 2.1

--- a/udisks/udisksobjectinfo.h
+++ b/udisks/udisksobjectinfo.h
@@ -46,6 +46,8 @@ GIcon        *udisks_object_info_get_media_icon_symbolic (UDisksObjectInfo  *inf
 const gchar  *udisks_object_info_get_one_liner           (UDisksObjectInfo  *info);
 const gchar  *udisks_object_info_get_sort_key            (UDisksObjectInfo  *info);
 
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(UDisksObjectInfo, g_object_unref)
+
 G_END_DECLS
 
 #endif /* __UDISKS_OBJECT_INFO_H__ */


### PR DESCRIPTION
Builds on https://github.com/storaged-project/udisks/pull/492 for some of the manually-defined types. I also added a GType macro and fixed a typo.

Unfortunately, UDisksObject (which is part of the generated code) still doesn't have autocleanup support. I'm not sure why: I think it's probably a gdbus-codegen bug. (**Update**: [it is](https://gitlab.gnome.org/GNOME/glib/merge_requests/420).)