### PR TITLE
Fix leaking UDisksLinuxDevice

### DIFF
--- a/src/udiskslinuxencrypted.c
+++ b/src/udiskslinuxencrypted.c
@@ -181,7 +181,8 @@ update_metadata_size (UDisksLinuxEncrypted   *encrypted,
     g_clear_error (&error);
   }
 
-  udisks_encrypted_set_metadata_size(UDISKS_ENCRYPTED (encrypted), metadata_size);
+  g_object_unref (device);
+  udisks_encrypted_set_metadata_size (UDISKS_ENCRYPTED (encrypted), metadata_size);
 }
 
 static void


### PR DESCRIPTION
The udisks_linux_block_object_get_device() call takes reference to UDisksLinuxDevice
and users are supposed to free it after use.

--

This was a blind shot, incidentally found by reading the code. No idea about the consequences as this may reveal wrong reference ownership somewhere else in the code.

Btw. the `find_fstab_entries_for_device()` function within `udiskslinuxblock.c` looks pretty nasty with the use of `goto` instead of proper `continue`. Also the `UDisksLinuxDevice->udev_device` is never supposed to be _NULL_ unless I'm missing something, not sure what was the original idea for this test here.