### PR TITLE
fixes to build where libblockdev include files require dbus.h

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -142,6 +142,9 @@ fi
 # Libraries
 #
 
+PKG_CHECK_MODULES(DBUS_1, [dbus-1])
+AC_SUBST(DBUS_1_CFLAGS)
+
 PKG_CHECK_MODULES(GLIB, [glib-2.0 >= 2.50])
 AC_SUBST(GLIB_CFLAGS)
 AC_SUBST(GLIB_LIBS)
@@ -603,7 +606,7 @@ if test "x$enable_daemon" = "xyes"; then
   SAVE_CFLAGS=$CFLAGS
   SAVE_LDFLAGS=$LDFLAGS
 
-  CFLAGS="$GLIB_CFLAGS"
+  CFLAGS="$GLIB_CFLAGS $DBUS_1_CFLAGS"
   LDFLAGS="$GLIB_LIBS"
   AC_MSG_CHECKING([libblockdev-swap presence])
   AC_TRY_COMPILE([#include <blockdev/swap.h>], [],
@@ -623,7 +626,7 @@ if test "x$enable_daemon" = "xyes"; then
   SAVE_CFLAGS=$CFLAGS
   SAVE_LDFLAGS=$LDFLAGS
 
-  CFLAGS="$GLIB_CFLAGS"
+  CFLAGS="$GLIB_CFLAGS $DBUS_1_CFLAGS"
   LDFLAGS="$GLIB_LIBS"
   AC_MSG_CHECKING([libblockdev-mdraid presence])
   AC_TRY_COMPILE([#include <blockdev/mdraid.h>], [],
@@ -643,7 +646,7 @@ if test "x$enable_daemon" = "xyes"; then
   SAVE_CFLAGS=$CFLAGS
   SAVE_LDFLAGS=$LDFLAGS
 
-  CFLAGS="$GLIB_CFLAGS"
+  CFLAGS="$GLIB_CFLAGS $DBUS_1_CFLAGS"
   LDFLAGS="$GLIB_LIBS"
   AC_MSG_CHECKING([libblockdev-fs presence])
   AC_TRY_COMPILE([#include <blockdev/fs.h>], [],
@@ -663,7 +666,7 @@ if test "x$enable_daemon" = "xyes"; then
   SAVE_CFLAGS=$CFLAGS
   SAVE_LDFLAGS=$LDFLAGS
 
-  CFLAGS="$GLIB_CFLAGS"
+  CFLAGS="$GLIB_CFLAGS $DBUS_1_CFLAGS"
   LDFLAGS="$GLIB_LIBS"
   AC_MSG_CHECKING([libblockdev-crypto presence])
   AC_TRY_COMPILE([#include <blockdev/crypto.h>], [],

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -27,6 +27,7 @@ CPPFLAGS =                                                                     \
 	$(GIO_CFLAGS)                                                          \
 	$(GMODULE_CFLAGS)                                                      \
 	$(BLOCKDEV_CFLAGS)                                                     \
+	$(DBUS_1_CFLAGS)                                                       \
 	$(WARN_CFLAGS)                                                         \
 	$(NULL)
 


### PR DESCRIPTION
In order to build the latest git checkout from source, I needed these changes. `/usr/include/blockdev/utils.h` contains the line `#include "dbus.h"` and configure was failing to find dbus include files such as `/usr/lib64/dbus-1.0/include/dbus/dbus-arch-deps.h`. So this is a transitive dependency that isn't being accounted for.

This was on an OpenSuSE tumbleweed system which is not a system I use extensively but a VM I have around for when it's useful to test or build against bleeding edge packages. I'm not sure if they have the same libblockdev as Redhat but their packages are called libbd-part etc rather than libblockdev. I initially tried on RHEL 8 but didn't want to get into dependency hell tracking down what was needed there. Perhaps more logic is needed if this is only applicable in some situations?