### PR TITLE
udiskslinuxfilesystem: Trigger uevent after resize

### DIFF
--- a/src/udiskslinuxfilesystem.c
+++ b/src/udiskslinuxfilesystem.c
@@ -2261,6 +2261,10 @@ handle_resize (UDisksFilesystem      *filesystem,
       goto out;
     }
 
+  /* At least resize2fs might need another uevent after it is done.
+   */
+  udisks_linux_block_object_trigger_uevent (UDISKS_LINUX_BLOCK_OBJECT (object));
+
   udisks_filesystem_complete_resize (filesystem, invocation);
   udisks_simple_job_complete (UDISKS_SIMPLE_JOB (job), TRUE, NULL);
 


### PR DESCRIPTION
I don't have the full theory for why this is necessary, but I can see failures without this in the Cockpit integration tests.

What seems to happen is that resize2fs opens and closes the block device twice, which normally generates two "change" events.  Thus, UDisks2 runs dumpe2fs twice: once too early (which might give the old size, or the new size, or even fail with a superblock checksum mismatch), and then again after the resize is done (which gives the correct size).

However, sometimes processing for the first event is still ongoing when the second event should happen, and the second event is dropped.