### PR TITLE
udisksstate: Silence the block device busy messages on cleanup lock

### DIFF
--- a/src/udisksstate.c
+++ b/src/udisksstate.c
@@ -727,7 +727,7 @@ udisks_state_check_mounted_fs_entry (UDisksState  *state,
           gchar *device_file;
 
           device_file = udisks_linux_block_object_get_device_file (UDISKS_LINUX_BLOCK_OBJECT (block_object));
-          udisks_notice ("udisks_state_check_mounted_fs_entry: block device %s is busy, skipping cleanup", device_file);
+          udisks_debug ("udisks_state_check_mounted_fs_entry: block device %s is busy, skipping cleanup", device_file);
           g_free (device_file);
 
           keep = TRUE;


### PR DESCRIPTION
Too confusing for users, actually gets logged among the daemon messages.
Most D-Bus method handlers locking the block device queue an explicit
cleanup once finished so this message is effectively useless anyway.