### PR TITLE
Error message prefixes

### DIFF
--- a/modules/bcache/udiskslinuxmanagerbcache.c
+++ b/modules/bcache/udiskslinuxmanagerbcache.c
@@ -317,7 +317,7 @@ handle_bcache_create (UDisksManagerBcache    *object,
   if (bcache_object == NULL)
     {
       g_prefix_error (&error,
-                      "Error waiting for bcache object after creating %s",
+                      "Error waiting for bcache object after creating '%s': ",
                       bcache_name);
       g_dbus_method_invocation_take_error (invocation, error);
       goto out;

--- a/modules/lvm2/udiskslinuxlogicalvolume.c
+++ b/modules/lvm2/udiskslinuxlogicalvolume.c
@@ -487,7 +487,7 @@ handle_delete (UDisksLogicalVolume   *_volume,
                                                          &error))
     {
       g_prefix_error (&error,
-                      "Error waiting for block object to disappear after deleting %s",
+                      "Error waiting for block object to disappear after deleting '%s': ",
                       udisks_logical_volume_get_name (_volume));
       g_dbus_method_invocation_take_error (invocation, error);
       goto out;
@@ -592,7 +592,7 @@ handle_rename (UDisksLogicalVolume   *_volume,
   if (lv_objpath == NULL)
     {
       g_prefix_error (&error,
-                      "Error waiting for logical volume object for %s",
+                      "Error waiting for logical volume object for '%s': ",
                       new_name);
       g_dbus_method_invocation_take_error (invocation, error);
       goto out;
@@ -753,7 +753,7 @@ handle_activate (UDisksLogicalVolume *_volume,
   if (block_object == NULL)
     {
       g_prefix_error (&error,
-                      "Error waiting for block object for %s",
+                      "Error waiting for block object for '%s': ",
                       udisks_logical_volume_get_name (_volume));
       g_dbus_method_invocation_take_error (invocation, error);
       goto out;
@@ -819,7 +819,7 @@ handle_deactivate (UDisksLogicalVolume   *_volume,
                                                          &error))
     {
       g_prefix_error (&error,
-                      "Error waiting for block object to disappear after deactivating %s",
+                      "Error waiting for block object to disappear after deactivating '%s': ",
                       udisks_logical_volume_get_name (_volume));
       g_dbus_method_invocation_take_error (invocation, error);
       goto out;
@@ -884,7 +884,7 @@ handle_create_snapshot (UDisksLogicalVolume   *_volume,
   if (lv_objpath == NULL)
     {
       g_prefix_error (&error,
-                      "Error waiting for logical volume object for %s",
+                      "Error waiting for logical volume object for '%s': ",
                       name);
       g_dbus_method_invocation_take_error (invocation, error);
       goto out;

--- a/modules/lvm2/udiskslinuxmanagerlvm2.c
+++ b/modules/lvm2/udiskslinuxmanagerlvm2.c
@@ -381,7 +381,7 @@ handle_volume_group_create (UDisksManagerLVM2     *_object,
   if (group_object == NULL)
     {
       g_prefix_error (&error,
-                      "Error waiting for volume group object for %s",
+                      "Error waiting for volume group object for '%s': ",
                       arg_name);
       g_dbus_method_invocation_take_error (invocation, error);
       goto out;

--- a/modules/lvm2/udiskslinuxvolumegroup.c
+++ b/modules/lvm2/udiskslinuxvolumegroup.c
@@ -438,7 +438,7 @@ handle_rename (UDisksVolumeGroup     *_group,
   if (group_object == NULL)
     {
       g_prefix_error (&error,
-                      "Error waiting for volume group object for %s",
+                      "Error waiting for volume group object for '%s': ",
                       new_name);
       g_dbus_method_invocation_take_error (invocation, error);
       goto out;
@@ -919,7 +919,7 @@ handle_create_volume (UDisksVolumeGroup              *_group,
   if (lv_objpath == NULL)
     {
       g_prefix_error (&error,
-                      "Error waiting for logical volume object for %s",
+                      "Error waiting for logical volume object for '%s': ",
                       arg_name);
       g_dbus_method_invocation_take_error (invocation, error);
       goto out;

--- a/modules/vdo/udiskslinuxmanagervdo.c
+++ b/modules/vdo/udiskslinuxmanagervdo.c
@@ -327,7 +327,7 @@ handle_create_volume (UDisksManagerVDO      *manager,
   if (vdo_object == NULL)
     {
       g_prefix_error (&error,
-                      "Error waiting for VDO object after creating %s: ",
+                      "Error waiting for VDO object after creating '%s': ",
                       arg_name);
       udisks_simple_job_complete (UDISKS_SIMPLE_JOB (job), FALSE, error->message);
       g_dbus_method_invocation_take_error (invocation, error);
@@ -443,7 +443,7 @@ handle_start_volume_by_name (UDisksManagerVDO      *manager,
   if (object == NULL)
     {
       g_prefix_error (&error,
-                      "Error waiting for VDO object after starting %s: ",
+                      "Error waiting for VDO object after starting '%s': ",
                       arg_name);
       udisks_simple_job_complete (UDISKS_SIMPLE_JOB (job), FALSE, error->message);
       g_dbus_method_invocation_take_error (invocation, error);

--- a/modules/zram/udiskslinuxmanagerzram.c
+++ b/modules/zram/udiskslinuxmanagerzram.c
@@ -426,7 +426,7 @@ handle_create_devices (UDisksManagerZRAM     *object,
   if (zram_objects == NULL)
     {
       g_prefix_error (&error,
-                      "Error waiting for ZRAM objects after creating.");
+                      "Error waiting for ZRAM objects after creating: ");
       g_dbus_method_invocation_take_error (invocation, error);
       goto out;
     }

--- a/src/udiskslinuxdevice.c
+++ b/src/udiskslinuxdevice.c
@@ -210,7 +210,7 @@ probe_ata (UDisksLinuxDevice  *device,
                                          error))
         {
           g_free (output.buffer);
-          g_prefix_error (error, "Error sending ATA command IDENTIFY DEVICE to %s: ",
+          g_prefix_error (error, "Error sending ATA command IDENTIFY DEVICE to '%s': ",
                           device_file);
           goto out;
         }
@@ -233,7 +233,7 @@ probe_ata (UDisksLinuxDevice  *device,
                                          error))
         {
           g_free (output.buffer);
-          g_prefix_error (error, "Error sending ATA command IDENTIFY PACKET DEVICE to %s: ",
+          g_prefix_error (error, "Error sending ATA command IDENTIFY PACKET DEVICE to '%s': ",
                           device_file);
           goto out;
         }

--- a/src/udiskslinuxencrypted.c
+++ b/src/udiskslinuxencrypted.c
@@ -591,7 +591,7 @@ handle_unlock (UDisksEncrypted        *encrypted,
   if (cleartext_object == NULL)
     {
       g_prefix_error (&error,
-                      "Error waiting for cleartext object after unlocking %s",
+                      "Error waiting for cleartext object after unlocking '%s': ",
                       udisks_block_get_device (block));
       g_dbus_method_invocation_take_error (invocation, error);
       goto out;

--- a/src/udiskslinuxloop.c
+++ b/src/udiskslinuxloop.c
@@ -269,7 +269,7 @@ handle_delete (UDisksLoop            *loop,
 
   if (!bd_loop_teardown (device_file, &error))
     {
-      g_prefix_error (&error, "Error deleting %s: ", device_file);
+      g_prefix_error (&error, "Error deleting '%s': ", device_file);
       g_dbus_method_invocation_take_error (invocation, error);
       udisks_simple_job_complete (UDISKS_SIMPLE_JOB (job), FALSE, error->message);
       goto out;

--- a/src/udiskslinuxmanager.c
+++ b/src/udiskslinuxmanager.c
@@ -439,7 +439,7 @@ handle_loop_setup (UDisksManager          *object,
   if (loop_object == NULL)
     {
       g_prefix_error (&error,
-                      "Error waiting for loop object after creating %s",
+                      "Error waiting for loop object after creating '%s': ",
                       loop_device);
       g_dbus_method_invocation_take_error (invocation, error);
       goto out;
@@ -703,7 +703,7 @@ handle_mdraid_create (UDisksManager         *_object,
           else
             {
               g_prefix_error (&error,
-                              "Error wiping device %s to be used in the RAID array:",
+                              "Error wiping device '%s' to be used in the RAID array: ",
                               udisks_block_get_device (block));
               g_dbus_method_invocation_take_error (invocation, error);
               success = FALSE;
@@ -739,7 +739,7 @@ handle_mdraid_create (UDisksManager         *_object,
 
   if (!bd_md_create (array_name, arg_level, disks, 0, NULL, FALSE, arg_chunk, NULL, &error))
     {
-      g_prefix_error (&error, "Error creating RAID array:");
+      g_prefix_error (&error, "Error creating RAID array: ");
       g_dbus_method_invocation_take_error (invocation, error);
       udisks_simple_job_complete (UDISKS_SIMPLE_JOB (job), FALSE, error->message);
       success = FALSE;
@@ -752,7 +752,7 @@ handle_mdraid_create (UDisksManager         *_object,
       raid_node = bd_md_node_from_name (array_name, &error);
       if (!raid_node)
         {
-          g_prefix_error (&error, "Failed to get md node for array %s", array_name);
+          g_prefix_error (&error, "Failed to get md node for array '%s': ", array_name);
           g_dbus_method_invocation_take_error (invocation, error);
           success = FALSE;
           goto out;
@@ -773,7 +773,7 @@ handle_mdraid_create (UDisksManager         *_object,
   if (array_object == NULL)
     {
       g_prefix_error (&error,
-                      "Error waiting for array object after creating %s",
+                      "Error waiting for array object after creating '%s': ",
                       raid_device_file);
       g_dbus_method_invocation_take_error (invocation, error);
       success = FALSE;
@@ -814,7 +814,7 @@ handle_mdraid_create (UDisksManager         *_object,
         g_clear_error (&error);
       else
         {
-          g_prefix_error (&error, "Error wiping raid device %s:", raid_device_file);
+          g_prefix_error (&error, "Error wiping raid device '%s': ", raid_device_file);
           g_dbus_method_invocation_take_error (invocation, error);
           success = FALSE;
           goto out;

--- a/src/udiskslinuxmdraid.c
+++ b/src/udiskslinuxmdraid.c
@@ -668,7 +668,7 @@ handle_start (UDisksMDRaid           *_mdraid,
 
   if (!bd_md_activate (NULL, NULL, udisks_mdraid_get_uuid (UDISKS_MDRAID (mdraid)), opt_start_degraded, NULL, &error))
     {
-      g_prefix_error (&error, "Error starting RAID array:");
+      g_prefix_error (&error, "Error starting RAID array: ");
       g_dbus_method_invocation_take_error (invocation, error);
       udisks_simple_job_complete (UDISKS_SIMPLE_JOB (job), FALSE, error->message);
       goto out;
@@ -686,7 +686,7 @@ handle_start (UDisksMDRaid           *_mdraid,
   if (block_object == NULL)
     {
       g_prefix_error (&error,
-                      "Error waiting for MD block device after starting array");
+                      "Error waiting for MD block device after starting array: ");
       g_dbus_method_invocation_take_error (invocation, error);
       goto out;
     }
@@ -842,7 +842,7 @@ udisks_linux_mdraid_stop (UDisksMDRaid           *_mdraid,
 
   if (!bd_md_deactivate (device_file, error))
     {
-      g_prefix_error (error, "Error stopping RAID array %s:", device_file);
+      g_prefix_error (error, "Error stopping RAID array '%s': ", device_file);
       g_dbus_method_invocation_take_error (invocation, *error);
       udisks_simple_job_complete (UDISKS_SIMPLE_JOB (job), FALSE, (*error)->message);
       ret = FALSE;
@@ -1066,7 +1066,7 @@ handle_remove_device (UDisksMDRaid           *_mdraid,
 
   if (!bd_md_remove (device_file, member_device_file, set_faulty, NULL, &error))
     {
-      g_prefix_error (&error, "Error removing %s from RAID array %s:", device_file, member_device_file);
+      g_prefix_error (&error, "Error removing '%s' from RAID array '%s': ", device_file, member_device_file);
       g_dbus_method_invocation_take_error (invocation, error);
       udisks_simple_job_complete (UDISKS_SIMPLE_JOB (job), FALSE, error->message);
       goto out;
@@ -1079,7 +1079,7 @@ handle_remove_device (UDisksMDRaid           *_mdraid,
       if (!bd_fs_wipe (member_device_file, TRUE, &error))
         {
           g_prefix_error (&error,
-                          "Error wiping  %s after removal from RAID array %s:",
+                          "Error wiping '%s' after removal from RAID array '%s': ",
                           member_device_file,
                           device_file);
           g_dbus_method_invocation_take_error (invocation, error);
@@ -1212,7 +1212,7 @@ handle_add_device (UDisksMDRaid           *_mdraid,
 
   if (!bd_md_add (device_file, new_member_device_file, 0, NULL, &error))
     {
-      g_prefix_error (&error, "Error adding %s to RAID array %s:", new_member_device_file, device_file);
+      g_prefix_error (&error, "Error adding '%s' to RAID array '%s': ", new_member_device_file, device_file);
       g_dbus_method_invocation_take_error (invocation, error);
       udisks_simple_job_complete (UDISKS_SIMPLE_JOB (job), FALSE, error->message);
       goto out;
@@ -1330,7 +1330,7 @@ handle_set_bitmap_location (UDisksMDRaid           *_mdraid,
 
   if (!bd_md_set_bitmap_location (device_file, value, &error))
     {
-      g_prefix_error (&error, "Error setting bitmap on RAID array %s: ", device_file);
+      g_prefix_error (&error, "Error setting bitmap on RAID array '%s': ", device_file);
       g_dbus_method_invocation_take_error (invocation, error);
       udisks_simple_job_complete (UDISKS_SIMPLE_JOB (job), FALSE, error->message);
       goto out;
@@ -1591,7 +1591,7 @@ udisks_linux_mdraid_delete (UDisksMDRaid           *mdraid,
 
       if (!bd_md_destroy (device, error))
         {
-          g_prefix_error (error, "Error wiping device %s:", device);
+          g_prefix_error (error, "Error wiping device '%s': ", device);
           ret = FALSE;
           goto out;
         }


### PR DESCRIPTION
Couple of tiny fixes. Of course this breaks translations :-)

Spot the difference:
```
dbus.exceptions.DBusException: org.freedesktop.UDisks2.Error.Failed: Error waiting for logical volume object for udisks_test_origin_lvTimed out waiting for object
dbus.exceptions.DBusException: org.freedesktop.UDisks2.Error.Failed: Error waiting for VDO object after creating udisks_activate_test: Timed out waiting for object
```