### PR TITLE
udiskslinuxpartition: Trigger uevent after changing partition type

### DIFF
--- a/src/udiskslinuxpartition.c
+++ b/src/udiskslinuxpartition.c
@@ -764,6 +764,9 @@ udisks_linux_partition_set_type_sync (UDisksLinuxPartition  *partition,
       goto out;
     }
 
+  udisks_linux_block_object_trigger_uevent_sync (UDISKS_LINUX_BLOCK_OBJECT (object),
+                                                 UDISKS_DEFAULT_WAIT_TIMEOUT);
+
   ret = TRUE;
   udisks_simple_job_complete (UDISKS_SIMPLE_JOB (job), TRUE, NULL);
 


### PR DESCRIPTION
We need to force UDev to update the value in the database. We
already do this in other similar partition functions when chaning
name or flags.