### PR TITLE
daemon: Port away from G_TYPE_INSTANCE_GET_PRIVATE()

### DIFF
--- a/src/udisksbasejob.c
+++ b/src/udisksbasejob.c
@@ -169,7 +169,7 @@ udisks_base_job_init (UDisksBaseJob *job)
 {
   gint64 now_usec;
 
-  job->priv = G_TYPE_INSTANCE_GET_PRIVATE (job, UDISKS_TYPE_BASE_JOB, UDisksBaseJobPrivate);
+  job->priv = udisks_base_job_get_instance_private (job);
 
   now_usec = g_get_real_time ();
   udisks_job_set_start_time (UDISKS_JOB (job), now_usec);

--- a/src/udisksprovider.c
+++ b/src/udisksprovider.c
@@ -117,7 +117,7 @@ udisks_provider_set_property (GObject      *object,
 static void
 udisks_provider_init (UDisksProvider *provider)
 {
-  provider->priv = G_TYPE_INSTANCE_GET_PRIVATE (provider, UDISKS_TYPE_PROVIDER, UDisksProviderPrivate);
+  provider->priv = udisks_provider_get_instance_private (provider);
 }
 
 static void


### PR DESCRIPTION
This has been deprecated since glib-2.58