### PR TITLE
udisksspawnedjob: Clear encoding of stdout and stderr channels

### DIFF
--- a/src/udisksspawnedjob.c
+++ b/src/udisksspawnedjob.c
@@ -1032,6 +1032,8 @@ void udisks_spawned_job_start (UDisksSpawnedJob *job)
     }
 
   job->child_stdout_channel = g_io_channel_unix_new (job->child_stdout_fd);
+  /* we want to read binary, suppress checking the encoding: */
+  g_io_channel_set_encoding (job->child_stdout_channel, NULL, NULL);
   g_io_channel_set_flags (job->child_stdout_channel, G_IO_FLAG_NONBLOCK, NULL);
   job->child_stdout_source = g_io_create_watch (job->child_stdout_channel, G_IO_IN);
 #if __GNUC__ >= 8
@@ -1050,6 +1052,8 @@ void udisks_spawned_job_start (UDisksSpawnedJob *job)
   g_source_unref (job->child_stdout_source);
 
   job->child_stderr_channel = g_io_channel_unix_new (job->child_stderr_fd);
+  /* we want to read binary, suppress checking the encoding: */
+  g_io_channel_set_encoding (job->child_stderr_channel, NULL, NULL);
   g_io_channel_set_flags (job->child_stderr_channel, G_IO_FLAG_NONBLOCK, NULL);
   job->child_stderr_source = g_io_create_watch (job->child_stderr_channel, G_IO_IN);
 #if __GNUC__ >= 8


### PR DESCRIPTION
We want to be able to read binary data from the stderr and stdout of
spawned processes, so unset the encoding for those channels — otherwise
it will be validated as UTF-8 and invalid data (particularly embedded
nuls) will be dropped.

GLib became stricter at validating this with
https://gitlab.gnome.org/GNOME/glib/merge_requests/967 in GLib 2.63.0,
but it’s not an API break.

Signed-off-by: Philip Withnall <withnall@endlessm.com>

Fixes: #724