### PR TITLE
udisksclient: Let the caller specify a D-Bus connection

### DIFF
--- a/doc/udisks2-sections.txt.in.in
+++ b/doc/udisks2-sections.txt.in.in
@@ -31,6 +31,8 @@ UDISKS_CHECK_VERSION
 UDisksClient
 udisks_client_new
 udisks_client_new_finish
+udisks_client_new_for_connection
+udisks_client_new_for_connection_finish
 udisks_client_new_sync
 udisks_client_get_object
 udisks_client_peek_object

--- a/udisks/udisksclient.h
+++ b/udisks/udisksclient.h
@@ -41,6 +41,12 @@ void                udisks_client_new                (GCancellable        *cance
                                                       gpointer             user_data);
 UDisksClient       *udisks_client_new_finish         (GAsyncResult        *res,
                                                       GError             **error);
+void                udisks_client_new_for_connection (GDBusConnection     *connection,
+                                                      GCancellable        *cancellable,
+                                                      GAsyncReadyCallback  callback,
+                                                      gpointer             user_data);
+UDisksClient       *udisks_client_new_for_connection_finish (GAsyncResult  *res,
+                                                             GError       **error);
 UDisksClient       *udisks_client_new_sync           (GCancellable        *cancellable,
                                                       GError             **error);
 GDBusObjectManager *udisks_client_get_object_manager (UDisksClient        *client);


### PR DESCRIPTION
Currently UDisksClient objects always talk to udisksd on the system bus.
This is fine for normal use, but unit tests may want to spin up a
private dbus-daemon using GTestDBus and have udisks use that, to isolate
the tests from the host. So this commit adds a new constructor so that a
GDBusConnection object can be passed in and used during initialization
of the UDisksClient. Also, reword a comment which seemed to imply that
UDisksClient objects are singletons (which they are not).

Before adding this feature we (in an Endless project) were setting
DBUS_SYSTEM_BUS_ADDRESS to the address of the GTestDBus daemon, to trick
udisks into using that daemon. However this led to intermittent unit
test failures when some I/O happened on the connection after the daemon
had been killed by g_test_dbus_down(), causing SIGTERM to be raised by
g_dbus_connection_real_closed(). With this patch and use of the new
constructor, the tests seem to always pass.

Fixes https://github.com/storaged-project/udisks/issues/679