### PR TITLE
WIP: LVM2 module uevent processing optimization

### DIFF
--- a/doc/udisks2-sections.txt.daemon.sections.in
+++ b/doc/udisks2-sections.txt.daemon.sections.in
@@ -196,6 +196,7 @@ UDisksLinuxProvider
 udisks_linux_provider_new
 udisks_linux_provider_get_udev_client
 udisks_linux_provider_get_coldplug
+udisks_linux_provider_get_modules_coldplug
 <SUBSECTION Standard>
 UDISKS_TYPE_LINUX_PROVIDER
 UDISKS_LINUX_PROVIDER

--- a/doc/udisks2-sections.txt.daemon.sections.in
+++ b/doc/udisks2-sections.txt.daemon.sections.in
@@ -197,6 +197,7 @@ udisks_linux_provider_new
 udisks_linux_provider_get_udev_client
 udisks_linux_provider_get_coldplug
 udisks_linux_provider_get_modules_coldplug
+udisks_linux_provider_get_last_uevent
 <SUBSECTION Standard>
 UDISKS_TYPE_LINUX_PROVIDER
 UDISKS_LINUX_PROVIDER

--- a/modules/lvm2/udiskslinuxvolumegroupobject.c
+++ b/modules/lvm2/udiskslinuxvolumegroupobject.c
@@ -904,3 +904,20 @@ udisks_linux_volume_group_object_get_name (UDisksLinuxVolumeGroupObject *object)
   g_return_val_if_fail (UDISKS_IS_LINUX_VOLUME_GROUP_OBJECT (object), NULL);
   return object->name;
 }
+
+/**
+ * udisks_linux_volume_group_object_get_lv_count:
+ * @object: A #UDisksLinuxVolumeGroupObject.
+ *
+ * Gets the number of logical volumes the volume group contains.
+ *
+ * Returns: The number of logical volumes for the object.
+ */
+guint
+udisks_linux_volume_group_object_get_lv_count (UDisksLinuxVolumeGroupObject *object)
+{
+  g_return_val_if_fail (UDISKS_IS_LINUX_VOLUME_GROUP_OBJECT (object), 0);
+  g_assert (object->logical_volumes != NULL);
+
+  return g_hash_table_size (object->logical_volumes);
+}

--- a/modules/lvm2/udiskslinuxvolumegroupobject.h
+++ b/modules/lvm2/udiskslinuxvolumegroupobject.h
@@ -40,7 +40,8 @@ const gchar                    *udisks_linux_volume_group_object_get_name      (
 UDisksLinuxModuleLVM2          *udisks_linux_volume_group_object_get_module    (UDisksLinuxVolumeGroupObject *object);
 void                            udisks_linux_volume_group_object_update        (UDisksLinuxVolumeGroupObject *object,
                                                                                 BDLVMVGdata                  *vginfo,
-                                                                                GSList                       *pvs);
+                                                                                GSList                       *pvs,
+                                                                                gboolean                      update_sync);
 
 void                            udisks_linux_volume_group_object_poll          (UDisksLinuxVolumeGroupObject *object);
 

--- a/modules/lvm2/udiskslinuxvolumegroupobject.h
+++ b/modules/lvm2/udiskslinuxvolumegroupobject.h
@@ -42,6 +42,7 @@ void                            udisks_linux_volume_group_object_update        (
                                                                                 BDLVMVGdata                  *vginfo,
                                                                                 GSList                       *pvs,
                                                                                 gboolean                      update_sync);
+guint                           udisks_linux_volume_group_object_get_lv_count  (UDisksLinuxVolumeGroupObject *object);
 
 void                            udisks_linux_volume_group_object_poll          (UDisksLinuxVolumeGroupObject *object);
 

--- a/modules/lvm2/udiskslvm2types.h
+++ b/modules/lvm2/udiskslvm2types.h
@@ -25,6 +25,14 @@
 #define LVM2_MODULE_NAME "lvm2"
 #define LVM2_POLICY_ACTION_ID "org.freedesktop.udisks2.lvm2.manage-lvm"
 
+/**
+ * LVM2_SCALABLE_MODE_THRESHOLD:
+ *
+ * Number of logical volumes detected in the system needed to
+ * switch the scalable mode on.
+ */
+#define LVM2_SCALABLE_MODE_THRESHOLD 100
+
 struct _UDisksLinuxModuleLVM2;
 typedef struct _UDisksLinuxModuleLVM2 UDisksLinuxModuleLVM2;
 

--- a/src/tests/dbus-tests/run_tests.py
+++ b/src/tests/dbus-tests/run_tests.py
@@ -184,6 +184,8 @@ def _get_test_tags(test):
         tags.add(udiskstestcase.TestTags.NOSTORAGE)
     if getattr(test_fn, "extradeps", False) or getattr(test_fn.__self__, "extradeps", False):
         tags.add(udiskstestcase.TestTags.EXTRADEPS)
+    if getattr(test_fn, "loadtest", False) or getattr(test_fn.__self__, "loadtest", False):
+        tags.add(udiskstestcase.TestTags.LOADTEST)
 
     tags.add(udiskstestcase.TestTags.ALL)
 
@@ -308,13 +310,15 @@ def parse_args():
         print('Unknown tag(s) specified:', ', '.join(args.exclude_tags - all_tags), file=sys.stderr)
         sys.exit(1)
 
-    # for backwards compatibility we want to exclude unsafe and unstable by default
+    # for backwards compatibility we want to exclude unsafe, unstable and loadtests by default
     if not 'JENKINS_HOME' in os.environ and not (udiskstestcase.TestTags.UNSAFE.value in args.include_tags or
                                                  udiskstestcase.TestTags.ALL.value in args.include_tags):
         args.exclude_tags.add(udiskstestcase.TestTags.UNSAFE.value)
     if not (udiskstestcase.TestTags.UNSTABLE.value in args.include_tags or
             udiskstestcase.TestTags.ALL.value in args.include_tags):
         args.exclude_tags.add(udiskstestcase.TestTags.UNSTABLE.value)
+    if not (udiskstestcase.TestTags.LOADTEST.value in args.include_tags):
+        args.exclude_tags.add(udiskstestcase.TestTags.LOADTEST.value)
 
     return args
 

--- a/src/tests/dbus-tests/test_20_LVM.py
+++ b/src/tests/dbus-tests/test_20_LVM.py
@@ -1,6 +1,7 @@
 import dbus
 import os
 import re
+import shutil
 import time
 import unittest
 
@@ -55,6 +56,8 @@ class UDisksLVMTestBase(udiskstestcase.UdisksTestCase):
             vg.Delete(True, options, dbus_interface=self.iface_prefix + '.VolumeGroup')
             ret, _out = self.run_command('vgs %s' % vgname)
             self.assertNotEqual(ret, 0)
+            # remove lingering /dev entries
+            shutil.rmtree(os.path.join('/dev', vgname), ignore_errors=True)
         except dbus.exceptions.DBusException as e:
             if not ignore_removed:
                 raise e

--- a/src/tests/dbus-tests/udiskstestcase.py
+++ b/src/tests/dbus-tests/udiskstestcase.py
@@ -656,6 +656,7 @@ class TestTags(Enum):
     UNSAFE = "unsafe"         # tests that change system configuration
     NOSTORAGE = "nostorage"   # tests that don't work with storage
     EXTRADEPS = "extradeps"   # tests that require special configuration and/or device to run
+    LOADTEST = "loadtest"     # tests used to prepare heavy load environment
 
     @classmethod
     def get_tags(cls):
@@ -678,6 +679,7 @@ def tag_test(*tags):
         func.unsafe = TestTags.UNSAFE in tags
         func.nostorage = TestTags.NOSTORAGE in tags
         func.extradeps = TestTags.EXTRADEPS in tags
+        func.loadtest = TestTags.LOADTEST in tags
 
         return func
 

--- a/src/udiskslinuxdevice.c
+++ b/src/udiskslinuxdevice.c
@@ -97,6 +97,7 @@ static gboolean probe_ata (UDisksLinuxDevice  *device,
 /**
  * udisks_linux_device_new_sync:
  * @udev_device: A #GUdevDevice.
+ * @timestamp: Monotonic time of the @udev_device first appearance.
  *
  * Creates a new #UDisksLinuxDevice from @udev_device which includes
  * probing the device for more information, if applicable.
@@ -107,15 +108,18 @@ static gboolean probe_ata (UDisksLinuxDevice  *device,
  * Returns: A #UDisksLinuxDevice.
  */
 UDisksLinuxDevice *
-udisks_linux_device_new_sync (GUdevDevice *udev_device)
+udisks_linux_device_new_sync (GUdevDevice *udev_device,
+                              gint64       timestamp)
 {
   UDisksLinuxDevice *device;
   GError *error = NULL;
 
   g_return_val_if_fail (G_UDEV_IS_DEVICE (udev_device), NULL);
+  g_return_val_if_fail (timestamp > 0, NULL);
 
   device = g_object_new (UDISKS_TYPE_LINUX_DEVICE, NULL);
   device->udev_device = g_object_ref (udev_device);
+  device->timestamp = timestamp;
 
   /* No point in probing on remove events */
   if (!(g_strcmp0 (g_udev_device_get_action (udev_device), "remove") == 0))

--- a/src/udiskslinuxdevice.h
+++ b/src/udiskslinuxdevice.h
@@ -48,10 +48,12 @@ struct _UDisksLinuxDevice
   GUdevDevice *udev_device;
   guchar *ata_identify_device_data;
   guchar *ata_identify_packet_device_data;
+  gint64  timestamp;
 };
 
 GType              udisks_linux_device_get_type     (void) G_GNUC_CONST;
-UDisksLinuxDevice *udisks_linux_device_new_sync     (GUdevDevice *udev_device);
+UDisksLinuxDevice *udisks_linux_device_new_sync     (GUdevDevice        *udev_device,
+                                                     gint64              timestamp);
 gboolean           udisks_linux_device_reprobe_sync (UDisksLinuxDevice  *device,
                                                      GCancellable       *cancellable,
                                                      GError            **error);

--- a/src/udiskslinuxprovider.c
+++ b/src/udiskslinuxprovider.c
@@ -90,6 +90,7 @@ struct _UDisksLinuxProvider
 
   /* set to TRUE only in the coldplug phase */
   gboolean coldplug;
+  gboolean modules_coldplug;
 
   guint housekeeping_timeout;
   guint64 housekeeping_last;
@@ -576,11 +577,13 @@ ensure_modules (UDisksLinuxProvider *provider)
     }
 
   /* Perform coldplug */
-  udisks_debug ("Performing coldplug...");
+  udisks_debug ("Performing secondary/modules coldplug...");
   udisks_devices = get_udisks_devices (provider);
+  provider->modules_coldplug = TRUE;
   do_coldplug (provider, udisks_devices);
+  provider->modules_coldplug = FALSE;
   g_list_free_full (udisks_devices, g_object_unref);
-  udisks_debug ("Coldplug complete");
+  udisks_debug ("Secondary/modules coldplug complete");
 }
 
 /*
@@ -849,6 +852,24 @@ udisks_linux_provider_get_coldplug (UDisksLinuxProvider *provider)
 {
   g_return_val_if_fail (UDISKS_IS_LINUX_PROVIDER (provider), FALSE);
   return provider->coldplug;
+}
+
+/**
+ * udisks_linux_provider_get_modules_coldplug:
+ * @provider: A #UDisksLinuxProvider.
+ *
+ * Gets whether @provider is in the secondary coldplug phase as a result
+ * of module(s) being activated. This "modules coldplug" phase is intended
+ * for synchronous additional module interfaces initialization over
+ * an already initialized (coldplugged) base drive or block object.
+ *
+ * Returns: %TRUE if in the secondary coldplug phase, %FALSE otherwise.
+ **/
+gboolean
+udisks_linux_provider_get_modules_coldplug (UDisksLinuxProvider *provider)
+{
+  g_return_val_if_fail (UDISKS_IS_LINUX_PROVIDER (provider), FALSE);
+  return provider->modules_coldplug;
 }
 
 /* ---------------------------------------------------------------------------------------------------- */

--- a/src/udiskslinuxprovider.c
+++ b/src/udiskslinuxprovider.c
@@ -1387,6 +1387,7 @@ handle_block_uevent (UDisksLinuxProvider *provider,
       handle_block_uevent_for_block (provider, action, device);
       handle_block_uevent_for_drive (provider, action, device);
       handle_block_uevent_for_mdraid (provider, action, device);
+      /* TODO: implement two-phase pre-remove and post-remove modules callback */
       handle_block_uevent_for_modules (provider, action, device);
     }
   else
@@ -1404,10 +1405,11 @@ handle_block_uevent (UDisksLinuxProvider *provider,
         }
       else
         {
-          handle_block_uevent_for_modules (provider, action, device);
           handle_block_uevent_for_mdraid (provider, action, device);
           handle_block_uevent_for_drive (provider, action, device);
           handle_block_uevent_for_block (provider, action, device);
+          /* TODO: implement two-phase pre-add and post-add modules callback */
+          handle_block_uevent_for_modules (provider, action, device);
         }
     }
 

--- a/src/udiskslinuxprovider.h
+++ b/src/udiskslinuxprovider.h
@@ -35,6 +35,7 @@ UDisksLinuxProvider   *udisks_linux_provider_new             (UDisksDaemon      
 GUdevClient           *udisks_linux_provider_get_udev_client (UDisksLinuxProvider *provider);
 gboolean               udisks_linux_provider_get_coldplug    (UDisksLinuxProvider *provider);
 gboolean               udisks_linux_provider_get_modules_coldplug (UDisksLinuxProvider *provider);
+gint64                 udisks_linux_provider_get_last_uevent (UDisksLinuxProvider *provider);
 
 G_END_DECLS
 

--- a/src/udiskslinuxprovider.h
+++ b/src/udiskslinuxprovider.h
@@ -34,6 +34,7 @@ GType                  udisks_linux_provider_get_type        (void) G_GNUC_CONST
 UDisksLinuxProvider   *udisks_linux_provider_new             (UDisksDaemon        *daemon);
 GUdevClient           *udisks_linux_provider_get_udev_client (UDisksLinuxProvider *provider);
 gboolean               udisks_linux_provider_get_coldplug    (UDisksLinuxProvider *provider);
+gboolean               udisks_linux_provider_get_modules_coldplug (UDisksLinuxProvider *provider);
 
 G_END_DECLS
 


### PR DESCRIPTION
This is a set of improvements to LVM2 module uevent processing. The primary goal was to rate-limit number of lvm commands spawned (using the libblockdev lvm-command based plugin) to prevent filling the sequential udisks daemon uevent queue. Uevent timestamp checking has been introduced and requests to the LVM updates are omitted when another update is running or when there was no new uevent received since the last update.

However there are couple of conceptual problems that are out of scope of this pull request. The major problem is the big global PVs/VGs/LVs update done in the udisks lvm2 module. The whole system picture is updated always when an uevent is received on a block device carrying DM/LVM signature. The big update then touches multiple D-Bus objects, updating object paths - cross references between objects, etc. 

By skipping calls to this global update may however uncover unexpected issues that are not obvious on a first sight. I've changed the order of uevent processing to run callbacks to modules as last. That's just a workaround and proper solution should be implemented (thus marking this PR as WIP).

The proper way would be to introduce pre- and post- hooks to block device uevent processing chain and split the current big update to smaller chunks, reacting on particular block devices only. I.e. attaching extra D-Bus interfaces to existing block objects should be separated and proper module API used, meta module objects should be handled in the current big update routine and cross-object references should be updated in a post- hook. This is a non-trivial amount of work and subsequent debugging and verification.

Related: #811


Also, a simple load test to create and destroy 1000 LVs/snapshots is introduced to produce some load and prepare "heavy" testing environment.