### PR TITLE
tests: Sleep for a while after ISO9660 image creation and udev settle

### DIFF
--- a/src/tests/dbus-tests/test_80_filesystem.py
+++ b/src/tests/dbus-tests/test_80_filesystem.py
@@ -895,6 +895,8 @@ class UdisksISO9660TestCase(udiskstestcase.UdisksTestCase):
             ret, _out = self.run_command("genisoimage -V TEST_iso9660 -o %s %s" % (dev, tmp))
             self.assertEqual(ret, 0)
             self.udev_settle()
+            # give udisks chance to probe the filesystem
+            time.sleep(1)
         finally:
             shutil.rmtree(tmp)
 


### PR DESCRIPTION
ISO9660	format creation is done outside of udisks and while we let udev
to settle it still takes a moment for udisks to finish probing the new
filesystem. As a result occassional test failures were observed as a timing
issue.