### PR TITLE
Move D-Bus policy file to /usr/share/dbus-1/system.d/

### DIFF
--- a/data/Makefile.am
+++ b/data/Makefile.am
@@ -8,7 +8,7 @@ dbusservice_DATA     = $(dbusservice_in_files:.service.in=.service)
 $(dbusservice_DATA): $(dbusservice_in_files) Makefile
 	@sed -e "s|\@udisksdprivdir\@|$(libexecdir)/udisks2|" $< > $@
 
-dbusconfdir = $(sysconfdir)/dbus-1/system.d
+dbusconfdir = $(datadir)/dbus-1/system.d
 dbusconf_in_files = org.freedesktop.UDisks2.conf.in
 dbusconf_DATA = $(dbusconf_in_files:.conf.in=.conf)
 

--- a/packaging/udisks2.spec
+++ b/packaging/udisks2.spec
@@ -356,7 +356,7 @@ udevadm trigger
 %endif
 %{_sysconfdir}/udisks2/udisks2.conf
 
-%{_sysconfdir}/dbus-1/system.d/org.freedesktop.UDisks2.conf
+%{_datadir}/dbus-1/system.d/org.freedesktop.UDisks2.conf
 %{_datadir}/bash-completion/completions/udisksctl
 %{_unitdir}/udisks2.service
 %{_unitdir}/clean-mount-point@.service


### PR DESCRIPTION
To better support stateless systems with an empty /etc, the old location
in /etc/dbus-1/system.d/ should only be used for local admin changes.
Package provided D-Bus policy files are supposed to be installed in
/usr/share/dbus-1/system.d/.

This is supported since dbus 1.9.18.

https://lists.freedesktop.org/archives/dbus/2015-July/016746.html