### PR TITLE
Always remove mountpoint created by udisks upon unmount

### DIFF
--- a/data/org.freedesktop.UDisks2.xml
+++ b/data/org.freedesktop.UDisks2.xml
@@ -1884,6 +1884,10 @@
         typically results in the user having to authenticate as an
         administrator). If authorized, the filesystem is unmounted.
 
+        If the mountpoint was previously created by udisks it is
+        guaranteed it will be removed upon returning from this method
+        call.
+
         If the filesystem is busy, this operation fails with the error
         <link linkend="UDISKS-ERROR-DEVICE-BUSY:CAPS"><constant>org.freedesktop.UDisks2.Error.DeviceBusy</constant></link>
         unless the @force option is used.

--- a/doc/udisks2-sections.txt.in.in
+++ b/doc/udisks2-sections.txt.in.in
@@ -332,6 +332,7 @@ udisks_state_new
 udisks_state_start_cleanup
 udisks_state_stop_cleanup
 udisks_state_check
+udisks_state_check_sync
 udisks_state_get_daemon
 <SUBSECTION>
 udisks_state_add_mounted_fs

--- a/src/udiskslinuxfilesystem.c
+++ b/src/udiskslinuxfilesystem.c
@@ -1885,7 +1885,8 @@ handle_unmount (UDisksFilesystem      *filesystem,
   else
     udisks_simple_job_complete (UDISKS_SIMPLE_JOB (job), TRUE, NULL);
 
-  /* OK, filesystem unmounted.. the state/cleanup routines will remove the mountpoint for us */
+  /* filesystem unmounted, run the state/cleanup routines now to remove the mountpoint (if applicable) */
+  udisks_state_check_sync (state);
 
   udisks_notice ("Unmounted %s on behalf of uid %u",
                  udisks_block_get_device (block),

--- a/src/udisksstate.h
+++ b/src/udisksstate.h
@@ -35,6 +35,7 @@ UDisksDaemon  *udisks_state_get_daemon           (UDisksState   *state);
 void           udisks_state_start_cleanup        (UDisksState   *state);
 void           udisks_state_stop_cleanup         (UDisksState   *state);
 void           udisks_state_check                (UDisksState   *state);
+void           udisks_state_check_sync           (UDisksState   *state);
 /* mounted-fs */
 void           udisks_state_add_mounted_fs       (UDisksState   *state,
                                                   const gchar   *mount_point,


### PR DESCRIPTION
Although the race condition itself could've been fixed by adding sleep long enough to guarantee the udisks clean functions would run, I think this may be actually useful to someone.