### PR TITLE
udiskslinuxprovider: Filter out spurious uevents

### DIFF
--- a/src/udiskslinuxprovider.c
+++ b/src/udiskslinuxprovider.c
@@ -222,6 +222,7 @@ typedef struct
   UDisksLinuxProvider *provider;
   GUdevDevice *udev_device;
   UDisksLinuxDevice *udisks_device;
+  gboolean known_block;
 } ProbeRequest;
 
 static void
@@ -253,6 +254,30 @@ on_idle_with_probed_uevent (gpointer user_data)
 }
 
 /* ---------------------------------------------------------------------------------------------------- */
+
+static gboolean
+uevent_is_spurious (GUdevDevice *dev)
+{
+  if (g_strcmp0 (g_udev_device_get_action (dev), "change") != 0)
+    return FALSE;
+
+  if (g_strcmp0 (g_udev_device_get_subsystem (dev), "block") != 0)
+    return FALSE;
+
+  if (g_strcmp0 (g_udev_device_get_devtype (dev), "disk") != 0)
+    return FALSE;
+
+  if (g_udev_device_has_property (dev, "ID_TYPE"))
+    return FALSE;
+
+  /* see kernel block/genhd.c: disk_uevents[] */
+  if (g_udev_device_get_property_as_int (dev, "DISK_MEDIA_CHANGE") == 1)
+    return TRUE;
+  if (g_udev_device_get_property_as_int (dev, "DISK_EJECT_REQUEST") == 1)
+    return TRUE;
+
+  return FALSE;
+}
 
 gpointer
 probe_request_thread_func (gpointer user_data)
@@ -289,6 +314,10 @@ probe_request_thread_func (gpointer user_data)
         dev_initialized = g_udev_device_get_is_initialized (request->udev_device);
       }
 
+      /* ignore spurious uevents */
+      if (!request->known_block && uevent_is_spurious (request->udev_device))
+        continue;
+
       /* probe the device - this may take a while */
       request->udisks_device = udisks_linux_device_new_sync (request->udev_device);
 
@@ -311,10 +340,14 @@ on_uevent (GUdevClient  *client,
 {
   UDisksLinuxProvider *provider = UDISKS_LINUX_PROVIDER (user_data);
   ProbeRequest *request;
+  const gchar *sysfs_path;
 
   request = g_slice_new0 (ProbeRequest);
   request->provider = g_object_ref (provider);
   request->udev_device = g_object_ref (device);
+
+  sysfs_path = g_udev_device_get_sysfs_path (device);
+  request->known_block = sysfs_path != NULL && g_hash_table_contains (provider->sysfs_to_block, sysfs_path);
 
   /* process uevent in "probing-thread" */
   g_async_queue_push (provider->probe_request_queue, request);


### PR DESCRIPTION
Sometimes a stray 'change' uevent with a wrong sysfs path is sent for a device
that demands attention or to indicate that media has changed. Such uevents
often carry no useful information and while the major:minor numbers match
a physical device, the sysfs path often don't match. That creates a trouble
to the current sysfs-to-block mapping and a new phantom object is being created.
As these uevents are rather rare the object may stay exported on the D-Bus
object manager forever as no 'remove' uevent is ever received. That in turn
creates object naming conflict when a device with the same major:minor numbers
and different sysfs path appears.

The attributes in question are DISK_MEDIA_CHANGE=1 and DISK_EJECT_REQUEST=1.
See the kernel block/genhd.c sources for further reference.

Let's just filter such 'change' uevents out in anticipation for a proper uevent
carrying probed identifiers.

An example of such uevents:

KERNEL[438.130580] change   /sdb (block)
ACTION=change
DEVPATH=/sdb
SUBSYSTEM=block
DISK_MEDIA_CHANGE=1
DEVNAME=/dev/sdb
DEVTYPE=disk
SEQNUM=3500
MAJOR=8
MINOR=16

UDEV  [438.132049] change   /sdb (block)
ACTION=change
DEVPATH=/sdb
SUBSYSTEM=block
DISK_MEDIA_CHANGE=1
DEVNAME=/dev/sdb
DEVTYPE=disk
SEQNUM=3500
USEC_INITIALIZED=438131885
ID_SCSI=1
ID_BUS=scsi
.ID_FS_TYPE_NEW=
ID_FS_TYPE=
MAJOR=8
MINOR=16
TAGS=:systemd:

Fixes #886
Fixes #887