### PR TITLE
rpm: Don't trigger udev if socket is not accessible

### DIFF
--- a/packaging/udisks2.spec
+++ b/packaging/udisks2.spec
@@ -317,8 +317,6 @@ if [ -S /run/udev/control ]; then
     udevadm control --reload
     udevadm trigger
 fi
-udevadm control --reload
-udevadm trigger
 
 %preun -n %{name}
 %systemd_preun udisks2.service


### PR DESCRIPTION
Attempt #2

Related: #698 