### PR TITLE
block: remove extra whitespace in OpenDevice error message

### DIFF
--- a/src/udiskslinuxblock.c
+++ b/src/udiskslinuxblock.c
@@ -3479,8 +3479,8 @@ open_device (const gchar      *device,
   if (flags & O_RDWR || flags & O_RDONLY || flags & O_WRONLY)
     {
       g_set_error (error, UDISKS_ERROR, UDISKS_ERROR_FAILED,
-                   "Using 'O_RDWR', 'O_RDONLY' and 'O_WRONLY' flags is not permitted.\
-                    Use 'mode' argument instead.");
+                   "Using 'O_RDWR', 'O_RDONLY' and 'O_WRONLY' flags is not permitted. "
+                   "Use 'mode' argument instead.");
       goto out;
     }
 


### PR DESCRIPTION
Previously, if `O_RDWR | O_RDONLY | O_WRONLY` were specified, the error
message would include whitespace up to the indentation level between its
two sentences. This is harmless but ugly.

(I notice that, since `O_RDONLY == 0`, `flags & O_RDONLY` is always false…)