### PR TITLE
udiskslinuxfilesystem: Fix lazy vs. force arguments passed to bd_fs_unmount()

### DIFF
--- a/src/udiskslinuxfilesystem.c
+++ b/src/udiskslinuxfilesystem.c
@@ -1772,7 +1772,7 @@ handle_unmount (UDisksFilesystem      *filesystem,
           BDExtraArg gid_arg = {g_strdup ("run_as_gid"), g_strdup_printf("%d", find_primary_gid (caller_uid))};
           const BDExtraArg *extra_args[3] = {&uid_arg, &gid_arg, NULL};
 
-          success = bd_fs_unmount (mount_point, opt_force, FALSE, extra_args, &error);
+          success = bd_fs_unmount (mount_point, FALSE, opt_force, extra_args, &error);
 
           g_free (uid_arg.opt);
           g_free (uid_arg.val);
@@ -1780,7 +1780,7 @@ handle_unmount (UDisksFilesystem      *filesystem,
           g_free (gid_arg.val);
         }
       else
-          success = bd_fs_unmount (mount_point, opt_force, FALSE, NULL, &error);
+          success = bd_fs_unmount (mount_point, FALSE, opt_force, NULL, &error);
 
       if (!success)
           udisks_simple_job_complete (UDISKS_SIMPLE_JOB (job), FALSE, error->message);
@@ -1871,7 +1871,7 @@ handle_unmount (UDisksFilesystem      *filesystem,
                                          NULL);
 
   if (!bd_fs_unmount (mount_point ? mount_point : udisks_block_get_device (block),
-                      opt_force, FALSE, NULL, &error))
+                      FALSE, opt_force, NULL, &error))
     {
       g_dbus_method_invocation_return_error (invocation,
                                              UDISKS_ERROR,


### PR DESCRIPTION
These two boolean arguments were mistakenly interchanged.