### PR TITLE
Fix (un)locking LUKS2 devices with integrity

### DIFF
--- a/src/udiskslinuxencrypted.c
+++ b/src/udiskslinuxencrypted.c
@@ -128,7 +128,8 @@ wait_for_cleartext_object (UDisksDaemon *daemon,
       block = udisks_object_get_block (object);
       if (block != NULL)
         {
-          if (g_strcmp0 (udisks_block_get_crypto_backing_device (block), crypto_object_path) == 0)
+          if (!is_integrity (UDISKS_LINUX_BLOCK_OBJECT (object)) &&
+              g_strcmp0 (udisks_block_get_crypto_backing_device (block), crypto_object_path) == 0)
             {
               g_object_unref (block);
               ret = g_object_ref (object);

--- a/src/udiskslinuxencryptedhelpers.h
+++ b/src/udiskslinuxencryptedhelpers.h
@@ -74,6 +74,12 @@ gboolean tcrypt_close_job_func (UDisksThreadedJob  *job,
                                 gpointer            user_data,
                                 GError            **error);
 
+gboolean is_luks (UDisksLinuxBlockObject *object);
+
+gboolean is_tcrypt (UDisksLinuxBlockObject *object);
+
+gboolean is_integrity (UDisksLinuxBlockObject *object);
+
 G_END_DECLS
 
 #endif /* __UDISKS_LINUX_ENCRYPTED_HELPERS_H__ */


### PR DESCRIPTION
There is an "extra" dm_integrity device for LUKS2+integerity
devices which confuses our functions that tries to get the
cleartext device. This patch basically ignores the dm_integrity
device and sets the CleartextDevice to the LUKS2 dm_crypt device.

----
The code for checking for if the object is a crypto device is still pretty messy and I'd like to move it to libblockdev (and hopefully use libdevmapper to do that instead of parsing UUID from UDev) in the future, but this should be good enough for now.