### PR TITLE
dbus-tests: Fix decoding journal messages with non-unicode data

### DIFF
--- a/src/tests/dbus-tests/udiskstestcase.py
+++ b/src/tests/dbus-tests/udiskstestcase.py
@@ -582,7 +582,7 @@ class JournalRecorder(FlightRecorder):
         self._stopped = monotonic()
 
     def _save(self):
-        j = journal.Reader()
+        j = journal.Reader(converters={"MESSAGE": lambda x: x.decode(errors="replace")})
         j.this_boot()
         j.seek_monotonic(self._started)
         journal_data = ""


### PR DESCRIPTION
Default converter tries to convert the message using decode() and
if it fails it will return bytes (which then fail to convert in
our code). This change adds custom converter for the MESSAGE key
that replaces the non-unicode characters.