### PR TITLE
Fix converting dbus.UInt values to string with Python 3.8

### DIFF
--- a/src/tests/dbus-tests/test_40_drive.py
+++ b/src/tests/dbus-tests/test_40_drive.py
@@ -82,7 +82,7 @@ class UdisksDriveTest(udiskstestcase.UdisksTestCase):
         # validate that configration property has changed
         conf_value = self.get_property(self.cd_drive, '.Drive', 'Configuration')
         conf_value.assertIsNotNone()
-        self.assertEqual(str(conf_value.value['ata-pm-standby']), '286')
+        self.assertEqual(int(conf_value.value['ata-pm-standby']), 286)
 
     @udiskstestcase.skip_on(("centos", "enterprise_linux"), "7", reason="SCSI debug bug causing kernel panic on CentOS/RHEL 7")
     def test_40_properties(self):
@@ -132,4 +132,4 @@ class UdisksDriveTest(udiskstestcase.UdisksTestCase):
         timemediadetected = self.get_property(self.cd_drive, '.Drive', 'TimeMediaDetected')
         self.assertEqual(timedetected.value, timemediadetected.value)
         sortkey = self.get_property(self.cd_drive, '.Drive', 'SortKey')
-        sortkey.assertEqual('01hotplug/%s' % timedetected.value)
+        sortkey.assertEqual('01hotplug/%d' % timedetected.value)


### PR DESCRIPTION
Behaviour change in the default `__str__` method for object in
Python 3.8 caused that converting dbus.UInt variables no longer
works as expected. We need to convert these values to int first.

Python 3.8:
>>> str(dbus.Int64(1))
'dbus.Int64(1)'

Python 3.7 (and older):
>>> str(dbus.UInt64(1))
'1'