### PR TITLE
dbus_tests: Fix including non-existing tests based on tags

### DIFF
--- a/src/tests/dbus-tests/run_tests.py
+++ b/src/tests/dbus-tests/run_tests.py
@@ -162,6 +162,7 @@ def _get_test_tags(test):
     """ Get test tags for single test case """
 
     tags = set()
+    tags.add(udiskstestcase.TestTags.ALL)
 
     # test failed to load, usually some ImportError or something really broken
     # in the test file, just return empty list and let it fail
@@ -184,8 +185,6 @@ def _get_test_tags(test):
         tags.add(udiskstestcase.TestTags.NOSTORAGE)
     if getattr(test_fn, "extradeps", False) or getattr(test_fn.__self__, "extradeps", False):
         tags.add(udiskstestcase.TestTags.EXTRADEPS)
-
-    tags.add(udiskstestcase.TestTags.ALL)
 
     return tags
 


### PR DESCRIPTION
When running tests with --include-tags=all we should not skip
non-existing tests and tests that fail to load and let unittest
show the exception instead.