### PR TITLE
iscsi: Use proper parser to get and set initiator name

### DIFF
--- a/modules/iscsi/udisksiscsitypes.h
+++ b/modules/iscsi/udisksiscsitypes.h
@@ -21,6 +21,7 @@
 #define __UDISKS_ISCSI_TYPES_H__
 
 #define ISCSI_MODULE_NAME "iscsi"
+#define ISCSI_MODULE_POLICY_ACTION_ID "org.freedesktop.udisks2.iscsi.manage-iscsi"
 
 typedef struct _UDisksISCSIState UDisksISCSIState;
 

--- a/modules/iscsi/udisksiscsiutil.c
+++ b/modules/iscsi/udisksiscsiutil.c
@@ -106,7 +106,6 @@ enum {
 
 const gchar *iscsi_nodes_fmt = "a(sisis)";
 const gchar *iscsi_node_fmt = "(sisis)";
-const gchar *iscsi_policy_action_id = "org.freedesktop.udisks2.iscsi.manage-iscsi";
 
 static struct libiscsi_context *
 iscsi_get_libiscsi_context (UDisksDaemon *daemon)

--- a/modules/iscsi/udisksiscsiutil.h
+++ b/modules/iscsi/udisksiscsiutil.h
@@ -33,8 +33,6 @@ typedef enum
 struct libiscsi_context;
 struct libiscsi_node;
 
-extern const gchar      *iscsi_policy_action_id;
-
 gint                     iscsi_login (UDisksDaemon  *daemon,
                                       const gchar   *name,
                                       const gint     tpgt,

--- a/modules/iscsi/udiskslinuxiscsisession.c
+++ b/modules/iscsi/udiskslinuxiscsisession.c
@@ -131,7 +131,7 @@ handle_logout_interface (UDisksISCSISession    *session,
   /* Policy check. */
   UDISKS_DAEMON_CHECK_AUTHORIZATION (daemon,
                                      UDISKS_OBJECT (object),
-                                     iscsi_policy_action_id,
+                                     ISCSI_MODULE_POLICY_ACTION_ID,
                                      arg_options,
                                      N_("Authentication is required to perform iSCSI logout"),
                                      invocation);


### PR DESCRIPTION
This ports the code for getting and setting initiator name to a proper
GKeyFile parser in order to handle comments, examples and multiple keys
in the config file properly. Some distributions do ship custom complex
config files by default.

Note that GKeyFile parser requires keys to always belong to some group,
for this we create a fake group in memory and strip it again when writing
the file back. This way we preserve all comments.

This commit also includes minor code cleanup and refactoring.

---
Fixes #650 