### PR TITLE
Set default LUKS version to LUKS2

### DIFF
--- a/packaging/udisks2.spec
+++ b/packaging/udisks2.spec
@@ -13,9 +13,6 @@
 %define with_zram                       1
 %define with_lvmcache                   1
 
-# valid options are 'luks1' or 'luks2'
-%define default_luks_encryption         luks1
-
 %define is_fedora                       0%{?rhel} == 0
 %define is_git                          %(git show > /dev/null 2>&1 && echo 1 || echo 0)
 %define git_hash                        %(git log -1 --pretty=format:"%h" || true)
@@ -37,11 +34,6 @@
 %if (0%{?rhel}) && (0%{?rhel} <= 7)
 %define with_lsm 0
 %define with_lvmcache 0
-%endif
-
-# default to LUKS2 for RHEL > 7
-%if 0%{?rhel} > 7
-%define default_luks_encryption luks2
 %endif
 
 
@@ -238,7 +230,6 @@ This package contains module for ZRAM configuration.
 
 %prep
 %setup -q -n udisks-%{version}
-sed -i udisks/udisks2.conf.in -e "s/encryption=luks1/encryption=%{default_luks_encryption}/"
 
 %build
 autoreconf -ivf

--- a/udisks/udisks2.conf.in
+++ b/udisks/udisks2.conf.in
@@ -7,4 +7,4 @@ modules_load_preference=ondemand
 
 [defaults]
 # Valid options are 'luks1' or 'luks2'
-encryption=luks1
+encryption=luks2


### PR DESCRIPTION
LUKS2 is mature enough so we should make it default everywhere
not only on RHEL.