### PR TITLE
Do not use bd_crypto_luks_uuid to get UUID of LUKS devices

### DIFF
--- a/src/udiskslinuxblock.c
+++ b/src/udiskslinuxblock.c
@@ -1636,16 +1636,16 @@ has_whitespace (const gchar *s)
 static gchar *
 make_block_luksname (UDisksBlock *block, GError **error)
 {
-  gchar *uuid = NULL;
+  BDCryptoLUKSInfo *info = NULL;
 
   udisks_linux_block_encrypted_lock (block);
-  uuid = bd_crypto_luks_uuid (udisks_block_get_device (block), error);
+  info = bd_crypto_luks_info (udisks_block_get_device (block), error);
   udisks_linux_block_encrypted_unlock (block);
 
-  if (uuid)
+  if (info)
     {
-      gchar *ret = g_strdup_printf ("luks-%s", uuid);
-      g_free (uuid);
+      gchar *ret = g_strdup_printf ("luks-%s", info->uuid);
+      bd_crypto_luks_info_free (info);
 
       return ret;
     }


### PR DESCRIPTION
This function will be removed in libblockdev 3.0, we can get
UUID from the bd_crypt_luks_info.

https://github.com/storaged-project/libblockdev/pull/614 needs to be merged first (`bd_crypto_luks_info` currently returns error when called with the backing block device)