### PR TITLE
remove dot (.) for easier selecting the mounted folder

### DIFF
--- a/tools/udisksctl.c
+++ b/tools/udisksctl.c
@@ -829,7 +829,7 @@ handle_command_mount_unmount (gint        *argc,
           g_object_unref (object);
           goto out;
         }
-      g_print ("Mounted %s at %s.\n",
+      g_print ("Mounted %s at %s\n",
                udisks_block_get_device (block),
                mount_path);
       g_free (mount_path);


### PR DESCRIPTION
When I use `udisksctl mount -b /dev/sda1` at this moment the output is:
`Mounted /dev/sda7 at /run/media/meeuw/2f9b224e-a729-4ae5-9ef6-02aaeb7a7fa6.`

If I double click the path in gnome-terminal to select and copy/paste the output to ie. `cd ` the path is selected including the dot (`.`) which is highly annoying because that path doesn't exist.

Could the dot please be removed from the output? I would also settle for a trailing slash or an additional space before the dot.