### PR TITLE
Various test cleanup related fixes

### DIFF
--- a/src/tests/dbus-tests/run_tests.py
+++ b/src/tests/dbus-tests/run_tests.py
@@ -110,17 +110,10 @@ def install_config_files(projdir, tmpdir):
     return copied
 
 def restore_files(restore_list, tmpdir):
-    banner = False
     for f, delete in restore_list:
         if delete:
-            if not banner:
-                print("*NOT* deleting the following file(s) that we placed there!")
-                banner = True
             print(f)
-            # os.unlink(f)
-            # The other test(s) needs these files, lets leave until we get
-            # this common code integrated with them as well.
-            pass
+            os.unlink(f)
         else:
             shutil.move(os.path.join(tmpdir, os.path.basename(f)), f)
 

--- a/src/tests/dbus-tests/run_tests.py
+++ b/src/tests/dbus-tests/run_tests.py
@@ -79,56 +79,35 @@ def _copy_files(source_files, target_dir, tmpdir):
     return restore_list
 
 
-def install_new_policy(projdir, tmpdir):
+def install_config_files(projdir, tmpdir):
     """
-    Copies the polkit policy files.
-    """
-    files = glob.glob(projdir + '/data/*.policy') + \
-            glob.glob(projdir + '/modules/*/data/*.policy')
-    return _copy_files(files, '/usr/share/polkit-1/actions/', tmpdir)
-
-
-def install_new_dbus_conf(projdir, tmpdir):
-    """
-    Copies the DBus config file(s)
+    Copies DBus, PolicyKit and UDev config file(s)
 
     Returns a list of files that need to be restored or deleted.
     """
-    return _copy_files([os.path.join(projdir,
-                                    "data/org.freedesktop.UDisks2.conf"), ],
-                       '/etc/dbus-1/system.d/',
-                       tmpdir)
+    copied = []
 
-def install_new_udisks_conf(projdir, tmpdir):
-    """
-    Copies the UDisks config file(s)
+    # udev rules
+    tgtdir = next((d for d in ['/usr/lib/udev/rules.d/', '/lib/udev/rules.d'] if os.path.exists(d)), None)
+    if tgtdir is None:
+        raise RuntimeError('Cannot find udev rules directory')
 
-    Returns a list of files that need to be restored or deleted.
-    """
-    return _copy_files([os.path.join(projdir,
-                                     'udisks/udisks2.conf'), ],
-                       '/etc/udisks2/',
-                       tmpdir)
+    copied.extend(_copy_files((os.path.join(projdir, 'data/80-udisks2.rules'),),
+                              tgtdir, tmpdir))
 
+    # dbus config files
+    copied.extend(_copy_files((os.path.join(projdir, 'data/org.freedesktop.UDisks2.conf'),),
+                              '/etc/dbus-1/system.d/', tmpdir))
 
-def install_new_udev_rules(projdir, tmpdir):
-    """
-    Copies the udev rules file to correct location.
+    # polkit policies
+    policies = glob.glob(projdir + '/data/*.policy') + glob.glob(projdir + '/modules/*/data/*.policy')
+    copied.extend(_copy_files(policies, '/usr/share/polkit-1/actions/', tmpdir))
 
-    Returns a list of file(s) that need to be restored or deleted.
-    """
-    tgt = ""
-    for p in ['/usr/lib/udev/rules.d/', '/lib/udev/rules.d']:
-        if os.path.exists(p):
-            tgt = p
-            break
+    # udisks2.conf
+    copied.extend(_copy_files((os.path.join(projdir, 'udisks/udisks2.conf'),),
+                              '/etc/udisks2/', tmpdir))
 
-    assert tgt
-    return _copy_files([os.path.join(projdir,
-                                    "data/80-udisks2.rules"), ],
-                       tgt,
-                       tmpdir)
-
+    return copied
 
 def restore_files(restore_list, tmpdir):
     banner = False
@@ -153,7 +132,6 @@ def udev_shake():
 
 
 if __name__ == '__main__':
-    files_to_restore = []
     tmpdir = None
     daemon = None
     cleaner = None
@@ -213,10 +191,9 @@ if __name__ == '__main__':
     if not args.system:
         tmpdir = tempfile.mkdtemp(prefix='udisks-tst-')
         atexit.register(shutil.rmtree, tmpdir)
-        files_to_restore.extend(install_new_policy(projdir, tmpdir))
-        files_to_restore.extend(install_new_dbus_conf(projdir, tmpdir))
-        files_to_restore.extend(install_new_udisks_conf(projdir, tmpdir))
-        files_to_restore.extend(install_new_udev_rules(projdir, tmpdir))
+
+        files_to_restore = install_config_files(projdir, tmpdir)
+        atexit.register(restore_files, files_to_restore, tmpdir)
 
         udev_shake()
 
@@ -255,8 +232,6 @@ if __name__ == '__main__':
 
         if args.logfile:
             daemon_log.close()
-
-        restore_files(files_to_restore, tmpdir)
 
         udev_shake()
 

--- a/src/tests/integration-test
+++ b/src/tests/integration-test
@@ -1824,6 +1824,70 @@ class MDRaid(UDisksTestCase):
 
 # ----------------------------------------------------------------------------
 
+def _copy_files(source_files, target_dir, tmpdir):
+    """
+    Copies the source files to the target directory.  If the file exists in the
+    target dir it's backed up to tmpdir and placed on a list of files to
+    restore.  If the file doesn't exist it's flagged to be deleted.
+    Use restore_files for processing.
+
+    Returns a list of files that need to be restored or deleted.
+    """
+    restore_list = []
+    for f in source_files:
+        tgt = os.path.join(target_dir, os.path.basename(f))
+        if os.path.exists(tgt):
+            shutil.move(tgt, tmpdir)
+            restore_list.append((tgt, False))
+        else:
+            restore_list.append((tgt, True))
+
+        print("Copying file: %s to %s directory!" % (f, target_dir))
+        shutil.copy(f, target_dir)
+
+    return restore_list
+
+
+def install_config_files(projdir, tmpdir):
+    """
+    Copies DBus, PolicyKit and UDev config file(s)
+
+    Returns a list of files that need to be restored or deleted.
+    """
+    copied = []
+
+    # udev rules
+    tgtdir = next((d for d in ['/usr/lib/udev/rules.d/', '/lib/udev/rules.d'] if os.path.exists(d)), None)
+    if tgtdir is None:
+        raise RuntimeError('Cannot find udev rules directory')
+
+    copied.extend(_copy_files((os.path.join(projdir, 'data/80-udisks2.rules'),),
+                              tgtdir, tmpdir))
+
+    # dbus config files
+    copied.extend(_copy_files((os.path.join(projdir, 'data/org.freedesktop.UDisks2.conf'),),
+                              '/etc/dbus-1/system.d/', tmpdir))
+
+    # polkit policies
+    policies = glob(projdir + '/data/*.policy') + glob(projdir + '/modules/*/data/*.policy')
+    copied.extend(_copy_files(policies, '/usr/share/polkit-1/actions/', tmpdir))
+
+    # udisks2.conf
+    copied.extend(_copy_files((os.path.join(projdir, 'udisks/udisks2.conf'),),
+                              '/etc/udisks2/', tmpdir))
+
+    return copied
+
+def restore_files(restore_list, tmpdir):
+    for f, delete in restore_list:
+        if delete:
+            print(f)
+            os.unlink(f)
+        else:
+            shutil.move(os.path.join(tmpdir, os.path.basename(f)), f)
+
+# ----------------------------------------------------------------------------
+
 
 if __name__ == '__main__':
     argparser = argparse.ArgumentParser(description='udisks2 integration test suite')
@@ -1832,6 +1896,14 @@ if __name__ == '__main__':
     argparser.add_argument('testname', nargs='*',
                            help='name of test class or method (e. g. "Drive", "FS.test_ext2")')
     cli_args = argparser.parse_args()
+
+    testdir = os.path.abspath(os.path.dirname(__file__))
+    projdir = os.path.abspath(os.path.normpath(os.path.join(testdir, '..', '..')))
+    tmpdir = tempfile.mkdtemp(prefix='udisks-tst-')
+    atexit.register(shutil.rmtree, tmpdir)
+
+    files_to_restore = install_config_files(projdir, tmpdir)
+    atexit.register(restore_files, files_to_restore, tmpdir)
 
     UDisksTestCase.init(logfile=cli_args.logfile)
     if cli_args.testname:


### PR DESCRIPTION
When working on #646 I have noticed that we don't remove config files installed for tests. This PR enables the config files cleanup for both DBus tests and integration tests.