### PR TITLE
integration-test: Skip read only mounting test for exFAT

### DIFF
--- a/src/tests/integration-test
+++ b/src/tests/integration-test
@@ -935,8 +935,8 @@ class FS(UDisksTestCase):
 
         self.assertProperty(fs, 'mount-points', [mount_a])
 
-        if fs_type != 'ntfs':
-            # ntfs-3g does not support multiple mounts
+        if fs_type not in ('ntfs', 'exfat'):
+            # ntfs-3g and exfat don't support multiple mounts
             subprocess.check_call([mount_prog, self.device, mount_b])
             self.assertProperty(fs, 'mount-points', {mount_a, mount_b})
             subprocess.call(['umount', mount_b])

--- a/src/tests/integration-test
+++ b/src/tests/integration-test
@@ -1065,7 +1065,8 @@ class FS(UDisksTestCase):
         # this is known-broken for reiserfs and xfs right now:
         # https://github.com/karelzak/util-linux/issues/17
         # https://github.com/karelzak/util-linux/issues/18
-        if fs_type not in ['reiserfs', 'xfs']:
+        # exfat can be mounted with '-o rw' even if read-only
+        if fs_type not in ['reiserfs', 'xfs', 'exfat']:
             # the scsi_debug CD drive content is the same as for the HD drive, but
             # udev does not know about this; so give it a nudge to re-probe
             subprocess.call(['partprobe', self.cd_device])


### PR DESCRIPTION
exFAT can be mounted with '-o rw' even if the device is read only,
it will just mount it read only.

Fixes #680 