### PR TITLE
Don't update_all_block_objects when utab entries change

### DIFF
--- a/src/udiskslinuxprovider.c
+++ b/src/udiskslinuxprovider.c
@@ -125,16 +125,6 @@ static void crypttab_monitor_on_entry_removed (UDisksCrypttabMonitor *monitor,
                                                UDisksCrypttabEntry   *entry,
                                                gpointer               user_data);
 
-#ifdef HAVE_LIBMOUNT
-static void utab_monitor_on_entry_added (UDisksUtabMonitor *monitor,
-                                         UDisksUtabEntry   *entry,
-                                         gpointer           user_data);
-
-static void utab_monitor_on_entry_removed (UDisksUtabMonitor *monitor,
-                                           UDisksUtabEntry   *entry,
-                                           gpointer           user_data);
-#endif
-
 static void on_etc_udisks2_dir_monitor_changed (GFileMonitor     *monitor,
                                                 GFile            *file,
                                                 GFile            *other_file,
@@ -715,16 +705,6 @@ udisks_linux_provider_start (UDisksProvider *_provider)
                     "entry-removed",
                     G_CALLBACK (crypttab_monitor_on_entry_removed),
                     provider);
-#ifdef HAVE_LIBMOUNT
-  g_signal_connect (udisks_daemon_get_utab_monitor (daemon),
-                    "entry-added",
-                    G_CALLBACK (utab_monitor_on_entry_added),
-                    provider);
-  g_signal_connect (udisks_daemon_get_utab_monitor (daemon),
-                    "entry-removed",
-                    G_CALLBACK (utab_monitor_on_entry_removed),
-                    provider);
-#endif
 
   /* The drive configurations need to be re-applied when system wakes up from suspend/hibernate */
   dbus_conn = udisks_daemon_get_connection (daemon);
@@ -1555,23 +1535,3 @@ crypttab_monitor_on_entry_removed (UDisksCrypttabMonitor *monitor,
   UDisksLinuxProvider *provider = UDISKS_LINUX_PROVIDER (user_data);
   update_all_block_objects (provider);
 }
-
-#ifdef HAVE_LIBMOUNT
-static void
-utab_monitor_on_entry_added (UDisksUtabMonitor *monitor,
-                             UDisksUtabEntry   *entry,
-                             gpointer           user_data)
-{
-  UDisksLinuxProvider *provider = UDISKS_LINUX_PROVIDER (user_data);
-  update_all_block_objects (provider);
-}
-
-static void
-utab_monitor_on_entry_removed (UDisksUtabMonitor *monitor,
-                               UDisksUtabEntry   *entry,
-                               gpointer           user_data)
-{
-  UDisksLinuxProvider *provider = UDISKS_LINUX_PROVIDER (user_data);
-  update_all_block_objects (provider);
-}
-#endif


### PR DESCRIPTION
I have been running _udisks_ patched with this change for a week and haven't noticed any issues. I can use GUI tools to mount/unmount partitions without renaming _/usr/bin/dumpe2fs_ now.

This pull request fixes #611. Merging an alternative fix in #621 is still useful because it prevents waking sleeping disks when _udisksd_ starts or restarts. This pull request and #621 together will cover:
* all mount/unmount operations even if `get_pm_state` returns non-standard values for a non-conforming disk device;
* service startup for "standard" ATA devices.

I have removed the callbacks but not the `UDisksUtabMonitor`'s signals as they might be connected to elsewhere - now or in the future.

I don't know if `update_all_block_objects` has to be called when fstab/crypttab entries change, so I haven't touched that code.