### PR TITLE
Fallback to safe udev values where possible for non UTF-8 strings

### DIFF
--- a/src/udisksdaemonutil.c
+++ b/src/udisksdaemonutil.c
@@ -205,6 +205,7 @@ udisks_variant_get_binary (GVariant  *value,
 /**
  * udisks_decode_udev_string:
  * @str: An udev-encoded string or %NULL.
+ * @fallback_str: String to use when @str can't be converted to a valid UTF-8 string.
  *
  * Unescapes sequences like \x20 to " " and ensures the returned string is valid UTF-8.
  *
@@ -218,7 +219,7 @@ udisks_variant_get_binary (GVariant  *value,
  * Returns: A valid UTF-8 string that must be freed with g_free().
  */
 gchar *
-udisks_decode_udev_string (const gchar *str)
+udisks_decode_udev_string (const gchar *str, const gchar *fallback_str)
 {
   GString *s;
   gchar *ret;
@@ -259,8 +260,17 @@ udisks_decode_udev_string (const gchar *str)
   if (!g_utf8_validate (s->str, -1, &end_valid))
     {
       udisks_warning ("The string `%s' is not valid UTF-8. Invalid characters begins at `%s'", s->str, end_valid);
-      ret = g_strndup (s->str, end_valid - s->str);
-      g_string_free (s, TRUE);
+      if (fallback_str)
+        {
+          udisks_info ("Invalid string `%s' replaced by `%s'", s->str, fallback_str);
+          ret = g_strdup (fallback_str);
+          g_string_free (s, TRUE);
+        }
+      else
+        {
+          ret = g_strndup (s->str, end_valid - s->str);
+          g_string_free (s, TRUE);
+        }
     }
   else
     {

--- a/src/udisksdaemonutil.h
+++ b/src/udisksdaemonutil.h
@@ -35,7 +35,8 @@ gboolean udisks_variant_lookup_binary (GVariant     *dict,
 gboolean udisks_variant_get_binary (GVariant  *variant,
                                     GString  **contents);
 
-gchar *udisks_decode_udev_string (const gchar *str);
+gchar *udisks_decode_udev_string (const gchar *str,
+                                  const gchar *fallback_str);
 
 void udisks_safe_append_to_object_path (GString      *str,
                                         const gchar  *s);

--- a/src/udiskslinuxblock.c
+++ b/src/udiskslinuxblock.c
@@ -1258,13 +1258,15 @@ udisks_linux_block_update (UDisksLinuxBlock       *block,
       udisks_block_set_id_type (iface, g_udev_device_get_property (device->udev_device, "ID_FS_TYPE"));
     }
 
-  s = udisks_decode_udev_string (g_udev_device_get_property (device->udev_device, "ID_FS_VERSION"));
+  s = udisks_decode_udev_string (g_udev_device_get_property (device->udev_device, "ID_FS_VERSION"), NULL);
   udisks_block_set_id_version (iface, s);
   g_free (s);
-  s = udisks_decode_udev_string (g_udev_device_get_property (device->udev_device, "ID_FS_LABEL_ENC"));
+  s = udisks_decode_udev_string (g_udev_device_get_property (device->udev_device, "ID_FS_LABEL_ENC"),
+                                 g_udev_device_get_property (device->udev_device, "ID_FS_LABEL"));
   udisks_block_set_id_label (iface, s);
   g_free (s);
-  s = udisks_decode_udev_string (g_udev_device_get_property (device->udev_device, "ID_FS_UUID_ENC"));
+  s = udisks_decode_udev_string (g_udev_device_get_property (device->udev_device, "ID_FS_UUID_ENC"),
+                                 g_udev_device_get_property (device->udev_device, "ID_FS_UUID"));
   udisks_block_set_id_uuid (iface, s);
   g_free (s);
 

--- a/src/udiskslinuxdrive.c
+++ b/src/udiskslinuxdrive.c
@@ -740,7 +740,8 @@ udisks_linux_drive_update (UDisksLinuxDrive       *drive,
       if (model != NULL)
         {
           gchar *s;
-          s = udisks_decode_udev_string (model);
+          s = udisks_decode_udev_string (model,
+                                         g_udev_device_get_property (device->udev_device, "ID_MODEL"));
           g_strstrip (s);
           udisks_drive_set_model (iface, s);
           g_free (s);
@@ -759,7 +760,8 @@ udisks_linux_drive_update (UDisksLinuxDrive       *drive,
       if (vendor != NULL)
         {
           gchar *s;
-          s = udisks_decode_udev_string (vendor);
+          s = udisks_decode_udev_string (vendor,
+                                         g_udev_device_get_property (device->udev_device, "ID_VENDOR"));
           g_strstrip (s);
           udisks_drive_set_vendor (iface, s);
           g_free (s);
@@ -769,7 +771,8 @@ udisks_linux_drive_update (UDisksLinuxDrive       *drive,
       if (model != NULL)
         {
           gchar *s;
-          s = udisks_decode_udev_string (model);
+          s = udisks_decode_udev_string (model,
+                                         g_udev_device_get_property (device->udev_device, "ID_MODEL"));
           g_strstrip (s);
           udisks_drive_set_model (iface, s);
           g_free (s);
@@ -801,7 +804,8 @@ udisks_linux_drive_update (UDisksLinuxDrive       *drive,
       if (vendor != NULL)
         {
           gchar *s;
-          s = udisks_decode_udev_string (vendor);
+          s = udisks_decode_udev_string (vendor,
+                                         g_udev_device_get_property (device->udev_device, "ID_VENDOR"));
           g_strstrip (s);
           udisks_drive_set_vendor (iface, s);
           g_free (s);
@@ -830,7 +834,8 @@ udisks_linux_drive_update (UDisksLinuxDrive       *drive,
       if (model != NULL)
         {
           gchar *s;
-          s = udisks_decode_udev_string (model);
+          s = udisks_decode_udev_string (model,
+                                         g_udev_device_get_property (device->udev_device, "ID_MODEL"));
           g_strstrip (s);
           udisks_drive_set_model (iface, s);
           g_free (s);

--- a/src/udiskslinuxpartition.c
+++ b/src/udiskslinuxpartition.c
@@ -244,7 +244,7 @@ udisks_linux_partition_update (UDisksLinuxPartition   *partition,
       type = g_udev_device_get_property (device->udev_device, "ID_PART_ENTRY_TYPE");
       offset = g_udev_device_get_property_as_uint64 (device->udev_device, "ID_PART_ENTRY_OFFSET") * G_GUINT64_CONSTANT (512);
       size = g_udev_device_get_property_as_uint64 (device->udev_device, "ID_PART_ENTRY_SIZE") * G_GUINT64_CONSTANT (512);
-      name = udisks_decode_udev_string (g_udev_device_get_property (device->udev_device, "ID_PART_ENTRY_NAME"));
+      name = udisks_decode_udev_string (g_udev_device_get_property (device->udev_device, "ID_PART_ENTRY_NAME"), NULL);
       uuid = g_udev_device_get_property (device->udev_device, "ID_PART_ENTRY_UUID");
       flags = g_udev_device_get_property_as_uint64 (device->udev_device, "ID_PART_ENTRY_FLAGS");
 


### PR DESCRIPTION
The `_ENC` udev properties contain escaped "unsafe" characters and
we try to un-escape these and convert to UTF-8 where possible.
Instead of cutting the non UTF-8 part of the string we should
fallback to the safe udev strings (with all unsafe characters
replaced with "_") where possible.

Fixes: #718 