### PR TITLE
Module naming limitation

### DIFF
--- a/doc/udisks2-sections.txt.daemon.sections.in
+++ b/doc/udisks2-sections.txt.daemon.sections.in
@@ -312,6 +312,7 @@ udisks_daemon_util_get_free_mdraid_device
 udisks_ata_identify_get_word
 udisks_daemon_util_trigger_uevent
 udisks_daemon_util_trigger_uevent_sync
+udisks_module_validate_name
 </SECTION>
 
 <SECTION>

--- a/src/tests/dbus-tests/test_10_basic.py
+++ b/src/tests/dbus-tests/test_10_basic.py
@@ -1,6 +1,7 @@
 import udiskstestcase
 import dbus
 import os
+import six
 from distutils.spawn import find_executable
 
 from config_h import UDISKS_MODULES_ENABLED
@@ -54,7 +55,9 @@ class UdisksBaseTest(udiskstestcase.UdisksTestCase):
             pass
 
         # mock the udisks2.conf to load only tested modules
-        contents = '[udisks2]\nmodules=%s\n' % ','.join(self._get_modules())
+        modules = self._get_modules()
+        modules.add('inva/id')
+        contents = '[udisks2]\nmodules=%s\n' % ','.join(modules)
         self.write_file(self._get_udisks2_conf_path(), contents)
         self.addCleanup(self._restore_udisks2_conf)
 
@@ -72,10 +75,21 @@ class UdisksBaseTest(udiskstestcase.UdisksTestCase):
             with self.assertRaises(dbus.exceptions.DBusException):
                 manager.EnableModule(module, dbus.Boolean(False))
             manager.EnableModule(module, dbus.Boolean(True))
-        with self.assertRaises(dbus.exceptions.DBusException):
-            manager.EnableModule("nonexistent", dbus.Boolean(True))
-        with self.assertRaises(dbus.exceptions.DBusException):
+        with six.assertRaisesRegex(self, dbus.exceptions.DBusException,
+                                   r'cannot open shared object file: No such file or directory'):
+            manager.EnableModule("non-exist_ent", dbus.Boolean(True))
+        with six.assertRaisesRegex(self, dbus.exceptions.DBusException,
+                                   r'Module unloading is not currently supported.'):
             manager.EnableModule("nonexistent", dbus.Boolean(False))
+        with six.assertRaisesRegex(self, dbus.exceptions.DBusException,
+                                   r'Requested module name .* is not a valid udisks2 module name.'):
+            manager.EnableModule("inváálěd", dbus.Boolean(True))
+        with six.assertRaisesRegex(self, dbus.exceptions.DBusException,
+                                   r'Requested module name .* is not a valid udisks2 module name.'):
+            manager.EnableModule("inváálěd", dbus.Boolean(False))
+        with six.assertRaisesRegex(self, dbus.exceptions.DBusException,
+                                   r'Requested module name .* is not a valid udisks2 module name.'):
+            manager.EnableModule("module/../intruder", dbus.Boolean(True))
 
     def test_30_supported_filesystems(self):
         fss = self.get_property(self.manager_obj, '.Manager', 'SupportedFilesystems')

--- a/src/udisksdaemonutil.c
+++ b/src/udisksdaemonutil.c
@@ -1880,3 +1880,29 @@ udisks_daemon_util_trigger_uevent_sync (UDisksDaemon *daemon,
 }
 
 /* ---------------------------------------------------------------------------------------------------- */
+
+/**
+ * udisks_module_validate_name:
+ * @module_name: A udisks2 module name.
+ *
+ * Checks the string for a valid udisks2 module name. Only alphanumeric characters
+ * along with the '-' and '_' separators are permitted.
+ *
+ * Returns: %TRUE if the string is a valid udisks2 module name, %FALSE otherwise.
+ */
+gboolean
+udisks_module_validate_name (const gchar *module_name)
+{
+  int i;
+
+  for (i = 0; module_name[i] != '\0'; i++)
+    /* going ASCII, will disqualify any UTF-* string */
+    if (! g_ascii_isalnum (module_name[i]) &&
+        module_name[i] != '-' &&
+        module_name[i] != '_')
+      return FALSE;
+
+  return TRUE;
+}
+
+/* ---------------------------------------------------------------------------------------------------- */

--- a/src/udisksdaemonutil.h
+++ b/src/udisksdaemonutil.h
@@ -129,6 +129,8 @@ gchar *udisks_daemon_util_get_free_mdraid_device (void);
 
 guint16 udisks_ata_identify_get_word (const guchar *identify_data, guint word_number);
 
+gboolean udisks_module_validate_name (const gchar *module_name);
+
 /* Utility macro for policy verification. */
 #define UDISKS_DAEMON_CHECK_AUTHORIZATION(daemon,                   \
                                           object,                   \

--- a/src/udiskslinuxmanager.c
+++ b/src/udiskslinuxmanager.c
@@ -956,6 +956,15 @@ handle_enable_module (UDisksManager         *object,
   UDisksLinuxManager *manager = UDISKS_LINUX_MANAGER (object);
   EnableModulesData *data;
 
+  if (! udisks_module_validate_name (arg_name))
+    {
+      g_dbus_method_invocation_return_error (invocation,
+                                             G_IO_ERROR, G_IO_ERROR_INVALID_ARGUMENT,
+                                             "Requested module name '%s' is not a valid udisks2 module name.",
+                                             arg_name);
+      return TRUE;
+    }
+
   if (! arg_enable)
     {
       /* TODO: implement proper module unloading */


### PR DESCRIPTION
Although the current way of mocking up a module soname filepath leaves very little room for exploitation, it's generally wise to constrain allowed characters in a module name.