### PR TITLE
udiskslinuxfilesystem: Update udisks_linux_filesystem_update() call

### DIFF
--- a/src /udiskslinuxblockobject.c
+++ b/src /udiskslinuxblockobject.c
@@ -747,7 +747,7 @@ filesystem_update (UDisksObject   *object,
                    GDBusInterface *_iface)
 {
   FsUpdateData *data = NULL;
-  data = g_new0 (FsUpdata, 1);
+  data = g_new0 (FsUpdateData, 1);
   data->filesystem = UDISKS_LINUX_FILESYSTEM (_iface);
   data->object = UDISKS_LINUX_BLOCK_OBJECT (object);
   g_thread_new("filesystem-update",udisks_linux_filesystem_update,data);

--- a/src/udiskslinuxblockobject.c
+++ b/src/udiskslinuxblockobject.c
@@ -746,7 +746,11 @@ filesystem_update (UDisksObject   *object,
                    const gchar    *uevent_action,
                    GDBusInterface *_iface)
 {
-  udisks_linux_filesystem_update (UDISKS_LINUX_FILESYSTEM (_iface), UDISKS_LINUX_BLOCK_OBJECT (object));
+  FsUpdateData *data = NULL;
+  data = g_new0 (FsUpdata, 1);
+  data->filesystem = UDISKS_LINUX_FILESYSTEM (_iface);
+  data->object = UDISKS_LINUX_BLOCK_OBJECT (object);
+  g_thread_new("filesystem-update",udisks_linux_filesystem_update,data);
   return TRUE;
 }
 

--- a/src/udiskslinuxfilesystem.h
+++ b/src/udiskslinuxfilesystem.h
@@ -29,10 +29,19 @@ G_BEGIN_DECLS
 #define UDISKS_LINUX_FILESYSTEM(o)           (G_TYPE_CHECK_INSTANCE_CAST ((o), UDISKS_TYPE_LINUX_FILESYSTEM, UDisksLinuxFilesystem))
 #define UDISKS_IS_LINUX_FILESYSTEM(o)        (G_TYPE_CHECK_INSTANCE_TYPE ((o), UDISKS_TYPE_LINUX_FILESYSTEM))
 
+/*
+ * @filesystem: A #UDisksLinuxFilesystem.
+ * @object: The enclosing #UDisksLinuxBlockObject instance.
+*/
+typedef struct
+{
+    UDisksLinuxFilesystem  *filesystem;
+    UDisksLinuxBlockObject *object;
+}FsUpdateData;
+
 GType             udisks_linux_filesystem_get_type (void) G_GNUC_CONST;
 UDisksFilesystem *udisks_linux_filesystem_new      (void);
-void              udisks_linux_filesystem_update   (UDisksLinuxFilesystem  *filesystem,
-                                                    UDisksLinuxBlockObject *object);
+void              udisks_linux_filesystem_update   (gpointer user_data);
 
 G_END_DECLS
 


### PR DESCRIPTION
When the udisks_linux_filesystem_update() function calls the
udisks_linux_filesystem_update() function, it adopts a
multi-threaded method. Prevent the main process from
freezing when a certain device resource is occupied.
#871 

Signed-off-by: changlianzhi <changlianzhi@uniontech.com>