### PR TITLE
tests: Skip resize tests for formats without function to get size

### DIFF
--- a/src/tests/dbus-tests/test_80_filesystem.py
+++ b/src/tests/dbus-tests/test_80_filesystem.py
@@ -159,6 +159,9 @@ class UdisksFSTestCase(udiskstestcase.UdisksTestCase):
         if not self._can_mount:
             self.skipTest('Cannot mount %s filesystem' % self._fs_name)
 
+        if not self._can_query_size:
+            self.skipTest('Cannot determine size of %s filesystem' % self._fs_name)
+
         manager = self.get_interface(self.get_object('/Manager'), '.Manager')
         try:
           rep, mode, _ = manager.CanResize(self._fs_name)


### PR DESCRIPTION
This was discovered thanks to recently added support for F2FS to
libblockdev -- UDisks automatically detects we can now resize it
but it can't check it's current size which causes the test to fail.