### PR TITLE
tests: Create udisks2 conf directory if it doesn't exist

### DIFF
--- a/src/tests/dbus-tests/run_tests.py
+++ b/src/tests/dbus-tests/run_tests.py
@@ -103,6 +103,8 @@ def install_config_files(projdir, tmpdir):
     copied.extend(_copy_files(policies, '/usr/share/polkit-1/actions/', tmpdir))
 
     # udisks2.conf
+    if not os.path.exists('/etc/udisks2'):
+        os.mkdir('/etc/udisks2', 0o755)
     copied.extend(_copy_files((os.path.join(projdir, 'udisks/udisks2.conf'),),
                               '/etc/udisks2/', tmpdir))
 

--- a/src/tests/integration-test
+++ b/src/tests/integration-test
@@ -1873,6 +1873,8 @@ def install_config_files(projdir, tmpdir):
     copied.extend(_copy_files(policies, '/usr/share/polkit-1/actions/', tmpdir))
 
     # udisks2.conf
+    if not os.path.exists('/etc/udisks2'):
+        os.mkdir('/etc/udisks2', 0o755)
     copied.extend(_copy_files((os.path.join(projdir, 'udisks/udisks2.conf'),),
                               '/etc/udisks2/', tmpdir))
 


### PR DESCRIPTION
We need to make sure that /etc/udisks2 exists if we want to copy
our config file to it.

Missed this in #651 