### PR TITLE
Fix cryptsetup calls locking

### DIFF
--- a/src/udiskslinuxblock.c
+++ b/src/udiskslinuxblock.c
@@ -1671,7 +1671,11 @@ has_whitespace (const gchar *s)
 static gchar *
 make_block_luksname (UDisksBlock *block, GError **error)
 {
-  gchar *uuid = bd_crypto_luks_uuid (udisks_block_get_device (block), error);
+  gchar *uuid = NULL;
+
+  udisks_linux_block_encrypted_lock (block);
+  uuid = bd_crypto_luks_uuid (udisks_block_get_device (block), error);
+  udisks_linux_block_encrypted_unlock (block);
 
   if (uuid)
     {

--- a/src/udiskslinuxencrypted.c
+++ b/src/udiskslinuxencrypted.c
@@ -1072,6 +1072,8 @@ handle_resize (UDisksEncrypted       *encrypted,
   else
     effective_passphrase = NULL;
 
+  udisks_linux_block_encrypted_lock (block);
+
   /* TODO: implement progress parsing for udisks_job_set_progress(_valid) */
   if (! bd_crypto_luks_resize_luks2_blob (udisks_block_get_device (cleartext_block),
                                           size / 512,
@@ -1086,8 +1088,11 @@ handle_resize (UDisksEncrypted       *encrypted,
                                              udisks_block_get_device (cleartext_block),
                                              error->message);
       udisks_simple_job_complete (UDISKS_SIMPLE_JOB (job), FALSE, error->message);
+      udisks_linux_block_encrypted_unlock (block);
       goto out;
     }
+
+  udisks_linux_block_encrypted_unlock (block);
 
   udisks_encrypted_complete_resize (encrypted, invocation);
   udisks_simple_job_complete (UDISKS_SIMPLE_JOB (job), TRUE, NULL);


### PR DESCRIPTION
cryptsetup is not thread safe, we need to make sure we are not
calling 'crypt_init' multiple times from different threafs.
This fixes only calls not covered in 25be16d