### PR TITLE
Add missing argument for bd_fs_wipe ()

### DIFF
--- a/src/udiskslinuxblock.c
+++ b/src/udiskslinuxblock.c
@@ -3100,7 +3100,7 @@ udisks_linux_block_handle_format (UDisksBlock             *block,
   device_name = udisks_block_dup_device (block);
 
   /* First wipe the device... */
-  if (! bd_fs_wipe (device_name, TRUE, &error))
+  if (! bd_fs_wipe (device_name, TRUE, TRUE, &error))
     {
       if (g_error_matches (error, BD_FS_ERROR, BD_FS_ERROR_NOFS))
         /* no signature to remove, ignore */

--- a/src/udiskslinuxmanager.c
+++ b/src/udiskslinuxmanager.c
@@ -699,7 +699,7 @@ handle_mdraid_create (UDisksManager         *_object,
   for (l = blocks; l != NULL; l = l->next)
     {
       UDisksBlock *block = UDISKS_BLOCK (l->data);
-      if (!bd_fs_wipe (udisks_block_get_device (block), TRUE, &error))
+      if (!bd_fs_wipe (udisks_block_get_device (block), TRUE, TRUE, &error))
         {
           /* no signature to remove, ignore */
           if (g_error_matches (error, BD_FS_ERROR, BD_FS_ERROR_NOFS))
@@ -815,7 +815,7 @@ handle_mdraid_create (UDisksManager         *_object,
                            caller_uid);
 
   /* ... wipe the created RAID array */
-  if (!bd_fs_wipe (raid_device_file, TRUE, &error))
+  if (!bd_fs_wipe (raid_device_file, TRUE, TRUE, &error))
     {
       if (g_error_matches (error, BD_FS_ERROR, BD_FS_ERROR_NOFS))
         g_clear_error (&error);

--- a/src/udiskslinuxmdraid.c
+++ b/src/udiskslinuxmdraid.c
@@ -1060,7 +1060,7 @@ handle_remove_device (UDisksMDRaid           *_mdraid,
 
   if (opt_wipe)
     {
-      if (!bd_fs_wipe (member_device_file, TRUE, &error))
+      if (!bd_fs_wipe (member_device_file, TRUE, TRUE, &error))
         {
           g_prefix_error (&error,
                           "Error wiping '%s' after removal from RAID array '%s': ",

--- a/src/udiskslinuxpartitiontable.c
+++ b/src/udiskslinuxpartitiontable.c
@@ -492,7 +492,7 @@ udisks_linux_partition_table_handle_create_partition (UDisksPartitionTable   *ta
   /* wipe the newly created partition if wanted */
   if (part_spec->type != BD_PART_TYPE_EXTENDED)
     {
-      if (!bd_fs_wipe (part_spec->path, TRUE, &error))
+      if (!bd_fs_wipe (part_spec->path, TRUE, TRUE, &error))
         {
           if (g_error_matches (error, BD_FS_ERROR, BD_FS_ERROR_NOFS))
             g_clear_error (&error);


### PR DESCRIPTION
libblockdev added a new argument for bd_fs_wipe/clean to control force wipe.   https://github.com/storaged-project/libblockdev/commit/4c7c8db78cd51bdfdf686a9a03213ddebc2bb709
As I understand it, before this change it was always forced.