### PR TITLE
dbus-tests: Fix expected MD_DEVICE key in mdadm --detail output

### DIFF
--- a/src/tests/dbus-tests/test_mdraid.py
+++ b/src/tests/dbus-tests/test_mdraid.py
@@ -102,8 +102,12 @@ class RAIDLevel(udiskstestcase.UdisksTestCase):
             # this is probably a bug in mdadm, but we need to fix it somehow
             # until they fix it (or call it a feature) and it's better to do
             # it here than change every test
+            # update: they fixed it, now we can choose beetween "ev", "dev" and
+            #         nothing based on mdadm version
             if key.startswith('MD_DEVICE_ev'):
                 data[key.replace('_ev_', '_')] = value
+            elif key.startswith('MD_DEVICE_dev'):
+                data[key.replace('_dev_', '_')] = value
             else:
                 data[key] = value
 


### PR DESCRIPTION
This should fix some of the failing unstable mdraid DBus tests.