### PR TITLE
spec: Add polkit as a weak dependency

### DIFF
--- a/packaging/udisks2.spec
+++ b/packaging/udisks2.spec
@@ -134,6 +134,12 @@ Requires: eject
 # For utab monitor
 Requires: libmount
 
+%if (0%{?rhel}) && (0%{?rhel} <= 7)
+# Not really needed but doesn't make much sense to use UDisks without polkit
+# (weak deps don't work on older versions of RHEL)
+Recommends: polkit
+%endif
+
 Requires: lib%{name}%{?_isa} = %{version}-%{release}
 
 # For mkntfs (not available on rhel or on ppc/ppc64)


### PR DESCRIPTION
It is possible to use UDisks without polkit (calling all functions
only as root) but it doesn't really make sense so we should
recommend installing it.