### PR TITLE
Add (no)autodefrag to list of allowed btrfs mount options

### DIFF
--- a/data/builtin_mount_options.conf
+++ b/data/builtin_mount_options.conf
@@ -20,7 +20,7 @@ udf_allow=uid=$UID,gid=$GID,iocharset,utf8,umask,mode,dmode,unhide,undelete
 hfsplus_defaults=uid=$UID,gid=$GID,nls=utf8
 hfsplus_allow=uid=$UID,gid=$GID,creator,type,umask,session,part,decompose,nodecompose,force,nls
 
-btrfs_allow=compress,compress-force,datacow,nodatacow,datasum,nodatasum,degraded,device,discard,nodiscard,subvol,subvolid,space_cache
+btrfs_allow=compress,compress-force,datacow,nodatacow,datasum,nodatasum,autodefrag,noautodefrag,degraded,device,discard,nodiscard,subvol,subvolid,space_cache
 
 f2fs_allow=discard,nodiscard,compress_algorithm,compress_log_size,compress_extension,alloc_mode
 


### PR DESCRIPTION
Fixes: #905