### PR TITLE
udisksctl: Explicitly close stdout once dump command finishes

### DIFF
--- a/tools/udisksctl.c
+++ b/tools/udisksctl.c
@@ -2572,6 +2572,9 @@ handle_command_dump (gint        *argc,
 
   ret = 0;
 
+  /* explicitly close stdout so that pagers are aware of EOF */
+  fclose (stdout);
+
  out:
   g_option_context_free (o);
   return ret;


### PR DESCRIPTION
Some pagers freeze when fetching data making it impossible to quit or
scroll through already buffered lines. Let's explicitly close stdout so
that pagers are aware that no more data are coming.