### PR TITLE
build: Migrate from intltool to gettext

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,7 +60,6 @@ doc/udisks2.interfaces
 doc/udisks2.prerequisites
 doc/*.signals
 gtk-doc.make
-intltool-*
 libtool
 m4/
 po/POTFILES

--- a/autogen.sh
+++ b/autogen.sh
@@ -1,18 +1,33 @@
 #!/bin/sh
 # Run this to generate all the initial makefiles, etc.
+test -n "$srcdir" || srcdir=$(dirname "$0")
+test -n "$srcdir" || srcdir=.
 
-srcdir=`dirname $0`
-test -z "$srcdir" && srcdir=.
+olddir=$(pwd)
 
-(test -f $srcdir/src/Makefile.am) || {
+cd "$srcdir"
+
+(test -f configure.ac) || {
     echo -n "**Error**: Directory "\`$srcdir\'" does not look like the"
-    echo " top-level $PKG_NAME directory"
+    echo " top-level project directory"
     exit 1
 }
 
-which gnome-autogen.sh || {
-    echo "You need to install gnome-common"
-    exit 1
-}
+PKG_NAME=$(autoconf --trace 'AC_INIT:$1' configure.ac)
 
-. gnome-autogen.sh --enable-gtk-doc "$@"
+gtkdocize --copy || exit 1
+autoreconf --verbose --force --install || exit 1
+
+cd "$olddir"
+
+if [ "$NOCONFIGURE" = "" ]; then
+        $srcdir/configure --enable-gtk-doc "$@" || exit 1
+
+        if [ "$1" = "--help" ]; then
+                exit 0
+        else
+                echo "Now type 'make' to compile $PKG_NAME" || exit 1
+        fi
+else
+        echo "Skipping configure process."
+fi

--- a/configure.ac
+++ b/configure.ac
@@ -37,8 +37,6 @@ AC_PROG_LIBTOOL
 # Compilation
 #
 
-GNOME_COMPILE_WARNINGS([maximum])
-
 CC_CHECK_CFLAGS_APPEND([                          \
         -Wall                                     \
         -W                                        \
@@ -654,10 +652,11 @@ fi
 # Internationalization
 #
 
-IT_PROG_INTLTOOL([$INTLTOOL_REQUIRED])
+AM_GNU_GETTEXT_VERSION([0.19.8])
+AM_GNU_GETTEXT([external])
+
 GETTEXT_PACKAGE=udisks2
 AC_SUBST([GETTEXT_PACKAGE])
-AM_GLIB_GNU_GETTEXT
 AC_DEFINE_UNQUOTED([GETTEXT_PACKAGE],["$GETTEXT_PACKAGE"],[gettext domain])
 
 AC_DEFINE([PROJECT_SYSCONF_DIR], ["udisks2"], [Project configuration directory])

--- a/data/Makefile.am
+++ b/data/Makefile.am
@@ -32,12 +32,13 @@ polkitdir        = $(datadir)/polkit-1/actions
 polkit_in_files  = org.freedesktop.UDisks2.policy.in
 polkit_DATA      = $(polkit_in_files:.policy.in=.policy)
 
+$(polkit_DATA): $(polkit_in_files)
+	$(AM_V_GEN) $(MSGFMT) --xml --template $< -d $(top_srcdir)/po -o $@
+
 completionsdir = $(datadir)/bash-completion/completions
 completions_DATA =                                                             \
 	completions/udisksctl                                                  \
 	$(NULL)
-
-@INTLTOOL_POLICY_RULE@
 
 EXTRA_DIST =                                                                   \
 	80-udisks2.rules                                                       \

--- a/data/org.freedesktop.UDisks2.policy.in
+++ b/data/org.freedesktop.UDisks2.policy.in
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <!DOCTYPE policyconfig PUBLIC
  "-//freedesktop//DTD PolicyKit Policy Configuration 1.0//EN"
@@ -13,8 +13,8 @@
   <!-- Mounting filesystems -->
 
   <action id="org.freedesktop.udisks2.filesystem-mount">
-    <_description>Mount a filesystem</_description>
-    <_message>Authentication is required to mount the filesystem</_message>
+    <description>Mount a filesystem</description>
+    <message>Authentication is required to mount the filesystem</message>
     <defaults>
       <allow_any>auth_admin</allow_any>
       <allow_inactive>auth_admin</allow_inactive>
@@ -24,8 +24,8 @@
 
   <!-- mount a device considered a "system device" -->
   <action id="org.freedesktop.udisks2.filesystem-mount-system">
-    <_description>Mount a filesystem on a system device</_description>
-    <_message>Authentication is required to mount the filesystem</_message>
+    <description>Mount a filesystem on a system device</description>
+    <message>Authentication is required to mount the filesystem</message>
     <defaults>
       <allow_any>auth_admin</allow_any>
       <allow_inactive>auth_admin</allow_inactive>
@@ -35,8 +35,8 @@
 
   <!-- mount a device attached to another seat -->
   <action id="org.freedesktop.udisks2.filesystem-mount-other-seat">
-    <_description>Mount a filesystem from a device plugged into another seat</_description>
-    <_message>Authentication is required to mount the filesystem</_message>
+    <description>Mount a filesystem from a device plugged into another seat</description>
+    <message>Authentication is required to mount the filesystem</message>
     <defaults>
       <allow_any>auth_admin</allow_any>
       <allow_inactive>auth_admin</allow_inactive>
@@ -46,8 +46,8 @@
 
   <!-- mount a device referenced in the /etc/fstab file with the x-udisks-auth option -->
   <action id="org.freedesktop.udisks2.filesystem-fstab">
-    <_description>Mount/unmount filesystems defined in the fstab file with the x-udisks-auth option</_description>
-    <_message>Authentication is required to mount/unmount the filesystem</_message>
+    <description>Mount/unmount filesystems defined in the fstab file with the x-udisks-auth option</description>
+    <message>Authentication is required to mount/unmount the filesystem</message>
     <defaults>
       <allow_any>auth_admin</allow_any>
       <allow_inactive>auth_admin</allow_inactive>
@@ -60,8 +60,8 @@
 
   <!-- unmount a filesystem mounted by another user -->
   <action id="org.freedesktop.udisks2.filesystem-unmount-others">
-    <_description>Unmount a device mounted by another user</_description>
-    <_message>Authentication is required to unmount a filesystem mounted by another user</_message>
+    <description>Unmount a device mounted by another user</description>
+    <message>Authentication is required to unmount a filesystem mounted by another user</message>
     <defaults>
       <allow_any>auth_admin</allow_any>
       <allow_inactive>auth_admin</allow_inactive>
@@ -73,8 +73,8 @@
   <!-- Taking ownership of filesystems -->
 
   <action id="org.freedesktop.udisks2.filesystem-take-ownership">
-    <_description>Take ownership of a filesystem</_description>
-    <_message>Authentication is required to take ownership of a filesystem.</_message>
+    <description>Take ownership of a filesystem</description>
+    <message>Authentication is required to take ownership of a filesystem.</message>
     <defaults>
       <allow_any>auth_admin</allow_any>
       <allow_inactive>auth_admin</allow_inactive>
@@ -86,8 +86,8 @@
   <!-- Unlocking encrypted devices -->
 
   <action id="org.freedesktop.udisks2.encrypted-unlock">
-    <_description>Unlock an encrypted device</_description>
-    <_message>Authentication is required to unlock an encrypted device</_message>
+    <description>Unlock an encrypted device</description>
+    <message>Authentication is required to unlock an encrypted device</message>
     <defaults>
       <allow_any>auth_admin</allow_any>
       <allow_inactive>auth_admin</allow_inactive>
@@ -97,8 +97,8 @@
 
   <!-- unlock a device considered a "system device" -->
   <action id="org.freedesktop.udisks2.encrypted-unlock-system">
-    <_description>Unlock an encrypted system device</_description>
-    <_message>Authentication is required to unlock an encrypted device</_message>
+    <description>Unlock an encrypted system device</description>
+    <message>Authentication is required to unlock an encrypted device</message>
     <defaults>
       <allow_any>auth_admin</allow_any>
       <allow_inactive>auth_admin</allow_inactive>
@@ -108,8 +108,8 @@
 
   <!-- mount a device attached to another seat -->
   <action id="org.freedesktop.udisks2.encrypted-unlock-other-seat">
-    <_description>Unlock an encrypted device plugged into another seat</_description>
-    <_message>Authentication is required to unlock an encrypted device</_message>
+    <description>Unlock an encrypted device plugged into another seat</description>
+    <message>Authentication is required to unlock an encrypted device</message>
     <defaults>
       <allow_any>auth_admin</allow_any>
       <allow_inactive>auth_admin</allow_inactive>
@@ -119,8 +119,8 @@
 
   <!-- unlock a device referenced in the /etc/crypttab file with the x-udisks-auth option -->
   <action id="org.freedesktop.udisks2.encrypted-unlock-crypttab">
-    <_description>Unlock an encrypted device specified in the crypttab file with the x-udisks-auth option</_description>
-    <_message>Authentication is required to unlock an encrypted device</_message>
+    <description>Unlock an encrypted device specified in the crypttab file with the x-udisks-auth option</description>
+    <message>Authentication is required to unlock an encrypted device</message>
     <defaults>
       <allow_any>auth_admin</allow_any>
       <allow_inactive>auth_admin</allow_inactive>
@@ -133,8 +133,8 @@
 
   <!-- lock a device unlocked by another user -->
   <action id="org.freedesktop.udisks2.encrypted-lock-others">
-    <_description>Lock an encrypted device unlocked by another user</_description>
-    <_message>Authentication is required to lock an encrypted device unlocked by another user</_message>
+    <description>Lock an encrypted device unlocked by another user</description>
+    <message>Authentication is required to lock an encrypted device unlocked by another user</message>
     <defaults>
       <allow_any>auth_admin</allow_any>
       <allow_inactive>auth_admin</allow_inactive>
@@ -146,8 +146,8 @@
   <!-- Changing passphrases on encrypted devices -->
 
   <action id="org.freedesktop.udisks2.encrypted-change-passphrase">
-    <_description>Change passphrase for an encrypted device</_description>
-    <_message>Authentication is required to change the passphrase for an encrypted device</_message>
+    <description>Change passphrase for an encrypted device</description>
+    <message>Authentication is required to change the passphrase for an encrypted device</message>
     <defaults>
       <allow_any>auth_admin</allow_any>
       <allow_inactive>auth_admin</allow_inactive>
@@ -157,8 +157,8 @@
 
   <!-- change passphrase on a device considered a "system device" -->
   <action id="org.freedesktop.udisks2.encrypted-change-passphrase-system">
-    <_description>Change passphrase for an encrypted device</_description>
-    <_message>Authentication is required to change the passphrase for an encrypted device</_message>
+    <description>Change passphrase for an encrypted device</description>
+    <message>Authentication is required to change the passphrase for an encrypted device</message>
     <defaults>
       <allow_any>auth_admin</allow_any>
       <allow_inactive>auth_admin</allow_inactive>
@@ -170,8 +170,8 @@
   <!-- Setting up loop devices -->
 
   <action id="org.freedesktop.udisks2.loop-setup">
-    <_description>Manage loop devices</_description>
-    <_message>Authentication is required to set up a loop device</_message>
+    <description>Manage loop devices</description>
+    <message>Authentication is required to set up a loop device</message>
     <defaults>
       <allow_any>auth_admin</allow_any>
       <allow_inactive>auth_admin</allow_inactive>
@@ -184,8 +184,8 @@
   <!-- Deleting and modifying loop devices -->
 
   <action id="org.freedesktop.udisks2.loop-delete-others">
-    <_description>Delete loop devices</_description>
-    <_message>Authentication is required to delete a loop device set up by another user</_message>
+    <description>Delete loop devices</description>
+    <message>Authentication is required to delete a loop device set up by another user</message>
     <defaults>
       <allow_any>auth_admin</allow_any>
       <allow_inactive>auth_admin</allow_inactive>
@@ -194,8 +194,8 @@
   </action>
 
   <action id="org.freedesktop.udisks2.loop-modify-others">
-    <_description>Modify loop devices</_description>
-    <_message>Authentication is required to modify a loop device set up by another user</_message>
+    <description>Modify loop devices</description>
+    <message>Authentication is required to modify a loop device set up by another user</message>
     <defaults>
       <allow_any>auth_admin</allow_any>
       <allow_inactive>auth_admin</allow_inactive>
@@ -207,8 +207,8 @@
   <!-- Manage (start/stop) swapspace -->
 
   <action id="org.freedesktop.udisks2.manage-swapspace">
-    <_description>Manage swapspace</_description>
-    <_message>Authentication is required to manage swapspace</_message>
+    <description>Manage swapspace</description>
+    <message>Authentication is required to manage swapspace</message>
     <defaults>
       <allow_any>auth_admin</allow_any>
       <allow_inactive>auth_admin</allow_inactive>
@@ -220,8 +220,8 @@
   <!-- Manage MD-RAID -->
 
   <action id="org.freedesktop.udisks2.manage-md-raid">
-    <_description>Manage RAID arrays</_description>
-    <_message>Authentication is required to manage RAID arrays</_message>
+    <description>Manage RAID arrays</description>
+    <message>Authentication is required to manage RAID arrays</message>
     <defaults>
       <allow_any>auth_admin</allow_any>
       <allow_inactive>auth_admin</allow_inactive>
@@ -233,8 +233,8 @@
   <!-- Power off drives -->
 
   <action id="org.freedesktop.udisks2.power-off-drive">
-    <_description>Power off drive</_description>
-    <_message>Authentication is required to power off a drive</_message>
+    <description>Power off drive</description>
+    <message>Authentication is required to power off a drive</message>
     <defaults>
       <allow_any>auth_admin</allow_any>
       <allow_inactive>auth_admin</allow_inactive>
@@ -244,8 +244,8 @@
 
   <!-- Power off a drive considered a "system device" -->
   <action id="org.freedesktop.udisks2.power-off-drive-system">
-    <_description>Power off a system drive</_description>
-    <_message>Authentication is required to power off a drive</_message>
+    <description>Power off a system drive</description>
+    <message>Authentication is required to power off a drive</message>
     <defaults>
       <allow_any>auth_admin</allow_any>
       <allow_inactive>auth_admin</allow_inactive>
@@ -255,8 +255,8 @@
 
   <!-- Power off a drive attached to another seat -->
   <action id="org.freedesktop.udisks2.power-off-drive-other-seat">
-    <_description>Power off a drive attached to another seat</_description>
-    <_message>Authentication is required to power off a drive plugged into another seat</_message>
+    <description>Power off a drive attached to another seat</description>
+    <message>Authentication is required to power off a drive plugged into another seat</message>
     <defaults>
       <allow_any>auth_admin</allow_any>
       <allow_inactive>auth_admin</allow_inactive>
@@ -268,8 +268,8 @@
   <!-- Eject media from a drive -->
 
   <action id="org.freedesktop.udisks2.eject-media">
-    <_description>Eject media</_description>
-    <_message>Authentication is required to eject media</_message>
+    <description>Eject media</description>
+    <message>Authentication is required to eject media</message>
     <defaults>
       <allow_any>auth_admin</allow_any>
       <allow_inactive>auth_admin</allow_inactive>
@@ -279,8 +279,8 @@
 
   <!-- eject media from a drive considered a "system device" -->
   <action id="org.freedesktop.udisks2.eject-media-system">
-    <_description>Eject media from a system drive</_description>
-    <_message>Authentication is required to eject media</_message>
+    <description>Eject media from a system drive</description>
+    <message>Authentication is required to eject media</message>
     <defaults>
       <allow_any>auth_admin</allow_any>
       <allow_inactive>auth_admin</allow_inactive>
@@ -290,8 +290,8 @@
 
   <!-- eject media from a drive attached to another seat -->
   <action id="org.freedesktop.udisks2.eject-media-other-seat">
-    <_description>Eject media from a drive attached to another seat</_description>
-    <_message>Authentication is required to eject media from a drive plugged into another seat</_message>
+    <description>Eject media from a drive attached to another seat</description>
+    <message>Authentication is required to eject media from a drive plugged into another seat</message>
     <defaults>
       <allow_any>auth_admin</allow_any>
       <allow_inactive>auth_admin</allow_inactive>
@@ -303,8 +303,8 @@
   <!-- Modify a device (create new filesystem, partitioning, change FS label etc.) -->
 
   <action id="org.freedesktop.udisks2.modify-device">
-    <_description>Modify a device</_description>
-    <_message>Authentication is required to modify a device</_message>
+    <description>Modify a device</description>
+    <message>Authentication is required to modify a device</message>
     <defaults>
       <allow_any>auth_admin</allow_any>
       <allow_inactive>auth_admin</allow_inactive>
@@ -314,8 +314,8 @@
 
   <!-- modify a device considered a "system device" -->
   <action id="org.freedesktop.udisks2.modify-device-system">
-    <_description>Modify a system device</_description>
-    <_message>Authentication is required to modify a device</_message>
+    <description>Modify a system device</description>
+    <message>Authentication is required to modify a device</message>
     <defaults>
       <allow_any>auth_admin</allow_any>
       <allow_inactive>auth_admin</allow_inactive>
@@ -325,8 +325,8 @@
 
   <!-- modify a device attached to another seat -->
   <action id="org.freedesktop.udisks2.modify-device-other-seat">
-    <_description>Modify a device</_description>
-    <_message>Authentication is required to modify a device plugged into another seat</_message>
+    <description>Modify a device</description>
+    <message>Authentication is required to modify a device plugged into another seat</message>
     <defaults>
       <allow_any>auth_admin</allow_any>
       <allow_inactive>auth_admin</allow_inactive>
@@ -336,8 +336,8 @@
 
   <!-- rescan a device -->
   <action id="org.freedesktop.udisks2.rescan">
-    <_description>Rescan a device</_description>
-    <_message>Authentication is required to rescan a device</_message>
+    <description>Rescan a device</description>
+    <message>Authentication is required to rescan a device</message>
     <defaults>
       <allow_any>auth_admin</allow_any>
       <allow_inactive>auth_admin</allow_inactive>
@@ -349,8 +349,8 @@
   <!-- Open a device for reading (for creating / restoring disk images) -->
 
   <action id="org.freedesktop.udisks2.open-device">
-    <_description>Open a device</_description>
-    <_message>Authentication is required to open a device</_message>
+    <description>Open a device</description>
+    <message>Authentication is required to open a device</message>
     <defaults>
       <allow_any>auth_admin</allow_any>
       <allow_inactive>auth_admin</allow_inactive>
@@ -359,8 +359,8 @@
   </action>
 
   <action id="org.freedesktop.udisks2.open-device-system">
-    <_description>Open a system device</_description>
-    <_message>Authentication is required to open a device</_message>
+    <description>Open a system device</description>
+    <message>Authentication is required to open a device</message>
     <defaults>
       <allow_any>auth_admin</allow_any>
       <allow_inactive>auth_admin</allow_inactive>
@@ -379,8 +379,8 @@
   -->
 
   <action id="org.freedesktop.udisks2.modify-system-configuration">
-    <_description>Modify system-wide configuration</_description>
-    <_message>Authentication is required to modify system-wide configuration</_message>
+    <description>Modify system-wide configuration</description>
+    <message>Authentication is required to modify system-wide configuration</message>
     <defaults>
       <allow_any>auth_admin</allow_any>
       <allow_inactive>auth_admin</allow_inactive>
@@ -390,8 +390,8 @@
 
   <!-- Get secrets from system-wide configuration files -->
   <action id="org.freedesktop.udisks2.read-system-configuration-secrets">
-    <_description>Modify system-wide configuration</_description>
-    <_message>Authentication is required to retrieve secrets from system-wide configuration</_message>
+    <description>Modify system-wide configuration</description>
+    <message>Authentication is required to retrieve secrets from system-wide configuration</message>
     <defaults>
       <allow_any>auth_admin</allow_any>
       <allow_inactive>auth_admin</allow_inactive>
@@ -403,8 +403,8 @@
   <!-- Drive configuration (Power Management, Acustics, etc.) -->
 
   <action id="org.freedesktop.udisks2.modify-drive-settings">
-    <_description>Modify drive settings</_description>
-    <_message>Authentication is required to modify drive settings</_message>
+    <description>Modify drive settings</description>
+    <message>Authentication is required to modify drive settings</message>
     <defaults>
       <allow_any>auth_admin</allow_any>
       <allow_inactive>auth_admin</allow_inactive>
@@ -417,8 +417,8 @@
 
   <!-- Update/refresh SMART data -->
   <action id="org.freedesktop.udisks2.ata-smart-update">
-    <_description>Update SMART data</_description>
-    <_message>Authentication is required to update SMART data</_message>
+    <description>Update SMART data</description>
+    <message>Authentication is required to update SMART data</message>
     <defaults>
       <allow_any>auth_admin</allow_any>
       <allow_inactive>auth_admin</allow_inactive>
@@ -428,8 +428,8 @@
 
   <!-- Set SMART data from blob -->
   <action id="org.freedesktop.udisks2.ata-smart-simulate">
-    <_description>Set SMART data from blob</_description>
-    <_message>Authentication is required to set SMART data from blob</_message>
+    <description>Set SMART data from blob</description>
+    <message>Authentication is required to set SMART data from blob</message>
     <defaults>
       <allow_any>auth_admin</allow_any>
       <allow_inactive>auth_admin</allow_inactive>
@@ -439,8 +439,8 @@
 
   <!-- Start and abort SMART self-tests -->
   <action id="org.freedesktop.udisks2.ata-smart-selftest">
-    <_description>Run SMART self-test</_description>
-    <_message>Authentication is required to run a SMART self-test</_message>
+    <description>Run SMART self-test</description>
+    <message>Authentication is required to run a SMART self-test</message>
     <defaults>
       <allow_any>auth_admin</allow_any>
       <allow_inactive>auth_admin</allow_inactive>
@@ -450,8 +450,8 @@
 
   <!-- Enable/Disable SMART -->
   <action id="org.freedesktop.udisks2.ata-smart-enable-disable">
-    <_description>Enable/Disable SMART</_description>
-    <_message>Authentication is required to enable/disable SMART</_message>
+    <description>Enable/Disable SMART</description>
+    <message>Authentication is required to enable/disable SMART</message>
     <defaults>
       <allow_any>auth_admin</allow_any>
       <allow_inactive>auth_admin</allow_inactive>
@@ -464,8 +464,8 @@
 
   <!-- Check power state -->
   <action id="org.freedesktop.udisks2.ata-check-power">
-    <_description>Check power state</_description>
-    <_message>Authentication is required to check the power state</_message>
+    <description>Check power state</description>
+    <message>Authentication is required to check the power state</message>
     <defaults>
       <allow_any>auth_admin</allow_any>
       <allow_inactive>auth_admin</allow_inactive>
@@ -475,8 +475,8 @@
 
   <!-- Send standby command / resume from standby -->
   <action id="org.freedesktop.udisks2.ata-standby">
-    <_description>Send standby command</_description>
-    <_message>Authentication is required to put a drive into standby mode</_message>
+    <description>Send standby command</description>
+    <message>Authentication is required to put a drive into standby mode</message>
     <defaults>
       <allow_any>auth_admin</allow_any>
       <allow_inactive>auth_admin</allow_inactive>
@@ -486,8 +486,8 @@
 
   <!-- Send standby command / resume from standby to a drive considered a "system device" -->
   <action id="org.freedesktop.udisks2.ata-standby-system">
-    <_description>Send standby command to a system drive</_description>
-    <_message>Authentication is required to put a drive into standby mode</_message>
+    <description>Send standby command to a system drive</description>
+    <message>Authentication is required to put a drive into standby mode</message>
     <defaults>
       <allow_any>auth_admin</allow_any>
       <allow_inactive>auth_admin</allow_inactive>
@@ -497,8 +497,8 @@
 
   <!-- Send standby command  / resume from standby to a drive on another seat -->
   <action id="org.freedesktop.udisks2.ata-standby-other-seat">
-    <_description>Send standby command to drive on other seat</_description>
-    <_message>Authentication is required to put a drive into standby mode</_message>
+    <description>Send standby command to drive on other seat</description>
+    <message>Authentication is required to put a drive into standby mode</message>
     <defaults>
       <allow_any>auth_admin</allow_any>
       <allow_inactive>auth_admin</allow_inactive>
@@ -511,8 +511,8 @@
 
   <!-- Send SECURE ERASE UNIT command -->
   <action id="org.freedesktop.udisks2.ata-secure-erase">
-    <_description>Securely erase a hard disk</_description>
-    <_message>Authentication is required to securely erase a hard disk</_message>
+    <description>Securely erase a hard disk</description>
+    <message>Authentication is required to securely erase a hard disk</message>
     <defaults>
       <allow_any>auth_admin</allow_any>
       <allow_inactive>auth_admin</allow_inactive>
@@ -525,8 +525,8 @@
 
   <!-- Cancel own job -->
   <action id="org.freedesktop.udisks2.cancel-job">
-    <_description>Cancel job</_description>
-    <_message>Authentication is required to cancel a job</_message>
+    <description>Cancel job</description>
+    <message>Authentication is required to cancel a job</message>
     <defaults>
       <allow_any>auth_admin</allow_any>
       <allow_inactive>auth_admin</allow_inactive>
@@ -536,8 +536,8 @@
 
   <!-- Cancel job initiated by other user -->
   <action id="org.freedesktop.udisks2.cancel-job-other-user">
-    <_description>Cancel job started by another user</_description>
-    <_message>Authentication is required to cancel a job started by another user</_message>
+    <description>Cancel job started by another user</description>
+    <message>Authentication is required to cancel a job started by another user</message>
     <defaults>
       <allow_any>auth_admin</allow_any>
       <allow_inactive>auth_admin</allow_inactive>

--- a/modules/bcache/data/Makefile.am
+++ b/modules/bcache/data/Makefile.am
@@ -5,7 +5,8 @@ polkitdir       = $(datadir)/polkit-1/actions
 polkit_in_files = org.freedesktop.UDisks2.bcache.policy.in
 polkit_DATA     = $(polkit_in_files:.policy.in=.policy)
 
-@INTLTOOL_POLICY_RULE@
+$(polkit_DATA): $(polkit_in_files)
+	$(AM_V_GEN) $(MSGFMT) --xml --template $< -d $(top_srcdir)/po -o $@
 
 EXTRA_DIST =                                                                   \
 	org.freedesktop.UDisks2.bcache.xml                                     \

--- a/modules/bcache/data/org.freedesktop.UDisks2.bcache.policy.in
+++ b/modules/bcache/data/org.freedesktop.UDisks2.bcache.policy.in
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <!DOCTYPE policyconfig PUBLIC
  "-//freedesktop//DTD PolicyKit Policy Configuration 1.0//EN"
@@ -10,8 +10,8 @@
   <icon_name>drive-removable-media</icon_name>
 
   <action id="org.freedesktop.udisks2.bcache.manage-bcache">
-    <_description>Manage Bcache</_description>
-    <_message>Authentication is required to manage Bcache</_message>
+    <description>Manage Bcache</description>
+    <message>Authentication is required to manage Bcache</message>
     <defaults>
       <allow_any>auth_admin</allow_any>
       <allow_inactive>auth_admin</allow_inactive>

--- a/modules/btrfs/data/Makefile.am
+++ b/modules/btrfs/data/Makefile.am
@@ -5,7 +5,8 @@ polkitdir        = $(datadir)/polkit-1/actions
 polkit_in_files  = org.freedesktop.UDisks2.btrfs.policy.in
 polkit_DATA      = $(polkit_in_files:.policy.in=.policy)
 
-@INTLTOOL_POLICY_RULE@
+$(polkit_DATA): $(polkit_in_files)
+	$(AM_V_GEN) $(MSGFMT) --xml --template $< -d $(top_srcdir)/po -o $@
 
 EXTRA_DIST =                                                                   \
 	org.freedesktop.UDisks2.btrfs.xml                                      \

--- a/modules/btrfs/data/org.freedesktop.UDisks2.btrfs.policy.in
+++ b/modules/btrfs/data/org.freedesktop.UDisks2.btrfs.policy.in
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <!DOCTYPE policyconfig PUBLIC
  "-//freedesktop//DTD PolicyKit Policy Configuration 1.0//EN"
@@ -13,8 +13,8 @@
   <!-- Manage BTRFS -->
 
   <action id="org.freedesktop.udisks2.btrfs.manage-btrfs">
-    <_description>Manage BTRFS</_description>
-    <_message>Authentication is required to manage BTRFS</_message>
+    <description>Manage BTRFS</description>
+    <message>Authentication is required to manage BTRFS</message>
     <defaults>
       <allow_any>auth_admin</allow_any>
       <allow_inactive>auth_admin</allow_inactive>

--- a/modules/iscsi/data/Makefile.am
+++ b/modules/iscsi/data/Makefile.am
@@ -5,7 +5,8 @@ polkitdir        = $(datadir)/polkit-1/actions
 polkit_in_files  = org.freedesktop.UDisks2.iscsi.policy.in
 polkit_DATA      = $(polkit_in_files:.policy.in=.policy)
 
-@INTLTOOL_POLICY_RULE@
+$(polkit_DATA): $(polkit_in_files)
+	$(AM_V_GEN) $(MSGFMT) --xml --template $< -d $(top_srcdir)/po -o $@
 
 EXTRA_DIST =                                                                   \
 	org.freedesktop.UDisks2.iscsi.xml                                      \

--- a/modules/iscsi/data/org.freedesktop.UDisks2.iscsi.policy.in
+++ b/modules/iscsi/data/org.freedesktop.UDisks2.iscsi.policy.in
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <!DOCTYPE policyconfig PUBLIC
  "-//freedesktop//DTD PolicyKit Policy Configuration 1.0//EN"
@@ -13,8 +13,8 @@
   <!-- Manage LVM -->
 
   <action id="org.freedesktop.udisks2.iscsi.manage-iscsi">
-    <_description>Manage iSCSI</_description>
-    <_message>Authentication is required to manage iSCSI</_message>
+    <description>Manage iSCSI</description>
+    <message>Authentication is required to manage iSCSI</message>
     <defaults>
       <allow_any>auth_admin</allow_any>
       <allow_inactive>auth_admin</allow_inactive>

--- a/modules/lsm/data/Makefile.am
+++ b/modules/lsm/data/Makefile.am
@@ -5,7 +5,8 @@ polkitdir        = $(datadir)/polkit-1/actions
 polkit_in_files  = org.freedesktop.UDisks2.lsm.policy.in
 polkit_DATA      = $(polkit_in_files:.policy.in=.policy)
 
-@INTLTOOL_POLICY_RULE@
+$(polkit_DATA): $(polkit_in_files)
+	$(AM_V_GEN) $(MSGFMT) --xml --template $< -d $(top_srcdir)/po -o $@
 
 modulesconfdir = $(sysconfdir)/udisks2/modules.conf.d
 modulesconf_DATA = udisks2_lsm.conf

--- a/modules/lsm/data/org.freedesktop.UDisks2.lsm.policy.in
+++ b/modules/lsm/data/org.freedesktop.UDisks2.lsm.policy.in
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <!DOCTYPE policyconfig PUBLIC
  "-//freedesktop//DTD PolicyKit Policy Configuration 1.0//EN"
@@ -13,8 +13,8 @@
   <!-- Drive LED Management -->
 
   <action id="org.freedesktop.udisks2.manage-led">
-    <_description>Manage disk drive LED</_description>
-    <_message>Authentication is required to manage disk drive LED</_message>
+    <description>Manage disk drive LED</description>
+    <message>Authentication is required to manage disk drive LED</message>
     <defaults>
       <allow_any>auth_admin</allow_any>
       <allow_inactive>auth_admin</allow_inactive>

--- a/modules/lvm2/data/Makefile.am
+++ b/modules/lvm2/data/Makefile.am
@@ -5,7 +5,8 @@ polkitdir        = $(datadir)/polkit-1/actions
 polkit_in_files  = org.freedesktop.UDisks2.lvm2.policy.in
 polkit_DATA      = $(polkit_in_files:.policy.in=.policy)
 
-@INTLTOOL_POLICY_RULE@
+$(polkit_DATA): $(polkit_in_files)
+	$(AM_V_GEN) $(MSGFMT) --xml --template $< -d $(top_srcdir)/po -o $@
 
 EXTRA_DIST =                                                                   \
 	org.freedesktop.UDisks2.lvm2.xml                                       \

--- a/modules/lvm2/data/org.freedesktop.UDisks2.lvm2.policy.in
+++ b/modules/lvm2/data/org.freedesktop.UDisks2.lvm2.policy.in
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <!DOCTYPE policyconfig PUBLIC
  "-//freedesktop//DTD PolicyKit Policy Configuration 1.0//EN"
@@ -13,8 +13,8 @@
   <!-- Manage LVM -->
 
   <action id="org.freedesktop.udisks2.lvm2.manage-lvm">
-    <_description>Manage LVM</_description>
-    <_message>Authentication is required to manage LVM</_message>
+    <description>Manage LVM</description>
+    <message>Authentication is required to manage LVM</message>
     <defaults>
       <allow_any>auth_admin</allow_any>
       <allow_inactive>auth_admin</allow_inactive>

--- a/modules/vdo/data/Makefile.am
+++ b/modules/vdo/data/Makefile.am
@@ -5,7 +5,8 @@ polkitdir        = $(datadir)/polkit-1/actions
 polkit_in_files  = org.freedesktop.UDisks2.vdo.policy.in
 polkit_DATA      = $(polkit_in_files:.policy.in=.policy)
 
-@INTLTOOL_POLICY_RULE@
+$(polkit_DATA): $(polkit_in_files)
+	$(AM_V_GEN) $(MSGFMT) --xml --template $< -d $(top_srcdir)/po -o $@
 
 EXTRA_DIST =                                                                   \
 	org.freedesktop.UDisks2.vdo.xml                                        \

--- a/modules/vdo/data/org.freedesktop.UDisks2.vdo.policy.in
+++ b/modules/vdo/data/org.freedesktop.UDisks2.vdo.policy.in
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <!DOCTYPE policyconfig PUBLIC
  "-//freedesktop//DTD PolicyKit Policy Configuration 1.0//EN"
@@ -13,8 +13,8 @@
   <!-- Manage VDO -->
 
   <action id="org.freedesktop.udisks2.vdo.manage-vdo">
-    <_description>Manage VDO</_description>
-    <_message>Authentication is required to manage VDO</_message>
+    <description>Manage VDO</description>
+    <message>Authentication is required to manage VDO</message>
     <defaults>
       <allow_any>auth_admin</allow_any>
       <allow_inactive>auth_admin</allow_inactive>

--- a/modules/zram/data/Makefile.am
+++ b/modules/zram/data/Makefile.am
@@ -5,9 +5,10 @@ polkitdir       = $(datadir)/polkit-1/actions
 polkit_in_files = org.freedesktop.UDisks2.zram.policy.in
 polkit_DATA     = $(polkit_in_files:.policy.in=.policy)
 
-systemdsystemunit_DATA = zram-setup@.service
+$(polkit_DATA): $(polkit_in_files)
+	$(AM_V_GEN) $(MSGFMT) --xml --template $< -d $(top_srcdir)/po -o $@
 
-@INTLTOOL_POLICY_RULE@
+systemdsystemunit_DATA = zram-setup@.service
 
 EXTRA_DIST =                                                                   \
 	org.freedesktop.UDisks2.zram.xml                                       \

--- a/modules/zram/data/org.freedesktop.UDisks2.zram.policy.in
+++ b/modules/zram/data/org.freedesktop.UDisks2.zram.policy.in
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <!DOCTYPE policyconfig PUBLIC
  "-//freedesktop//DTD PolicyKit Policy Configuration 1.0//EN"
@@ -10,8 +10,8 @@
   <icon_name>drive-removable-media</icon_name>
 
   <action id="org.freedesktop.udisks2.zram.manage-zram">
-    <_description>Manage zRAM</_description>
-    <_message>Authentication is required to manage zRAM</_message>
+    <description>Manage zRAM</description>
+    <message>Authentication is required to manage zRAM</message>
     <defaults>
       <allow_any>auth_admin</allow_any>
       <allow_inactive>auth_admin</allow_inactive>

--- a/packaging/udisks2.spec
+++ b/packaging/udisks2.spec
@@ -75,11 +75,10 @@ BuildRequires: libgudev1-devel >= %{systemd_version}
 BuildRequires: libatasmart-devel >= %{libatasmart_version}
 BuildRequires: polkit-devel >= %{polkit_version}
 BuildRequires: systemd-devel >= %{systemd_version}
-BuildRequires: gnome-common
 BuildRequires: libacl-devel
 BuildRequires: chrpath
 BuildRequires: gtk-doc
-BuildRequires: intltool
+BuildRequires: gettext-devel
 BuildRequires: redhat-rpm-config
 BuildRequires: libblockdev-devel        >= %{libblockdev_version}
 BuildRequires: libblockdev-part-devel   >= %{libblockdev_version}

--- a/po/Makevars
+++ b/po/Makevars
@@ -1,0 +1,78 @@
+# Makefile variables for PO directory in any package using GNU gettext.
+
+# Usually the message domain is the same as the package name.
+DOMAIN = udisks2
+
+# These two variables depend on the location of this directory.
+subdir = po
+top_builddir = ..
+
+# These options get passed to xgettext.
+XGETTEXT_OPTIONS = --from-code=UTF-8 --keyword=_ --keyword=N_ --keyword=C_:1c,2 --keyword=NC_:1c,2 --keyword=g_dngettext:2,3 --add-comments
+
+# This is the copyright holder that gets inserted into the header of the
+# $(DOMAIN).pot file.  Set this to the copyright holder of the surrounding
+# package.  (Note that the msgstr strings, extracted from the package's
+# sources, belong to the copyright holder of the package.)  Translators are
+# expected to transfer the copyright for their translations to this person
+# or entity, or to disclaim their copyright.  The empty string stands for
+# the public domain; in this case the translators are expected to disclaim
+# their copyright.
+COPYRIGHT_HOLDER =
+
+# This tells whether or not to prepend "GNU " prefix to the package
+# name that gets inserted into the header of the $(DOMAIN).pot file.
+# Possible values are "yes", "no", or empty.  If it is empty, try to
+# detect it automatically by scanning the files in $(top_srcdir) for
+# "GNU packagename" string.
+PACKAGE_GNU = no
+
+# This is the email address or URL to which the translators shall report
+# bugs in the untranslated strings:
+# - Strings which are not entire sentences, see the maintainer guidelines
+#   in the GNU gettext documentation, section 'Preparing Strings'.
+# - Strings which use unclear terms or require additional context to be
+#   understood.
+# - Strings which make invalid assumptions about notation of date, time or
+#   money.
+# - Pluralisation problems.
+# - Incorrect English spelling.
+# - Incorrect formatting.
+# It can be your email address, or a mailing list address where translators
+# can write to without being subscribed, or the URL of a web page through
+# which the translators can contact you.
+MSGID_BUGS_ADDRESS = https://github.com/storaged-project/udisks/issues
+
+# This is the list of locale categories, beyond LC_MESSAGES, for which the
+# message catalogs shall be used.  It is usually empty.
+EXTRA_LOCALE_CATEGORIES =
+
+# This tells whether the $(DOMAIN).pot file contains messages with an 'msgctxt'
+# context.  Possible values are "yes" and "no".  Set this to yes if the
+# package uses functions taking also a message context, like pgettext(), or
+# if in $(XGETTEXT_OPTIONS) you define keywords with a context argument.
+USE_MSGCTXT = yes
+
+# These options get passed to msgmerge.
+# Useful options are in particular:
+#   --previous            to keep previous msgids of translated messages,
+#   --quiet               to reduce the verbosity.
+MSGMERGE_OPTIONS =
+
+# These options get passed to msginit.
+# If you want to disable line wrapping when writing PO files, add
+# --no-wrap to MSGMERGE_OPTIONS, XGETTEXT_OPTIONS, and
+# MSGINIT_OPTIONS.
+MSGINIT_OPTIONS =
+
+# This tells whether or not to regenerate a PO file when $(DOMAIN).pot
+# has changed.  Possible values are "yes" and "no".  Set this to no if
+# the POT file is checked in the repository and the version control
+# program ignores timestamps.
+PO_DEPENDS_ON_POT = no
+
+# This tells whether or not to forcibly update $(DOMAIN).pot and
+# regenerate PO files on "make dist".  Possible values are "yes" and
+# "no".  Set this to no if the POT file and PO files are maintained
+# externally.
+DIST_DEPENDS_ON_UPDATE_PO = no

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -1,4 +1,3 @@
-[encoding: UTF-8]
 # List of source files containing translatable strings.
 # Please keep this file sorted alphabetically.
 data/org.freedesktop.UDisks2.policy.in


### PR DESCRIPTION
This patch changes the build scripts to use `gettext` for i18n strings extraction and merging in place of `intltool`. This allow dropping the dependency on outdated intltool. It also drops the `gnome-common` dependency, now deprecated.

  https://wiki.gnome.org/Initiatives/GnomeGoals/GettextMigration
  https://wiki.gnome.org/Projects/GnomeCommon/Migration

Closes https://github.com/storaged-project/udisks/issues/629