### PR TITLE
tests: Test modules that are actually enabled during build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,6 +72,7 @@ src/tests/udisks-test
 src/tests/udisks-test-helper
 src/udisksd
 stamp-*
+src/tests/dbus-tests/config_h.py
 tools/udisksctl
 tools/umount.udisks2
 udisks/modules.conf.d/udisks2_lsm.conf

--- a/Makefile.am
+++ b/Makefile.am
@@ -28,7 +28,6 @@ EXTRA_DIST =                                                                   \
 DISTCHECK_CONFIGURE_FLAGS =                                                    \
 	--enable-gtk-doc                                                       \
 	--enable-modules                                                       \
-	--enable-vdo                                                           \
 	--disable-introspection                                                \
 	--with-udevdir=$$dc_install_base/$(udevdir)                            \
 	--with-systemdsystemunitdir=$$dc_install_base/$(systemdsystemunitdir)  \

--- a/configure.ac
+++ b/configure.ac
@@ -732,6 +732,7 @@ udisks/modules.conf.d/Makefile
 udisks/modules.conf.d/udisks2_lsm.conf
 src/Makefile
 src/tests/Makefile
+src/tests/dbus-tests/Makefile
 tools/Makefile
 modules/Makefile
 modules/btrfs/Makefile

--- a/src/tests/Makefile.am
+++ b/src/tests/Makefile.am
@@ -1,6 +1,6 @@
 ## Process this file with automake to produce Makefile.in
 
-SUBDIRS =
+SUBDIRS = dbus-tests
 
 NULL =
 

--- a/src/tests/dbus-tests/Makefile.am
+++ b/src/tests/dbus-tests/Makefile.am
@@ -1,0 +1,46 @@
+# Generate config.h.py with translated defines for easy use within Python
+
+CONFIG_H_PY = config_h.py
+MODULES =
+
+if HAVE_BTRFS
+MODULES += btrfs
+endif
+
+if HAVE_ISCSI
+MODULES += iscsi
+endif
+
+if HAVE_LVM2
+MODULES += lvm2
+endif
+
+if HAVE_ZRAM
+MODULES += zram
+endif
+
+if HAVE_LSM
+MODULES += lsm
+endif
+
+if HAVE_BCACHE
+MODULES += bcache
+endif
+
+if HAVE_VDO
+MODULES += vdo
+endif
+
+$(CONFIG_H_PY):
+	echo -n 'UDISKS_MODULES_ENABLED = { ' > $(CONFIG_H_PY)
+	for i in $(MODULES); do \
+		echo -n "'$$i', " >> $(CONFIG_H_PY); \
+	done
+	echo '}' >> $(CONFIG_H_PY)
+
+all: $(CONFIG_H_PY)
+
+EXTRA_DIST =
+
+clean-local:
+	rm -f *~ $(CONFIG_H_PY)


### PR DESCRIPTION
Runtime detection against running distribution and available executables
was always a problem to keep in sync. Use actual list of build-time
enabled modules instead.