### PR TITLE
Use the mkfs command to format exfat partitions

### DIFF
--- a/src/udiskslinuxfsinfo.c
+++ b/src/udiskslinuxfsinfo.c
@@ -123,7 +123,7 @@ const FSInfo _fs_info[] =
       NULL,
       FALSE, /* supports_online_label_rename */
       FALSE, /* supports_owners */
-      "mkexfatfs -n $LABEL $DEVICE",
+      "mkfs.exfat -n $LABEL $DEVICE",
       NULL,
       NULL, /* option_no_discard */
     },


### PR DESCRIPTION
The currently used mkexfatfs is only available in exfat-utils and not in
the new exfatprogs. Unfortunately those project use different arguments
to set the label so workaround by not setting it...

https://github.com/storaged-project/udisks/issues/882