### PR TITLE
Allow unlocking encrypted devices as read only

### DIFF
--- a/data/org.freedesktop.UDisks2.xml
+++ b/data/org.freedesktop.UDisks2.xml
@@ -2059,7 +2059,7 @@
     <!--
         Unlock:
         @passphrase: The passphrase to use.
-        @options: Options - known options (in addition to <link linkend="udisks-std-options">standard options</link>) includes <parameter>keyfile_contents</parameter> (of type 'ay') which is preferred over @passphrase if specified.
+        @options: Options - known options (in addition to <link linkend="udisks-std-options">standard options</link>) includes <parameter>keyfile_contents</parameter> (of type 'ay') which is preferred over @passphrase if specified and <parameter>read-only</parameter> (of type 'b').
         @cleartext_device: An object path to the unlocked object implementing the #org.freedesktop.UDisks2.Block interface.
 
         Tries to unlock the encrypted device using @passphrase.

--- a/doc/man/udisksctl.xml.in
+++ b/doc/man/udisksctl.xml.in
@@ -72,6 +72,7 @@
       </group>
       <arg choice="opt">--no-user-interaction</arg>
       <arg choice="opt">--key-file <replaceable>PATH</replaceable></arg>
+      <arg choice="opt">--read-only</arg>
     </cmdsynopsis>
 
     <cmdsynopsis>

--- a/src/udiskslinuxencrypted.c
+++ b/src/udiskslinuxencrypted.c
@@ -551,7 +551,8 @@ handle_unlock (UDisksEncrypted        *encrypted,
 
   device = udisks_block_dup_device (block);
 
-  /* TODO: support reading a 'readonly' option from @options */
+  /* unlock as read-only if specified in @options or if the device itself is read-only */
+  g_variant_lookup (options, "read-only", "b", &read_only);
   if (udisks_block_get_read_only (block))
     read_only = TRUE;
 

--- a/tools/udisksctl.c
+++ b/tools/udisksctl.c
@@ -981,6 +981,7 @@ static gchar   *opt_unlock_lock_object_path = NULL;
 static gchar   *opt_unlock_lock_device = NULL;
 static gboolean opt_unlock_lock_no_user_interaction = FALSE;
 static gchar   *opt_unlock_keyfile = NULL;
+static gboolean opt_unlock_read_only = FALSE;
 
 static const GOptionEntry command_unlock_entries[] =
 {
@@ -1018,6 +1019,15 @@ static const GOptionEntry command_unlock_entries[] =
     G_OPTION_ARG_STRING,
     &opt_unlock_keyfile,
     "Keyfile for unlocking",
+    NULL
+  },
+  {
+    "read-only",
+    0, /* no short option */
+    0,
+    G_OPTION_ARG_NONE,
+    &opt_unlock_read_only,
+    "Unlock the device as read-only",
     NULL
   },
   {
@@ -1279,6 +1289,10 @@ handle_command_unlock_lock (gint        *argc,
                              "keyfile_contents",
                              pack_binary_blob (keyfile_contents, keyfile_size));
     }
+  if (opt_unlock_read_only)
+    g_variant_builder_add (&builder,
+                           "{sv}",
+                           "read-only", g_variant_new_boolean (TRUE));
   options = g_variant_builder_end (&builder);
   g_variant_ref_sink (options);
 


### PR DESCRIPTION
I've noticed this TODO when working on the BitLocker support, so one less TODO for us :-)