### PR TITLE
udisksclient: Make get_block_for_drive deterministic

### DIFF
--- a/udisks/udisksclient.c
+++ b/udisks/udisksclient.c
@@ -816,6 +816,20 @@ udisks_client_get_block_for_dev (UDisksClient *client,
 
 /* ---------------------------------------------------------------------------------------------------- */
 
+static int
+compare_blocks_by_device (gconstpointer a,
+                          gconstpointer b)
+{
+  UDisksBlock *block_a = udisks_object_get_block (UDISKS_OBJECT (a));
+  UDisksBlock *block_b = udisks_object_get_block (UDISKS_OBJECT (b));
+
+  g_assert (block_a != NULL);
+  g_assert (block_b != NULL);
+
+  return g_strcmp0 (udisks_block_get_device (block_a),
+                    udisks_block_get_device (block_b));
+}
+
 static GList *
 get_top_level_blocks_for_drive (UDisksClient *client,
                                 const gchar  *drive_object_path)
@@ -847,6 +861,7 @@ get_top_level_blocks_for_drive (UDisksClient *client,
         }
       g_object_unref (block);
     }
+  ret = g_list_sort (ret, compare_blocks_by_device);
   g_list_free_full (object_proxies, g_object_unref);
   return ret;
 }


### PR DESCRIPTION
While any given Block object has at most one corresponding Drive, many
Block objects may share the same Drive. One example is eMMC devices
which provide a block device for the main data area (e.g. /dev/mmcblk0)
as well as additional logical block devices for device partitions (e.g.
/dev/mmcblk0boot0 and /dev/mmcblk0boot1).

This behaviour was introduced in #834 to resolve issue #619 that these
device partitions caused a phantom additional Drive object to be
exposed. On that issue, I wrote:

> I believe that Block.Drive on the boot partitions should point to the
> same data area as the main data area (and its logical partitions);
> udisks_client_get_block_for_drive() on the drive should return
> /org/freedesktop/UDisks2/block_devices/mmcblk0.

The first part is now true, but as described on #879 the second part is
not true. It is now non-deterministic which Block will be returned,
based only on the order of objects returned by
g_dbus_object_manager_get_objects().

Make the return value of udisks_client_get_block_for_drive()
deterministic by sorting the list of candidate Block objects by their
device path in lexicographic order. Since (e.g.) /dev/mmcblk0 sorts
before /dev/mmcblk0boot0, this has the desirable side-effect that
calling udisks_client_get_block_for_drive() on an eMMC Drive returns the
'real' Block for the main data area.

Fixes #879.