### PR TITLE
mount options: Allow 'nosymfollow' mount option for unprivileged mounts

### DIFF
--- a/data/builtin_mount_options.conf
+++ b/data/builtin_mount_options.conf
@@ -1,5 +1,5 @@
 [defaults]
-allow=exec,noexec,nodev,nosuid,atime,noatime,nodiratime,relatime,strictatime,lazytime,ro,rw,sync,dirsync,noload,acl
+allow=exec,noexec,nodev,nosuid,atime,noatime,nodiratime,relatime,strictatime,lazytime,ro,rw,sync,dirsync,noload,acl,nosymfollow
 
 vfat_defaults=uid=$UID,gid=$GID,shortname=mixed,utf8=1,showexec,flush
 vfat_allow=uid=$UID,gid=$GID,flush,utf8,shortname,umask,dmask,fmask,codepage,iocharset,usefree,showexec


### PR DESCRIPTION
New in kernel 5.10, a handy security hardening feature.
https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=dab741e0e02bd3c4f5e2e97be74b39df2523fc6e