### PR TITLE
split out get_user_info from get_caller_uid_sync

### DIFF
--- a/modules/lvm2/udiskslinuxlogicalvolume.c
+++ b/modules/lvm2/udiskslinuxlogicalvolume.c
@@ -362,8 +362,7 @@ common_setup (UDisksLinuxLogicalVolume           *volume,
               const gchar                        *auth_err_msg,
               UDisksLinuxLogicalVolumeObject    **object,
               UDisksDaemon                      **daemon,
-              uid_t                              *out_uid,
-              gid_t                              *out_gid)
+              uid_t                              *out_uid)
 {
   gboolean rc = FALSE;
   GError *error = NULL;
@@ -381,8 +380,6 @@ common_setup (UDisksLinuxLogicalVolume           *volume,
                                                invocation,
                                                NULL /* GCancellable */,
                                                out_uid,
-                                               out_gid,
-                                               NULL,
                                                &error))
     {
       g_dbus_method_invocation_return_gerror (invocation, error);
@@ -421,7 +418,7 @@ handle_delete (UDisksLogicalVolume   *_volume,
 
   if (!common_setup (volume, invocation, options,
                      N_("Authentication is required to delete a logical volume"),
-                     &object, &daemon, &caller_uid, NULL))
+                     &object, &daemon, &caller_uid))
     goto out;
 
   if (teardown_flag &&
@@ -533,7 +530,7 @@ handle_rename (UDisksLogicalVolume   *_volume,
 
   if (!common_setup (volume, invocation, options,
                      N_("Authentication is required to rename a logical volume"),
-                     &object, &daemon, &caller_uid, NULL))
+                     &object, &daemon, &caller_uid))
     goto out;
 
   group_object = udisks_linux_logical_volume_object_get_volume_group (object);
@@ -594,7 +591,7 @@ handle_resize (UDisksLogicalVolume   *_volume,
 
   if (!common_setup (volume, invocation, options,
                      N_("Authentication is required to resize a logical volume"),
-                     &object, &daemon, &caller_uid, NULL))
+                     &object, &daemon, &caller_uid))
     goto out;
 
   group_object = udisks_linux_logical_volume_object_get_volume_group (object);
@@ -687,7 +684,7 @@ handle_activate (UDisksLogicalVolume *_volume,
 
   if (!common_setup (volume, invocation, options,
                      N_("Authentication is required to activate a logical volume"),
-                     &object, &daemon, &caller_uid, NULL))
+                     &object, &daemon, &caller_uid))
     goto out;
 
   group_object = udisks_linux_logical_volume_object_get_volume_group (object);
@@ -754,7 +751,7 @@ handle_deactivate (UDisksLogicalVolume   *_volume,
 
   if (!common_setup (volume, invocation, options,
                      N_("Authentication is required to deactivate a logical volume"),
-                     &object, &daemon, &caller_uid, NULL))
+                     &object, &daemon, &caller_uid))
     goto out;
 
   group_object = udisks_linux_logical_volume_object_get_volume_group (object);
@@ -820,7 +817,7 @@ handle_create_snapshot (UDisksLogicalVolume   *_volume,
 
   if (!common_setup (volume, invocation, options,
                      N_("Authentication is required to create a snapshot of a logical volume"),
-                     &object, &daemon, &caller_uid, NULL))
+                     &object, &daemon, &caller_uid))
     goto out;
 
   group_object = udisks_linux_logical_volume_object_get_volume_group (object);
@@ -890,7 +887,7 @@ handle_cache_attach (UDisksLogicalVolume   *volume_,
 
   if (!common_setup (volume, invocation, options,
                      N_("Authentication is required to convert logical volume to cache"),
-                     &object, &daemon, &caller_uid, NULL))
+                     &object, &daemon, &caller_uid))
     goto out;
 
   group_object = udisks_linux_logical_volume_object_get_volume_group (object);
@@ -952,7 +949,7 @@ handle_cache_detach_or_split (UDisksLogicalVolume  *volume_,
 
   if (!common_setup (volume, invocation, options,
                      N_("Authentication is required to split cache pool LV off of a cache LV"),
-                     &object, &daemon, &caller_uid, NULL))
+                     &object, &daemon, &caller_uid))
     goto out;
 
   group_object = udisks_linux_logical_volume_object_get_volume_group (object);

--- a/modules/lvm2/udiskslinuxmanagerlvm2.c
+++ b/modules/lvm2/udiskslinuxmanagerlvm2.c
@@ -220,7 +220,7 @@ handle_volume_group_create (UDisksManagerLVM2     *_object,
   VGJobData data;
 
   error = NULL;
-  if (!udisks_daemon_util_get_caller_uid_sync (manager->daemon, invocation, NULL /* GCancellable */, &caller_uid, NULL, NULL, &error))
+  if (!udisks_daemon_util_get_caller_uid_sync (manager->daemon, invocation, NULL /* GCancellable */, &caller_uid, &error))
     {
       g_dbus_method_invocation_return_gerror (invocation, error);
       g_clear_error (&error);

--- a/modules/lvm2/udiskslinuxvolumegroup.c
+++ b/modules/lvm2/udiskslinuxvolumegroup.c
@@ -249,7 +249,6 @@ handle_delete (UDisksVolumeGroup     *_group,
   UDisksLinuxVolumeGroupObject *object = NULL;
   UDisksDaemon *daemon;
   uid_t caller_uid;
-  gid_t caller_gid;
   gboolean teardown_flag = FALSE;
   GList *objects_to_wipe = NULL;
   GList *l;
@@ -286,8 +285,6 @@ handle_delete (UDisksVolumeGroup     *_group,
                                                invocation,
                                                NULL /* GCancellable */,
                                                &caller_uid,
-                                               &caller_gid,
-                                               NULL,
                                                &error))
     {
       g_dbus_method_invocation_return_gerror (invocation, error);
@@ -371,7 +368,6 @@ handle_rename (UDisksVolumeGroup     *_group,
   UDisksLinuxVolumeGroupObject *object = NULL;
   UDisksDaemon *daemon;
   uid_t caller_uid;
-  gid_t caller_gid;
   UDisksObject *group_object = NULL;
   VGJobData data;
 
@@ -388,8 +384,6 @@ handle_rename (UDisksVolumeGroup     *_group,
                                                invocation,
                                                NULL /* GCancellable */,
                                                &caller_uid,
-                                               &caller_gid,
-                                               NULL,
                                                &error))
     {
       g_dbus_method_invocation_return_gerror (invocation, error);
@@ -462,7 +456,6 @@ handle_add_device (UDisksVolumeGroup     *_group,
   UDisksDaemon *daemon;
   UDisksLinuxVolumeGroupObject *object;
   uid_t caller_uid;
-  gid_t caller_gid;
   GError *error = NULL;
   UDisksObject *new_member_device_object = NULL;
   UDisksBlock *new_member_device = NULL;
@@ -483,8 +476,6 @@ handle_add_device (UDisksVolumeGroup     *_group,
                                                invocation,
                                                NULL /* GCancellable */,
                                                &caller_uid,
-                                               &caller_gid,
-                                               NULL,
                                                &error))
     {
       g_dbus_method_invocation_return_gerror (invocation, error);
@@ -598,7 +589,6 @@ handle_remove_common (UDisksVolumeGroup     *_group,
   UDisksDaemon *daemon;
   UDisksLinuxVolumeGroupObject *object;
   uid_t caller_uid;
-  gid_t caller_gid;
   GError *error = NULL;
   UDisksObject *member_device_object = NULL;
   UDisksBlock *member_device = NULL;
@@ -638,8 +628,6 @@ handle_remove_common (UDisksVolumeGroup     *_group,
                                                invocation,
                                                NULL /* GCancellable */,
                                                &caller_uid,
-                                               &caller_gid,
-                                               NULL,
                                                &error))
     {
       g_dbus_method_invocation_return_gerror (invocation, error);
@@ -812,7 +800,6 @@ handle_create_volume (UDisksVolumeGroup              *_group,
   UDisksLinuxVolumeGroupObject *object = NULL;
   UDisksDaemon *daemon;
   uid_t caller_uid;
-  gid_t caller_gid;
   const gchar *lv_objpath;
   LVJobData data;
   UDisksLinuxLogicalVolumeObject *pool_object = NULL;
@@ -852,8 +839,6 @@ handle_create_volume (UDisksVolumeGroup              *_group,
                                                invocation,
                                                NULL /* GCancellable */,
                                                &caller_uid,
-                                               &caller_gid,
-                                               NULL,
                                                &error))
     {
       g_dbus_method_invocation_return_gerror (invocation, error);

--- a/modules/vdo/udiskslinuxblockvdo.c
+++ b/modules/vdo/udiskslinuxblockvdo.c
@@ -302,7 +302,6 @@ check_pk_auth (UDisksBlockVDO        *block_vdo,
                                                 invocation,
                                                 NULL /* GCancellable */,
                                                 &caller_uid,
-                                                NULL, NULL,
                                                 &error))
     {
       g_dbus_method_invocation_take_error (invocation, error);

--- a/modules/vdo/udiskslinuxmanagervdo.c
+++ b/modules/vdo/udiskslinuxmanagervdo.c
@@ -264,7 +264,6 @@ handle_create_volume (UDisksManagerVDO      *manager,
                                                 invocation,
                                                 NULL /* GCancellable */,
                                                 &caller_uid,
-                                                NULL, NULL,
                                                 &error))
     {
       g_dbus_method_invocation_take_error (invocation, error);
@@ -409,7 +408,6 @@ handle_start_volume_by_name (UDisksManagerVDO      *manager,
                                                 invocation,
                                                 NULL /* GCancellable */,
                                                 &caller_uid,
-                                                NULL, NULL,
                                                 &error))
     {
       g_dbus_method_invocation_take_error (invocation, error);

--- a/src/udisksbasejob.c
+++ b/src/udisksbasejob.c
@@ -367,7 +367,6 @@ handle_cancel (UDisksJob              *_job,
   const gchar *action_id;
   const gchar *message;
   uid_t caller_uid;
-  gid_t caller_gid;
   GError *error = NULL;
 
   object = udisks_daemon_util_dup_object (job, &error);
@@ -381,8 +380,6 @@ handle_cancel (UDisksJob              *_job,
                                                invocation,
                                                NULL /* GCancellable */,
                                                &caller_uid,
-                                               &caller_gid,
-                                               NULL,
                                                &error))
     {
       g_dbus_method_invocation_take_error (invocation, error);

--- a/src/udisksdaemonutil.h
+++ b/src/udisksdaemonutil.h
@@ -79,12 +79,15 @@ gboolean udisks_daemon_util_check_authorization_sync_with_error (UDisksDaemon   
                                                                  GDBusMethodInvocation  *invocation,
                                                                  GError                **error);
 
+gboolean udisks_daemon_util_get_user_info (const uid_t   uid,
+                                           gid_t        *out_gid,
+                                           gchar       **out_user_name,
+                                           GError      **error);
+
 gboolean udisks_daemon_util_get_caller_uid_sync (UDisksDaemon            *daemon,
                                                  GDBusMethodInvocation   *invocation,
                                                  GCancellable            *cancellable,
                                                  uid_t                   *out_uid,
-                                                 gid_t                   *out_gid,
-                                                 gchar                  **out_user_name,
                                                  GError                 **error);
 
 gboolean udisks_daemon_util_get_caller_pid_sync (UDisksDaemon            *daemon,

--- a/src/udiskslinuxblock.c
+++ b/src/udiskslinuxblock.c
@@ -2991,7 +2991,14 @@ udisks_linux_block_handle_format (UDisksBlock             *block,
     }
 
   error = NULL;
-  if (!udisks_daemon_util_get_caller_uid_sync (daemon, invocation, NULL /* GCancellable */, &caller_uid, &caller_gid, NULL, &error))
+  if (!udisks_daemon_util_get_caller_uid_sync (daemon, invocation, NULL /* GCancellable */, &caller_uid, &error))
+    {
+      g_dbus_method_invocation_return_gerror (invocation, error);
+      g_clear_error (&error);
+      goto out;
+    }
+
+  if (!udisks_daemon_util_get_user_info (caller_uid, &caller_gid, NULL /* user name */, &error))
     {
       g_dbus_method_invocation_return_gerror (invocation, error);
       g_clear_error (&error);

--- a/src/udiskslinuxdrive.c
+++ b/src/udiskslinuxdrive.c
@@ -965,7 +965,6 @@ handle_eject (UDisksDrive           *_drive,
   GError *error = NULL;
   gchar *escaped_device = NULL;
   uid_t caller_uid;
-  gid_t caller_gid;
 
   object = udisks_daemon_util_dup_object (drive, &error);
   if (object == NULL)
@@ -999,8 +998,6 @@ handle_eject (UDisksDrive           *_drive,
                                                invocation,
                                                NULL /* GCancellable */,
                                                &caller_uid,
-                                               &caller_gid,
-                                               NULL,
                                                &error))
     {
       g_dbus_method_invocation_return_gerror (invocation, error);
@@ -1344,7 +1341,6 @@ handle_power_off (UDisksDrive           *_drive,
   GError *error = NULL;
   gchar *escaped_device = NULL;
   uid_t caller_uid;
-  gid_t caller_gid;
   GList *sibling_objects = NULL, *l;
   gint fd = -1;
 
@@ -1403,8 +1399,6 @@ handle_power_off (UDisksDrive           *_drive,
                                                invocation,
                                                NULL /* GCancellable */,
                                                &caller_uid,
-                                               &caller_gid,
-                                               NULL,
                                                &error))
     {
       g_dbus_method_invocation_return_gerror (invocation, error);

--- a/src/udiskslinuxdriveata.c
+++ b/src/udiskslinuxdriveata.c
@@ -1143,7 +1143,6 @@ handle_smart_selftest_start (UDisksDriveAta        *_drive,
   UDisksDaemon *daemon;
   UDisksLinuxDriveAta *drive = UDISKS_LINUX_DRIVE_ATA (_drive);
   uid_t caller_uid;
-  gid_t caller_gid;
   GError *error;
 
   error = NULL;
@@ -1180,8 +1179,6 @@ handle_smart_selftest_start (UDisksDriveAta        *_drive,
                                                invocation,
                                                NULL /* GCancellable */,
                                                &caller_uid,
-                                               &caller_gid,
-                                               NULL,
                                                &error))
     {
       g_dbus_method_invocation_return_gerror (invocation, error);
@@ -1388,8 +1385,6 @@ handle_pm_standby_wakeup (UDisksDriveAta        *_drive,
                                                invocation,
                                                NULL /* GCancellable */,
                                                &caller_uid,
-                                               NULL,
-                                               NULL,
                                                &error))
     {
       g_dbus_method_invocation_return_gerror (invocation, error);
@@ -2205,7 +2200,6 @@ handle_security_erase_unit (UDisksDriveAta        *_drive,
   const gchar *message;
   const gchar *action_id;
   uid_t caller_uid;
-  gid_t caller_gid;
   gboolean enhanced = FALSE;
 
   object = udisks_daemon_util_dup_object (drive, &error);
@@ -2232,8 +2226,6 @@ handle_security_erase_unit (UDisksDriveAta        *_drive,
                                                invocation,
                                                NULL /* GCancellable */,
                                                &caller_uid,
-                                               &caller_gid,
-                                               NULL,
                                                &error))
     {
       g_dbus_method_invocation_return_gerror (invocation, error);
@@ -2294,7 +2286,6 @@ handle_smart_set_enabled (UDisksDriveAta        *_drive,
   const gchar *message;
   const gchar *action_id;
   uid_t caller_uid;
-  gid_t caller_gid;
 
   object = udisks_daemon_util_dup_object (drive, &error);
   if (object == NULL)
@@ -2320,8 +2311,6 @@ handle_smart_set_enabled (UDisksDriveAta        *_drive,
                                                invocation,
                                                NULL /* GCancellable */,
                                                &caller_uid,
-                                               &caller_gid,
-                                               NULL,
                                                &error))
     {
       g_dbus_method_invocation_return_gerror (invocation, error);

--- a/src/udiskslinuxencrypted.c
+++ b/src/udiskslinuxencrypted.c
@@ -432,7 +432,7 @@ handle_unlock (UDisksEncrypted        *encrypted,
 
   /* we need the uid of the caller for the unlocked-crypto-dev file */
   error = NULL;
-  if (!udisks_daemon_util_get_caller_uid_sync (daemon, invocation, NULL /* GCancellable */, &caller_uid, NULL, NULL, &error))
+  if (!udisks_daemon_util_get_caller_uid_sync (daemon, invocation, NULL /* GCancellable */, &caller_uid, &error))
     {
       g_dbus_method_invocation_return_gerror (invocation, error);
       g_clear_error (&error);
@@ -723,8 +723,6 @@ udisks_linux_encrypted_lock (UDisksLinuxEncrypted   *encrypted,
                                                invocation,
                                                NULL /* GCancellable */,
                                                &caller_uid,
-                                               NULL,
-                                               NULL,
                                                error))
     {
       ret = FALSE;
@@ -886,7 +884,7 @@ handle_change_passphrase (UDisksEncrypted        *encrypted,
     }
 
   error = NULL;
-  if (!udisks_daemon_util_get_caller_uid_sync (daemon, invocation, NULL /* GCancellable */, &caller_uid, NULL, NULL, &error))
+  if (!udisks_daemon_util_get_caller_uid_sync (daemon, invocation, NULL /* GCancellable */, &caller_uid, &error))
     {
       g_dbus_method_invocation_return_gerror (invocation, error);
       g_clear_error (&error);
@@ -1005,7 +1003,7 @@ handle_resize (UDisksEncrypted       *encrypted,
     }
 
   error = NULL;
-  if (!udisks_daemon_util_get_caller_uid_sync (daemon, invocation, NULL /* GCancellable */, &caller_uid, NULL, NULL, &error))
+  if (!udisks_daemon_util_get_caller_uid_sync (daemon, invocation, NULL /* GCancellable */, &caller_uid, &error))
     {
       g_dbus_method_invocation_return_gerror (invocation, error);
       g_clear_error (&error);

--- a/src/udiskslinuxfilesystem.c
+++ b/src/udiskslinuxfilesystem.c
@@ -1358,9 +1358,14 @@ handle_mount (UDisksFilesystem      *filesystem,
                                                invocation,
                                                NULL /* GCancellable */,
                                                &caller_uid,
-                                               &caller_gid,
-                                               &caller_user_name,
                                                &error))
+    {
+      g_dbus_method_invocation_return_gerror (invocation, error);
+      g_clear_error (&error);
+      goto out;
+    }
+
+  if (!udisks_daemon_util_get_user_info (caller_uid, &caller_gid, &caller_user_name, &error))
     {
       g_dbus_method_invocation_return_gerror (invocation, error);
       g_clear_error (&error);
@@ -1731,7 +1736,7 @@ handle_unmount (UDisksFilesystem      *filesystem,
     }
 
   error = NULL;
-  if (!udisks_daemon_util_get_caller_uid_sync (daemon, invocation, NULL, &caller_uid, NULL, NULL, &error))
+  if (!udisks_daemon_util_get_caller_uid_sync (daemon, invocation, NULL, &caller_uid, &error))
     {
       g_dbus_method_invocation_return_gerror (invocation, error);
       g_clear_error (&error);
@@ -1917,7 +1922,6 @@ handle_set_label (UDisksFilesystem      *filesystem,
   const gchar *message;
   gchar *real_label = NULL;
   uid_t caller_uid;
-  gid_t caller_gid;
   gchar *command;
   gint status = 0;
   gchar *out_message = NULL;
@@ -1945,8 +1949,6 @@ handle_set_label (UDisksFilesystem      *filesystem,
                                                invocation,
                                                NULL /* GCancellable */,
                                                &caller_uid,
-                                               &caller_gid,
-                                               NULL,
                                                &error))
     {
       g_dbus_method_invocation_return_gerror (invocation, error);
@@ -2121,7 +2123,6 @@ handle_resize (UDisksFilesystem      *filesystem,
   const gchar *action_id = NULL;
   const gchar *message = NULL;
   uid_t caller_uid;
-  gid_t caller_gid;
   GError *error = NULL;
   UDisksBaseJob *job = NULL;
   gchar *required_utility = NULL;
@@ -2143,8 +2144,6 @@ handle_resize (UDisksFilesystem      *filesystem,
                                                 invocation,
                                                 NULL /* GCancellable */,
                                                 &caller_uid,
-                                                &caller_gid,
-                                                NULL,
                                                 &error))
     {
       g_dbus_method_invocation_return_gerror (invocation, error);
@@ -2289,7 +2288,6 @@ handle_repair (UDisksFilesystem      *filesystem,
   const gchar *action_id = NULL;
   const gchar *message = NULL;
   uid_t caller_uid;
-  gid_t caller_gid;
   GError *error = NULL;
   gboolean ret = FALSE;
   UDisksBaseJob *job = NULL;
@@ -2312,8 +2310,6 @@ handle_repair (UDisksFilesystem      *filesystem,
                                                 invocation,
                                                 NULL /* GCancellable */,
                                                 &caller_uid,
-                                                &caller_gid,
-                                                NULL,
                                                 &error))
     {
       g_dbus_method_invocation_return_gerror (invocation, error);
@@ -2449,7 +2445,6 @@ handle_check (UDisksFilesystem      *filesystem,
   const gchar *action_id = NULL;
   const gchar *message = NULL;
   uid_t caller_uid;
-  gid_t caller_gid;
   GError *error = NULL;
   gboolean ret = FALSE;
   UDisksBaseJob *job = NULL;
@@ -2472,8 +2467,6 @@ handle_check (UDisksFilesystem      *filesystem,
                                                 invocation,
                                                 NULL /* GCancellable */,
                                                 &caller_uid,
-                                                &caller_gid,
-                                                NULL,
                                                 &error))
     {
       g_dbus_method_invocation_return_gerror (invocation, error);
@@ -2631,11 +2624,16 @@ handle_take_ownership (UDisksFilesystem      *filesystem,
                                                 invocation,
                                                 NULL /* GCancellable */,
                                                 &caller_uid,
-                                                &caller_gid,
-                                                NULL,
                                                 &error))
     {
       g_dbus_method_invocation_return_gerror (invocation, error);
+      goto out;
+    }
+
+  if (!udisks_daemon_util_get_user_info (caller_uid, &caller_gid, NULL /* user name */, &error))
+    {
+      g_dbus_method_invocation_return_gerror (invocation, error);
+      g_clear_error (&error);
       goto out;
     }
 

--- a/src/udiskslinuxloop.c
+++ b/src/udiskslinuxloop.c
@@ -220,7 +220,7 @@ handle_delete (UDisksLoop            *loop,
   state = udisks_daemon_get_state (daemon);
 
   error = NULL;
-  if (!udisks_daemon_util_get_caller_uid_sync (daemon, invocation, NULL, &caller_uid, NULL, NULL, &error))
+  if (!udisks_daemon_util_get_caller_uid_sync (daemon, invocation, NULL, &caller_uid, &error))
     {
       g_dbus_method_invocation_return_gerror (invocation, error);
       g_clear_error (&error);
@@ -316,7 +316,7 @@ handle_set_autoclear (UDisksLoop             *loop,
   daemon = udisks_linux_block_object_get_daemon (UDISKS_LINUX_BLOCK_OBJECT (object));
 
   error = NULL;
-  if (!udisks_daemon_util_get_caller_uid_sync (daemon, invocation, NULL, &caller_uid, NULL, NULL, &error))
+  if (!udisks_daemon_util_get_caller_uid_sync (daemon, invocation, NULL, &caller_uid, &error))
     {
       g_dbus_method_invocation_return_gerror (invocation, error);
       g_clear_error (&error);

--- a/src/udiskslinuxmanager.c
+++ b/src/udiskslinuxmanager.c
@@ -323,7 +323,7 @@ handle_loop_setup (UDisksManager          *object,
 
   /* we need the uid of the caller for the loop file */
   error = NULL;
-  if (!udisks_daemon_util_get_caller_uid_sync (manager->daemon, invocation, NULL /* GCancellable */, &caller_uid, NULL, NULL, &error))
+  if (!udisks_daemon_util_get_caller_uid_sync (manager->daemon, invocation, NULL /* GCancellable */, &caller_uid, &error))
     {
       g_dbus_method_invocation_return_gerror (invocation, error);
       g_clear_error (&error);
@@ -522,7 +522,6 @@ handle_mdraid_create (UDisksManager         *_object,
                                                invocation,
                                                NULL /* GCancellable */,
                                                &caller_uid,
-                                               NULL, NULL,
                                                &error))
     {
       g_dbus_method_invocation_return_gerror (invocation, error);

--- a/src/udiskslinuxmdraid.c
+++ b/src/udiskslinuxmdraid.c
@@ -588,7 +588,6 @@ handle_start (UDisksMDRaid           *_mdraid,
   const gchar *action_id;
   const gchar *message;
   uid_t caller_uid;
-  gid_t caller_gid;
   UDisksLinuxDevice *raid_device = NULL;
   GList *member_devices = NULL;
   gchar *raid_device_file = NULL;
@@ -618,8 +617,6 @@ handle_start (UDisksMDRaid           *_mdraid,
                                                invocation,
                                                NULL /* GCancellable */,
                                                &caller_uid,
-                                               &caller_gid,
-                                               NULL,
                                                &error))
     {
       g_dbus_method_invocation_return_gerror (invocation, error);
@@ -760,7 +757,6 @@ udisks_linux_mdraid_stop (UDisksMDRaid           *_mdraid,
   UDisksLinuxMDRaidObject *object;
   uid_t started_by_uid;
   uid_t caller_uid;
-  gid_t caller_gid;
   UDisksLinuxDevice *raid_device = NULL;
   UDisksBaseJob *job = NULL;
   const gchar *device_file = NULL;
@@ -780,8 +776,6 @@ udisks_linux_mdraid_stop (UDisksMDRaid           *_mdraid,
                                                invocation,
                                                NULL /* GCancellable */,
                                                &caller_uid,
-                                               &caller_gid,
-                                               NULL,
                                                error))
     {
       ret = FALSE;
@@ -958,7 +952,6 @@ handle_remove_device (UDisksMDRaid           *_mdraid,
   const gchar *message;
   uid_t started_by_uid;
   uid_t caller_uid;
-  gid_t caller_gid;
   UDisksLinuxDevice *raid_device = NULL;
   const gchar *device_file = NULL;
   const gchar *member_device_file = NULL;
@@ -987,8 +980,6 @@ handle_remove_device (UDisksMDRaid           *_mdraid,
                                                invocation,
                                                NULL /* GCancellable */,
                                                &caller_uid,
-                                               &caller_gid,
-                                               NULL,
                                                &error))
     {
       g_dbus_method_invocation_return_gerror (invocation, error);
@@ -1124,7 +1115,6 @@ handle_add_device (UDisksMDRaid           *_mdraid,
   const gchar *message;
   uid_t started_by_uid;
   uid_t caller_uid;
-  gid_t caller_gid;
   UDisksLinuxDevice *raid_device = NULL;
   const gchar *device_file = NULL;
   const gchar *new_member_device_file = NULL;
@@ -1148,8 +1138,6 @@ handle_add_device (UDisksMDRaid           *_mdraid,
                                                invocation,
                                                NULL /* GCancellable */,
                                                &caller_uid,
-                                               &caller_gid,
-                                               NULL,
                                                &error))
     {
       g_dbus_method_invocation_return_gerror (invocation, error);
@@ -1258,7 +1246,6 @@ handle_set_bitmap_location (UDisksMDRaid           *_mdraid,
   const gchar *message;
   uid_t started_by_uid;
   uid_t caller_uid;
-  gid_t caller_gid;
   UDisksLinuxDevice *raid_device = NULL;
   const gchar *device_file = NULL;
   GError *error = NULL;
@@ -1279,8 +1266,6 @@ handle_set_bitmap_location (UDisksMDRaid           *_mdraid,
                                                invocation,
                                                NULL /* GCancellable */,
                                                &caller_uid,
-                                               &caller_gid,
-                                               NULL,
                                                &error))
     {
       g_dbus_method_invocation_return_gerror (invocation, error);
@@ -1378,7 +1363,6 @@ handle_request_sync_action (UDisksMDRaid           *_mdraid,
   const gchar *message;
   uid_t started_by_uid;
   uid_t caller_uid;
-  gid_t caller_gid;
   UDisksLinuxDevice *raid_device = NULL;
   GError *error = NULL;
   const gchar *device_file = NULL;
@@ -1399,8 +1383,6 @@ handle_request_sync_action (UDisksMDRaid           *_mdraid,
                                                invocation,
                                                NULL /* GCancellable */,
                                                &caller_uid,
-                                               &caller_gid,
-                                               NULL,
                                                &error))
     {
       g_dbus_method_invocation_return_gerror (invocation, error);
@@ -1494,7 +1476,6 @@ udisks_linux_mdraid_delete (UDisksMDRaid           *mdraid,
   UDisksLinuxMDRaidObject *object;
   UDisksDaemon *daemon;
   uid_t caller_uid;
-  gid_t caller_gid;
   const gchar *message;
   const gchar *action_id;
   gboolean teardown_flag = FALSE;
@@ -1521,8 +1502,6 @@ udisks_linux_mdraid_delete (UDisksMDRaid           *mdraid,
                                                invocation,
                                                NULL /* GCancellable */,
                                                &caller_uid,
-                                               &caller_gid,
-                                               NULL,
                                                error))
     {
       ret = FALSE;

--- a/src/udiskslinuxpartition.c
+++ b/src/udiskslinuxpartition.c
@@ -132,8 +132,6 @@ check_authorization (UDisksPartition       *partition,
                                                invocation,
                                                NULL /* GCancellable */,
                                                caller_uid,
-                                               NULL,
-                                               NULL,
                                                &error))
     {
       g_dbus_method_invocation_return_gerror (invocation, error);

--- a/src/udiskslinuxpartitiontable.c
+++ b/src/udiskslinuxpartitiontable.c
@@ -268,7 +268,6 @@ udisks_linux_partition_table_handle_create_partition (UDisksPartitionTable   *ta
   BDPartTypeReq part_type = 0;
   gchar *table_type = NULL;
   uid_t caller_uid;
-  gid_t caller_gid;
   GError *error = NULL;
   UDisksBaseJob *job = NULL;
   gchar *partition_type = NULL;
@@ -297,8 +296,6 @@ udisks_linux_partition_table_handle_create_partition (UDisksPartitionTable   *ta
                                                invocation,
                                                NULL /* GCancellable */,
                                                &caller_uid,
-                                               &caller_gid,
-                                               NULL,
                                                &error))
     {
       g_dbus_method_invocation_return_gerror (invocation, error);

--- a/src/udiskslinuxswapspace.c
+++ b/src/udiskslinuxswapspace.c
@@ -164,7 +164,6 @@ handle_start (UDisksSwapspace        *swapspace,
   UDisksDaemon *daemon;
   GError *error = NULL;
   uid_t caller_uid;
-  gid_t caller_gid;
 
   object = udisks_daemon_util_dup_object (swapspace, &error);
   if (object == NULL)
@@ -179,8 +178,6 @@ handle_start (UDisksSwapspace        *swapspace,
                                                invocation,
                                                NULL /* GCancellable */,
                                                &caller_uid,
-                                               &caller_gid,
-                                               NULL,
                                                &error))
     {
       g_dbus_method_invocation_return_gerror (invocation, error);
@@ -259,7 +256,6 @@ handle_stop (UDisksSwapspace        *swapspace,
   UDisksObject *object;
   UDisksDaemon *daemon;
   uid_t caller_uid;
-  gid_t caller_gid;
   GError *error = NULL;
 
   object = UDISKS_OBJECT (g_dbus_interface_get_object (G_DBUS_INTERFACE (swapspace)));
@@ -270,8 +266,6 @@ handle_stop (UDisksSwapspace        *swapspace,
                                                invocation,
                                                NULL /* GCancellable */,
                                                &caller_uid,
-                                               &caller_gid,
-                                               NULL,
                                                &error))
     {
       g_dbus_method_invocation_return_gerror (invocation, error);
@@ -334,7 +328,6 @@ handle_set_label (UDisksSwapspace        *swapspace,
   GError *error = NULL;
   UDisksBlock *block = NULL;
   uid_t caller_uid;
-  gid_t caller_gid;
 
   object = UDISKS_OBJECT (g_dbus_interface_get_object (G_DBUS_INTERFACE (swapspace)));
   daemon = udisks_linux_block_object_get_daemon (UDISKS_LINUX_BLOCK_OBJECT (object));
@@ -344,8 +337,6 @@ handle_set_label (UDisksSwapspace        *swapspace,
                                                invocation,
                                                NULL /* GCancellable */,
                                                &caller_uid,
-                                               &caller_gid,
-                                               NULL,
                                                &error))
     {
       g_dbus_method_invocation_return_gerror (invocation, error);


### PR DESCRIPTION
Previously, the function was lying. It didn't return the actual group of
the caller, but the default group associated with the user configured in
/etc/passwd (or equivalents).

I first wanted to change the function to return the gid of the caller. The problem there is that glib doesn't provide any way to do that - one can get a [`GCredentials`](https://developer.gnome.org/gio/stable/GCredentials.html) for the caller through a long chain of function calls, but this doesn't actually contain a group id, except through the platform-dependent return value of `get_native`.

I don't believe there's any problem with using the gid configured in passwd instead of the caller for the file system permissions like the current code does, but since this was a generic utility function that might (or might not) be used in the future for all kinds of other things, I believe splitting things up like this is a good idea to prevent future misuse.

There were also quite a few callers asking for a gid without ever using it, so this is a bit of an optimization, too. (Fewer calls to `getpwuid_r`, which can be a network call.)