### PR TITLE
Install a tmpfiles.d snippet to create /run/media on boot with systemd

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -124,6 +124,7 @@ AC_ARG_ENABLE(fhs-media,
                               [Mount devices in /media instead of /run/media [default=no]])],
               AS_IF([test "x$enable_fhs_media" == "xyes"], [fhs_media=yes]),
               fhs_media=no)
+AM_CONDITIONAL(HAVE_FHS_MEDIA, test "x$fhs_media" = "xyes")
 if test "x$fhs_media" = "xyes"; then
   AC_DEFINE([HAVE_FHS_MEDIA], 1, [Define to 1 to use /media for mounting])
 fi
@@ -213,6 +214,14 @@ if test "x$with_systemdsystemunitdir" != "xno"; then
   AC_SUBST([systemdsystemunitdir], [$with_systemdsystemunitdir])
 fi
 AM_CONDITIONAL(HAVE_SYSTEMD, [test -n "$systemdsystemunitdir"])
+
+AC_ARG_WITH([tmpfilesdir],
+            AS_HELP_STRING([--with-tmpfilesdir=DIR], [Directory for configuring creation of files at boot]),
+            [],
+            [with_tmpfilesdir=$($PKG_CONFIG --variable=tmpfilesdir systemd)])
+if test "x$with_tmpfilesdir" != "xno"; then
+  AC_SUBST([tmpfilesdir], [$with_tmpfilesdir])
+fi
 
 # kernel modules
 AC_ARG_WITH([modloaddir],
@@ -676,6 +685,7 @@ fi
 AC_OUTPUT([
 Makefile
 data/Makefile
+data/tmpfiles.d/Makefile
 udisks/Makefile
 udisks/udisks2.conf
 udisks/udisks2.pc
@@ -762,6 +772,7 @@ echo "
 
         udevdir:                    ${udevdir}
         systemdsystemunitdir:       ${systemdsystemunitdir}
+        tmpfilesdir:                ${tmpfilesdir}
         using libsystemd-login:     ${have_libsystemd_login}
         using libelogind:           ${have_libelogind}
         use /media for mounting:    ${fhs_media}

--- a/data/Makefile.am
+++ b/data/Makefile.am
@@ -1,6 +1,8 @@
 
 NULL =
 
+SUBDIRS = tmpfiles.d
+
 dbusservicedir       = $(datadir)/dbus-1/system-services
 dbusservice_in_files = org.freedesktop.UDisks2.service.in
 dbusservice_DATA     = $(dbusservice_in_files:.service.in=.service)

--- a/data/tmpfiles.d/Makefile.am
+++ b/data/tmpfiles.d/Makefile.am
@@ -1,0 +1,8 @@
+
+NULL =
+
+if HAVE_SYSTEMD
+if !HAVE_FHS_MEDIA
+dist_tmpfiles_DATA = udisks2.conf
+endif
+endif

--- a/data/tmpfiles.d/udisks2.conf
+++ b/data/tmpfiles.d/udisks2.conf
@@ -1,0 +1,1 @@
+d /run/media 0755 root root

--- a/packaging/udisks2.spec
+++ b/packaging/udisks2.spec
@@ -73,6 +73,7 @@ BuildRequires: gobject-introspection-devel >= %{gobject_introspection_version}
 BuildRequires: libgudev1-devel >= %{systemd_version}
 BuildRequires: libatasmart-devel >= %{libatasmart_version}
 BuildRequires: polkit-devel >= %{polkit_version}
+BuildRequires: systemd >= %{systemd_version}
 BuildRequires: systemd-devel >= %{systemd_version}
 BuildRequires: libacl-devel
 BuildRequires: chrpath
@@ -347,6 +348,7 @@ udevadm trigger
 
 %{_datadir}/dbus-1/system.d/org.freedesktop.UDisks2.conf
 %{_datadir}/bash-completion/completions/udisksctl
+%{_tmpfilesdir}/%{name}.conf
 %{_unitdir}/udisks2.service
 %{_unitdir}/clean-mount-point@.service
 %{_udevrulesdir}/80-udisks2.rules
@@ -433,6 +435,9 @@ udevadm trigger
 %endif
 
 %changelog
+* Fri Mar 15 2019 Debarshi Ray <rishi@fedoraproject.org> - 2.8.2-2
+- Update for tmpfiles.d snippet
+
 * Mon Mar 04 2019 Tomas Bzatek <tbzatek@redhat.com> - 2.8.2-1
 - Version 2.8.2
 


### PR DESCRIPTION
Currently, when udisks is configured to use /run/media instead of
/media, on most operating systems, the /run/media directory is created
by udisks itself when the first mount is handled. This causes problems
when creating rootless or unprivileged OCI containers that are meant
to have access to udisks mount points because, depending on whether
something has been mounted or not after the current boot, /run/media
might be absent.

A rootless or unprivileged OCI container is created, by definition,
without requiring root privileges. Therefore, it's not possible to
create /run/media during container creation because creating a
directory under /run can only be done by the root user, and a missing
directory can't be bind mounted into the container. Moreover OCI
containers tend to be immutable, so one cannot bind in the directory
later once the container has been created. A practical example of such
a use case are Toolbox [2] containers that are meant to offer an
unprivileged development environment that's seamlessly integrated with
the host.

This problem can be solved by creating /run/media during boot with
systemd-tmpfiles by installing a snippet in tmpfiles.d [3].

[1] https://www.opencontainers.org/
[2] https://github.com/debarshiray/toolbox
[3] https://www.freedesktop.org/software/systemd/man/tmpfiles.d.html