### PR TITLE
iSCSI timeouts

### DIFF
--- a/src/tests/dbus-tests/udiskstestcase.py
+++ b/src/tests/dbus-tests/udiskstestcase.py
@@ -37,7 +37,8 @@ def run_command(command):
 def get_call_long(call):
     def call_long(*args, **kwargs):
         """Do an async call with a very long timeout (unless specified otherwise)"""
-        kwargs['timeout'] = 100  # seconds
+        if 'timeout' not in kwargs:
+            kwargs['timeout'] = 100  # seconds
         return call(*args, **kwargs)
 
     return call_long


### PR DESCRIPTION
There's an issue somewhere within the `open-iscsi` library handling the actual initiator login, sometimes causing timeouts after roughly 120 seconds. That however exceeds the default tests D-Bus method call timeout of 100 seconds, leading to test failures. Also since the `libiscsi` (or the UDisks iscsi module) has a global lock and the daemon is still handling that previous method call, all further tests would lock and wait, causing further test failures (timeouts).