### PR TITLE
dbus_tests: Test tags and other run_tests.py improvements from libblockdev

### DIFF
--- a/src/tests/dbus-tests/run_tests.py
+++ b/src/tests/dbus-tests/run_tests.py
@@ -13,6 +13,7 @@ import glob
 import shutil
 import tempfile
 import re
+import six
 import atexit
 from datetime import datetime
 
@@ -125,14 +126,80 @@ def udev_shake():
     assert subprocess.call(['udevadm', 'settle']) == 0
 
 
-if __name__ == '__main__':
-    tmpdir = None
-    daemon = None
-    suite = unittest.TestSuite()
-    daemon_log = sys.stdout
+def _get_tests_from_suite(suite, tests):
+    """ Extract tests from the test suite """
+    # 'tests' we get from 'unittest.defaultTestLoader.discover' are "wrapped"
+    # in multiple 'unittest.suite.TestSuite' classes/lists so we need to "unpack"
+    # the indivudual test cases
+    for test in suite:
+        if isinstance(test, unittest.suite.TestSuite):
+            _get_tests_from_suite(test, tests)
 
-    # store time when tests started (needed for journal cropping)
-    start_time = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+        if isinstance(test, unittest.TestCase):
+            tests.append(test)
+
+    return tests
+
+
+def _get_test_tags(test):
+    """ Get test tags for single test case """
+
+    tags = set()
+
+    # test failed to load, usually some ImportError or something really broken
+    # in the test file, just return empty list and let it fail
+    # with python2 the loader will raise an exception directly without returning
+    # a "fake" FailedTest test case
+    if six.PY3 and isinstance(test, unittest.loader._FailedTest):
+        return tags
+
+    test_fn = getattr(test, test._testMethodName)
+
+    # it is possible to either tag a test funcion or the class so we need to
+    # check both for the tag
+    if getattr(test_fn, "slow", False) or getattr(test_fn.__self__, "slow", False):
+        tags.add(udiskstestcase.TestTags.SLOW)
+    if getattr(test_fn, "unstable", False) or getattr(test_fn.__self__, "unstable", False):
+        tags.add(udiskstestcase.TestTags.UNSTABLE)
+    if getattr(test_fn, "unsafe", False) or getattr(test_fn.__self__, "unsafe", False):
+        tags.add(udiskstestcase.TestTags.UNSAFE)
+    if getattr(test_fn, "nostorage", False) or getattr(test_fn.__self__, "nostorage", False):
+        tags.add(udiskstestcase.TestTags.NOSTORAGE)
+    if getattr(test_fn, "extradeps", False) or getattr(test_fn.__self__, "extradeps", False):
+        tags.add(udiskstestcase.TestTags.EXTRADEPS)
+
+    return tags
+
+
+def _split_test_id(test_id):
+    # test.id() looks like 'crypto_test.CryptoTestResize.test_luks2_resize'
+    # and we want to print 'test_luks2_resize (crypto_test.CryptoTestResize)'
+    test_desc = test.id().split(".")
+    test_name = test_desc[-1]
+    test_module = ".".join(test_desc[:-1])
+
+    return test_name, test_module
+
+
+def _print_skip_message(test, skip_tags, missing):
+    test_id = test.id()
+    test_module, test_name = _split_test_id(test_id)
+
+    if missing:
+        reason = 'skipping test because it is not tagged as one of: ' + ', '.join((t.value for t in skip_tags))
+    else:
+        reason = 'skipping test because it is tagged as: ' + ', '.join((t.value for t in skip_tags))
+
+    if test._testMethodDoc:
+        print("%s (%s)\n%s ... skipped '%s'" % (test_name, test_module, test._testMethodDoc, reason),
+              file=sys.stderr)
+    else:
+        print("%s (%s) ... skipped '%s'" % (test_name, test_module, reason),
+              file=sys.stderr)
+
+
+def parse_args():
+    """ Parse cmdline arguments """
 
     argparser = argparse.ArgumentParser(description='udisks D-Bus test suite')
     argparser.add_argument('-l', '--log-file', dest='logfile',
@@ -145,7 +212,51 @@ if __name__ == '__main__':
     argparser.add_argument('-f', '--failfast', dest='failfast',
                            help='stop the test run on a first error',
                            action='store_true')
+    argparser.add_argument('--exclude-tags', nargs='+', dest='exclude_tags',
+                           help='skip tests tagged with (at least one of) the provided tags')
+    argparser.add_argument('--include-tags', nargs='+', dest='include_tags',
+                           help='run only tests tagged with (at least one of) the provided tags')
+    argparser.add_argument('--list-tags', dest='list_tags', help='print available tags and exit',
+                           action='store_true')
     args = argparser.parse_args()
+
+    all_tags = set(udiskstestcase.TestTags.get_tags())
+
+    if args.list_tags:
+        print('Available tags:', ', '.join(all_tags))
+        sys.exit(0)
+
+    # lets convert these to sets now to make argument checks easier
+    args.include_tags = set(args.include_tags) if args.include_tags else set()
+    args.exclude_tags = set(args.exclude_tags) if args.exclude_tags else set()
+
+    # make sure user provided only valid tags
+    if not all_tags.issuperset(args.include_tags):
+        print('Unknown tag(s) specified:', ', '.join(args.include_tags - all_tags), file=sys.stderr)
+        sys.exit(1)
+    if not all_tags.issuperset(args.exclude_tags):
+        print('Unknown tag(s) specified:', ', '.join(args.exclude_tags - all_tags), file=sys.stderr)
+        sys.exit(1)
+
+    # for backwards compatibility we want to exclude unsafe and unstable by default
+    if not 'JENKINS_HOME' in os.environ and udiskstestcase.TestTags.UNSAFE.value not in args.include_tags:
+        args.exclude_tags.add(udiskstestcase.TestTags.UNSAFE.value)
+    if udiskstestcase.TestTags.UNSTABLE.value not in args.include_tags:
+        args.exclude_tags.add(udiskstestcase.TestTags.UNSTABLE.value)
+
+    return args
+
+
+if __name__ == '__main__':
+    tmpdir = None
+    daemon = None
+    suite = unittest.TestSuite()
+    daemon_log = sys.stdout
+
+    # store time when tests started (needed for journal cropping)
+    start_time = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+
+    args = parse_args()
 
     setup_vdevs()
 
@@ -187,19 +298,47 @@ if __name__ == '__main__':
         print("Not spawning own process: testing the system installed instance.")
         time.sleep(3)
 
-    # Load all files in this directory whose name starts with 'test'
+    loader = unittest.defaultTestLoader
+    suite = unittest.TestSuite()
+
     if args.testname:
-        for n in args.testname:
-            suite.addTests(unittest.TestLoader().loadTestsFromName(n))
+        test_cases = loader.loadTestsFromNames(args.testname)
     else:
-        for test_cases in unittest.defaultTestLoader.discover(testdir):
-            suite.addTest(test_cases)
+        test_cases = loader.discover(start_dir=testdir)
 
     # truncate the flight record file and make sure it exists
     with open(udiskstestcase.FLIGHT_RECORD_FILE, "w"):
         pass
 
-    result = unittest.TextTestRunner(verbosity=2, failfast=args.failfast).run(suite)
+    # extract list of test classes so we can check/run them manually one by one
+    tests = []
+    tests = _get_tests_from_suite(test_cases, tests)
+
+    # get sets of include/exclude tags as tags not strings from arguments
+    include_tags = set(udiskstestcase.TestTags.get_tag_by_value(t) for t in args.include_tags)
+    exclude_tags = set(udiskstestcase.TestTags.get_tag_by_value(t) for t in args.exclude_tags)
+
+    for test in tests:
+        test_id = test.id()
+
+        # get tags and (possibly) skip the test
+        tags = _get_test_tags(test)
+
+        # if user specified include_tags, test must have at least one of these to run
+        if include_tags and not (include_tags & tags):
+            _print_skip_message(test, include_tags - tags, missing=True)
+            continue
+
+        # if user specified exclude_tags, test can't have any of these
+        if exclude_tags and (exclude_tags & tags):
+            _print_skip_message(test, exclude_tags & tags, missing=False)
+            continue
+
+        # finally add the test to the suite
+        suite.addTest(test)
+
+    runner = unittest.TextTestRunner(verbosity=2, failfast=args.failfast)
+    result = runner.run(suite)
 
     if not args.system:
         daemon.terminate()

--- a/src/tests/dbus-tests/skip.yml
+++ b/src/tests/dbus-tests/skip.yml
@@ -1,0 +1,31 @@
+# List of tests to be skipped
+#
+# Example:
+# This will skip the 'test_mount_ntfs' test case on Debian 10
+# and on all 32bit machines
+#
+###################################
+# - test: fs_test.MountTest.test_mount_ntfs
+#   skip_on:
+#     - distro: "debian"
+#       version: "10"
+#       reason: "NTFS mounting is broken on Debian testing"
+#
+#     - arch: "i686"
+#       reason: "testing skipping from config file"
+###################################
+#
+# Notes:
+# - multiple combinations of reasons are supported.
+# - 'reason' and at least one of 'distro', 'version' and 'arch' is required
+# - 'test' (ID of the test case) can be specified as a regular expression
+#   for example 'kbd_test.KbdBcacheTestCase.*' to skip all kbd tests
+# - all "skips" can specified as a list, for example 'version: [10, 11]'
+
+---
+
+- test: test_40_drive.UdisksDriveTest.*
+  skip_on:
+    - distro: ["centos", "enterprise_linux"]
+      version: "7"
+      reason: "SCSI debug bug causing kernel panic on CentOS/RHEL 7"

--- a/src/tests/dbus-tests/test_40_drive.py
+++ b/src/tests/dbus-tests/test_40_drive.py
@@ -46,7 +46,6 @@ class UdisksDriveTest(udiskstestcase.UdisksTestCase):
             self.udev_settle()
             self.run_command('modprobe -r scsi_debug')
 
-    @udiskstestcase.skip_on(("centos", "enterprise_linux"), "7", reason="SCSI debug bug causing kernel panic on CentOS/RHEL 7")
     def test_10_eject(self):
         ''' Test of Drive.Eject method '''
 
@@ -60,7 +59,6 @@ class UdisksDriveTest(udiskstestcase.UdisksTestCase):
         drive = self.get_drive(dev)
         drive.Eject(self.no_options)
 
-    @udiskstestcase.skip_on(("centos", "enterprise_linux"), "7", reason="SCSI debug bug causing kernel panic on CentOS/RHEL 7")
     def test_20_poweroff(self):
         ''' Test of Drive.PowerOff method '''
         for dev in (self.vdevs[0], self.cd_dev):
@@ -73,7 +71,6 @@ class UdisksDriveTest(udiskstestcase.UdisksTestCase):
                                        'Failed: No usb device'):
                 drive.PowerOff(self.no_options)
 
-    @udiskstestcase.skip_on(("centos", "enterprise_linux"), "7", reason="SCSI debug bug causing kernel panic on CentOS/RHEL 7")
     def test_30_setconfiguration(self):
         ''' Test of Drive.SetConfiguration method '''
         # set configuration value to some improbable value
@@ -84,7 +81,6 @@ class UdisksDriveTest(udiskstestcase.UdisksTestCase):
         conf_value.assertIsNotNone()
         self.assertEqual(int(conf_value.value['ata-pm-standby']), 286)
 
-    @udiskstestcase.skip_on(("centos", "enterprise_linux"), "7", reason="SCSI debug bug causing kernel panic on CentOS/RHEL 7")
     def test_40_properties(self):
         ''' Test of Drive properties values '''
 

--- a/src/tests/dbus-tests/test_50_block.py
+++ b/src/tests/dbus-tests/test_50_block.py
@@ -138,7 +138,7 @@ class UdisksBlockTest(udiskstestcase.UdisksTestCase):
         self.assertTrue(bool(mode & os.O_ASYNC))
         os.close(fd)
 
-    @unittest.skipUnless("JENKINS_HOME" in os.environ, "skipping test that modifies system configuration")
+    @udiskstestcase.tag_test(udiskstestcase.TestTags.UNSAFE)
     def test_configuration_fstab(self):
 
         # this test will change /etc/fstab, we might want to revert the changes when it finishes
@@ -192,7 +192,7 @@ class UdisksBlockTest(udiskstestcase.UdisksTestCase):
         upd_conf = self.get_property(disk, '.Block', 'Configuration')
         upd_conf.assertFalse()
 
-    @unittest.skipUnless("JENKINS_HOME" in os.environ, "skipping test that modifies system configuration")
+    @udiskstestcase.tag_test(udiskstestcase.TestTags.UNSAFE)
     def test_configuration_crypttab(self):
 
         # this test will change /etc/crypttab, we might want to revert the changes when it finishes
@@ -246,7 +246,7 @@ class UdisksBlockTest(udiskstestcase.UdisksTestCase):
         upd_conf = self.get_property(disk, '.Block', 'Configuration')
         upd_conf.assertFalse()
 
-    @unittest.skipUnless("JENKINS_HOME" in os.environ, "skipping test that modifies system configuration")
+    @udiskstestcase.tag_test(udiskstestcase.TestTags.UNSAFE)
     def test_configuration_crypttab_multiple_spaces(self):
         # this test will change /etc/crypttab, we might want to revert the changes when it finishes
         crypttab = self.read_file('/etc/crypttab')

--- a/src/tests/dbus-tests/test_60_partitioning.py
+++ b/src/tests/dbus-tests/test_60_partitioning.py
@@ -4,7 +4,6 @@ import six
 import time
 
 import udiskstestcase
-from udiskstestcase import unstable_test
 
 BLOCK_SIZE = 512
 
@@ -618,7 +617,7 @@ class UdisksPartitionTest(udiskstestcase.UdisksTestCase):
         _ret, sys_type = self.run_command('blkid /dev/%s -p -o value -s PART_ENTRY_TYPE' % part_name)
         self.assertEqual(sys_type, part_type)
 
-    @unstable_test
+    @udiskstestcase.tag_test(udiskstestcase.TestTags.UNSTABLE)
     def test_resize(self):
         disk = self.get_object('/block_devices/' + os.path.basename(self.vdevs[0]))
         self.assertIsNotNone(disk)

--- a/src/tests/dbus-tests/test_70_encrypted.py
+++ b/src/tests/dbus-tests/test_70_encrypted.py
@@ -182,7 +182,7 @@ class UdisksEncryptedTest(udiskstestcase.UdisksTestCase):
         luks_ro = self.get_property(luks_obj, '.Block', 'ReadOnly')
         luks_ro.assertTrue()
 
-    @unittest.skipUnless("JENKINS_HOME" in os.environ, "skipping test that modifies system configuration")
+    @udiskstestcase.tag_test(udiskstestcase.TestTags.UNSAFE)
     def test_open_crypttab(self):
         # this test will change /etc/crypttab, we might want to revert the changes when it finishes
         crypttab = self.read_file('/etc/crypttab')
@@ -228,7 +228,7 @@ class UdisksEncryptedTest(udiskstestcase.UdisksTestCase):
         luks_path = self.get_property(luks_obj, '.Block', 'PreferredDevice')
         luks_path.assertEqual(self.str_to_ay(dm_path))
 
-    @unittest.skipUnless("JENKINS_HOME" in os.environ, "skipping test that modifies system configuration")
+    @udiskstestcase.tag_test(udiskstestcase.TestTags.UNSAFE)
     def test_open_crypttab_keyfile(self):
         # this test will change /etc/crypttab, we might want to revert the changes when it finishes
         crypttab = self.read_file('/etc/crypttab')
@@ -543,7 +543,7 @@ class UdisksEncryptedTestLUKS2(UdisksEncryptedTest):
         default_encryption_type = self.get_property(manager, '.Manager', 'DefaultEncryptionType')
         default_encryption_type.assertEqual(config['defaults']['encryption'])
 
-    @udiskstestcase.unstable_test
+    @udiskstestcase.tag_test(udiskstestcase.TestTags.UNSTABLE)
     def test_integrity(self):
         passwd = 'test'
 

--- a/src/tests/dbus-tests/test_80_filesystem.py
+++ b/src/tests/dbus-tests/test_80_filesystem.py
@@ -18,7 +18,6 @@ from gi.repository import GLib
 
 import safe_dbus
 import udiskstestcase
-from udiskstestcase import unstable_test
 
 
 class UdisksFSTestCase(udiskstestcase.UdisksTestCase):
@@ -768,7 +767,7 @@ class VFATTestCase(UdisksFSTestCase):
 
         return res
 
-    @unittest.skipUnless("JENKINS_HOME" in os.environ, "skipping test that modifies system configuration")
+    @udiskstestcase.tag_test(udiskstestcase.TestTags.UNSAFE)
     def test_mount_fstab_fail(self):
         """ Test that user can't mount device not listed in /etc/fstab """
         disk = self.get_object('/block_devices/' + os.path.basename(self.vdevs[0]))
@@ -802,7 +801,7 @@ class VFATTestCase(UdisksFSTestCase):
         self.assertTrue(os.path.ismount(mnt_path))
         self.try_unmount(mnt_path)
 
-    @unittest.skipUnless("JENKINS_HOME" in os.environ, "skipping test that modifies system configuration")
+    @udiskstestcase.tag_test(udiskstestcase.TestTags.UNSAFE)
     def test_mount_fstab_users_option(self):
         """ Test that user can mount and unmount device with the "users" option in /etc/fstab """
         # users -- any user can mount the device and any user can also unmount it
@@ -836,7 +835,7 @@ class VFATTestCase(UdisksFSTestCase):
         if not res[0]:
             self.fail(res[1])
 
-    @unittest.skipUnless("JENKINS_HOME" in os.environ, "skipping test that modifies system configuration")
+    @udiskstestcase.tag_test(udiskstestcase.TestTags.UNSAFE)
     def test_mount_fstab_user_option(self):
         """ Test that user can mount and unmount device with the "user" option in /etc/fstab """
         # user -- any user can mount the device, only user that mounted it (and root) can
@@ -873,7 +872,7 @@ class VFATTestCase(UdisksFSTestCase):
         if not res[0]:
             self.fail(res[1])
 
-    @unstable_test
+    @udiskstestcase.tag_test(udiskstestcase.TestTags.UNSTABLE)
     def test_repair_resize_check(self):
         super(VFATTestCase, self).test_repair_resize_check()
 
@@ -884,11 +883,11 @@ class NTFSTestCase(UdisksFSTestCase):
     _can_relabel = True and UdisksFSTestCase.command_exists('ntfslabel')
     _can_mount = True
 
-    @unstable_test
+    @udiskstestcase.tag_test(udiskstestcase.TestTags.UNSTABLE)
     def test_repair_resize_check(self):
         super(NTFSTestCase, self).test_repair_resize_check()
 
-    @unstable_test
+    @udiskstestcase.tag_test(udiskstestcase.TestTags.UNSTABLE)
     def test_userspace_mount_options(self):
         super(NTFSTestCase, self).test_userspace_mount_options()
 
@@ -923,7 +922,7 @@ class NILFS2TestCase(UdisksFSTestCase):
     _can_relabel = True and UdisksFSTestCase.command_exists('nilfs-tune')
     _can_mount = True and UdisksFSTestCase.module_available('nilfs2')
 
-    @unstable_test
+    @udiskstestcase.tag_test(udiskstestcase.TestTags.UNSTABLE)
     def test_userspace_mount_options(self):
         super(NILFS2TestCase, self).test_userspace_mount_options()
 

--- a/src/tests/dbus-tests/test_90_swapspace.py
+++ b/src/tests/dbus-tests/test_90_swapspace.py
@@ -3,7 +3,6 @@
 import os
 import dbus
 import udiskstestcase
-from udiskstestcase import unstable_test
 
 class UdisksSwapSpaceTest(udiskstestcase.UdisksTestCase):
     """This is SwapSpace related functions unit test"""
@@ -60,7 +59,7 @@ class UdisksSwapSpaceTest(udiskstestcase.UdisksTestCase):
         active = self.get_property(self.device, '.Swapspace', 'Active')
         active.assertFalse()  # swap shouldn't be active
 
-    @unstable_test
+    @udiskstestcase.tag_test(udiskstestcase.TestTags.UNSTABLE)
     def test_30_set_label(self):
         self.device.Format('swap', self.no_options, dbus_interface=self.iface_prefix + '.Block')
 

--- a/src/tests/dbus-tests/test_btrfs.py
+++ b/src/tests/dbus-tests/test_btrfs.py
@@ -11,7 +11,6 @@ from contextlib import contextmanager
 from distutils.version import LooseVersion
 
 import udiskstestcase
-from udiskstestcase import unstable_test
 
 
 Device = namedtuple('Device', ['obj', 'obj_path', 'path', 'name', 'size'])
@@ -104,7 +103,7 @@ class UdisksBtrfsTest(udiskstestcase.UdisksTestCase):
             sys_size = bytesize.Size(m.group(1))
             self.assertEqual(sys_size.convert_to(bytesize.B), dev.size)
 
-    @unstable_test
+    @udiskstestcase.tag_test(udiskstestcase.TestTags.UNSTABLE)
     def test_create_raid(self):
         devs = self._get_devices(2)
 

--- a/src/tests/dbus-tests/test_mdraid.py
+++ b/src/tests/dbus-tests/test_mdraid.py
@@ -6,7 +6,6 @@ from collections import namedtuple
 from contextlib import contextmanager
 
 import udiskstestcase
-from udiskstestcase import unstable_test
 
 
 Member = namedtuple('Member', ['obj', 'path', 'name', 'size'])
@@ -110,7 +109,7 @@ class RAIDLevel(udiskstestcase.UdisksTestCase):
 
         return data
 
-    @unstable_test
+    @udiskstestcase.tag_test(udiskstestcase.TestTags.UNSTABLE)
     def test_create(self):
         if self.level is None:
             self.skipTest('Abstract class for RAID tests.')
@@ -205,7 +204,7 @@ class RAID0TestCase(RAIDLevel):
     def size(self):
         return len(self.members) * self.smallest_member.size
 
-    @unstable_test
+    @udiskstestcase.tag_test(udiskstestcase.TestTags.UNSTABLE)
     def test_create_noname(self):
         array = self._array_create("")
 
@@ -226,7 +225,7 @@ class RAID0TestCase(RAIDLevel):
         else:
             dbus_name.assertEqual(md_name[2:])
 
-    @unstable_test
+    @udiskstestcase.tag_test(udiskstestcase.TestTags.UNSTABLE)
     def test_start_stop(self):
         name = 'udisks_test_start_stop'
         array = self._array_create(name)
@@ -252,7 +251,7 @@ class RAID0TestCase(RAIDLevel):
         ret, _out = self.run_command('mdadm /dev/md/%s' % name)
         self.assertEqual(ret, 0)
 
-    @unstable_test
+    @udiskstestcase.tag_test(udiskstestcase.TestTags.UNSTABLE)
     def test_delete(self):
         name = 'udisks_test_delete'
         array = self._array_create(name)
@@ -285,7 +284,7 @@ class RAID1TestCase(RAIDLevel):
     def size(self):
         return self.smallest_member.size
 
-    @unstable_test
+    @udiskstestcase.tag_test(udiskstestcase.TestTags.UNSTABLE)
     def test_add_remove_device(self):
         name = 'udisks_delete'
         array = self._array_create(name)
@@ -349,7 +348,7 @@ class RAID1TestCase(RAIDLevel):
         _ret, out = self.run_command('lsblk -d -no FSTYPE %s' % new_dev)
         self.assertEqual(out, '')
 
-    @unstable_test
+    @udiskstestcase.tag_test(udiskstestcase.TestTags.UNSTABLE)
     def test_bitmap_location(self):
         array_name = 'udisks_test_bitmap'
         array = self._array_create(array_name)
@@ -375,7 +374,7 @@ class RAID1TestCase(RAIDLevel):
         sys_bitmap = self.read_file('/sys/block/%s/md/bitmap/location' % md_name).strip()
         dbus_bitmap.assertEqual(self.str_to_ay(sys_bitmap))
 
-    @unstable_test
+    @udiskstestcase.tag_test(udiskstestcase.TestTags.UNSTABLE)
     def test_request_action(self):
 
         array_name = 'udisks_test_request'

--- a/src/tests/dbus-tests/test_vdo.py
+++ b/src/tests/dbus-tests/test_vdo.py
@@ -247,7 +247,7 @@ class UdisksVDOTest(udiskstestcase.UdisksTestCase):
         vdo.Remove(False, self.no_options, dbus_interface=self.iface_prefix + '.Block.VDO')
         self.assertFalse(os.path.exists('/dev/mapper/%s' % vdo_name))
 
-    @udiskstestcase.unstable_test
+    @udiskstestcase.tag_test(udiskstestcase.TestTags.UNSTABLE)
     def test_grow_physical(self):
         '''Test org.freedesktop.UDisks2.Block.VDO.GrowPhysical()'''
 

--- a/src/tests/dbus-tests/test_zram.py
+++ b/src/tests/dbus-tests/test_zram.py
@@ -6,7 +6,6 @@ import unittest
 from distutils.version import LooseVersion
 
 import udiskstestcase
-from udiskstestcase import unstable_test
 
 
 MODPROBECONF = '/usr/lib/modprobe.d/zram.conf'
@@ -81,7 +80,7 @@ class UdisksZRAMTest(udiskstestcase.UdisksTestCase):
     def _swapoff(self, swap):
         self.run_command('swapoff %s' % swap)
 
-    @unstable_test
+    @udiskstestcase.tag_test(udiskstestcase.TestTags.UNSTABLE)
     def test_create_destroy(self):
         manager = self.get_object('/Manager')
         zrams = manager.CreateDevices([10 * 1024**2, 10 * 1024**2], [1, 2], self.no_options,
@@ -156,7 +155,7 @@ class UdisksZRAMTest(udiskstestcase.UdisksTestCase):
         dbus_orig = self.get_property(zram_obj, '.Block.ZRAM', 'OrigDataSize')
         dbus_orig.assertEqual(sys_orig)
 
-    @unstable_test
+    @udiskstestcase.tag_test(udiskstestcase.TestTags.UNSTABLE)
     def test_activate_deactivate(self):
         manager = self.get_object('/Manager')
         zrams = manager.CreateDevices([10 * 1024**2], [1], self.no_options,


### PR DESCRIPTION
Few changes for running tests (DBus tests only in this case) inspired by libblockdev test suite. The biggest change are the test tags. I've not tagged the tests yet (other than converting existing "unsafe" and "unstable" decorators to the new tags), because I'm not sure if we want to use all tags that libblockdev uses -- do we want to mark also "slow" tests (to be able to run just quick tests, instead of the entire suite which takes around 1 hour) and select a subset of "core" tests for even quicker sanity checks?
Note I will adjust the jenkins PR job to run "stable" and "unstable" tests separately before merging this.