### PR TITLE
Use relative logical partition start in partitioning tests

### DIFF
--- a/src/tests/dbus-tests/test_60_partitioning.py
+++ b/src/tests/dbus-tests/test_60_partitioning.py
@@ -175,8 +175,11 @@ class UdisksPartitionTableTest(udiskstestcase.UdisksTestCase):
         dbus_cont = self.get_property(log_part, '.Partition', 'IsContained')
         dbus_cont.assertTrue()
 
+        dbus_offset = self.get_property(log_part, '.Partition', 'Offset')
+        dbus_size = self.get_property(log_part, '.Partition', 'Size')
+
         # create one more logical partition
-        log_path2 = disk.CreatePartition(dbus.UInt64(51 * 1024**2), dbus.UInt64(50 * 1024**2), '', '',
+        log_path2 = disk.CreatePartition(dbus.UInt64(dbus_offset.value + dbus_size.value), dbus.UInt64(50 * 1024**2), '', '',
                                          log_options, dbus_interface=self.iface_prefix + '.PartitionTable')
         self.udev_settle()
 


### PR DESCRIPTION
We can't assume that the free space in the extended partition will
start at a fixed position, we should use end of the previous
logical partition instead.

This is related to the ongoing rewrite of libblockdev to libfdisk (see https://github.com/storaged-project/libblockdev/pull/455). Optimal partition alignment is slightly different in libfdisk, especially for logical partitions where libfdisk leaves more free space between these (up to 1 MiB) so we should use end of the previous logical partition + 1 as the offset and let fdisk align it. This is also what GNOME Disks uses when creating a new (logical) partition.