### PR TITLE
dosfstools >= 4.2 quirks

### DIFF
--- a/src/udiskslinuxblock.c
+++ b/src/udiskslinuxblock.c
@@ -2913,7 +2913,9 @@ static inline gboolean
 need_partprobe_after_mkfs (const gchar *fs_type)
 {
   /* udftools makes fake MBR since the 2.0 release */
-  return (g_strcmp0 (fs_type, "udf") == 0);
+  /* dosfstools makes fake MBR since the 4.2 release */
+  return (g_strcmp0 (fs_type, "udf") == 0 ||
+          g_strcmp0 (fs_type, "vfat") == 0);
 }
 
 void


### PR DESCRIPTION
This is a quick and ugly workaround reverting back the old behaviour until we sort out all the related issues and find a proper way across the storage stack (#859)

The rule of thumb here is that UDisks is just a tool and its consumers with higher level logic should be aware of what they're doing.

References:
https://github.com/dosfstools/dosfstools/releases/tag/v4.2
https://github.com/storaged-project/libblockdev/pull/618

Closes #851