### PR TITLE
tests: Fix checking if VFAT is resizable

### DIFF
--- a/src/tests/dbus-tests/test_10_basic.py
+++ b/src/tests/dbus-tests/test_10_basic.py
@@ -139,9 +139,11 @@ class UdisksBaseTest(udiskstestcase.UdisksTestCase):
             self.assertEqual(util, 'resize2fs')
         self.assertEqual(avail, find_executable('resize2fs') is not None)
         avail, mode, util = manager.CanResize('vfat')
-        self.assertTrue(avail)  # libparted, no executable
-        self.assertEqual(util, '')
-        self.assertEqual(mode, offline_shrink | offline_grow)
+        if avail:
+            self.assertEqual(util, '')
+        else:
+            self.assertEqual(util, 'vfat-resize')
+        self.assertEqual(avail, find_executable('vfat-resize') is not None)
 
     def test_40_can_repair(self):
         '''Test for installed filesystem repair utility with CanRepair'''


### PR DESCRIPTION
The resize functionallity is no longer provided by libblockdev
fs module directly, "vfat-resize" tool is now required so we need
to check for its availability in the test.