### PR TITLE
Distutils deprecation

### DIFF
--- a/src/tests/dbus-tests/force_clean.py
+++ b/src/tests/dbus-tests/force_clean.py
@@ -3,7 +3,7 @@ import subprocess
 import glob
 import syslog
 
-from distutils.version import LooseVersion
+from packaging.version import Version
 
 
 class ForceClean(object):
@@ -55,7 +55,7 @@ class ForceClean(object):
         import blivet
 
         # we need at least blivet 2.0 to do this cleanup
-        if LooseVersion(blivet.__version__) >= LooseVersion("2.0.0"):
+        if Version(blivet.__version__) >= Version("2.0.0"):
             blvt = blivet.Blivet()
             blvt.reset()
             for device in diff:

--- a/src/tests/dbus-tests/test_10_basic.py
+++ b/src/tests/dbus-tests/test_10_basic.py
@@ -2,7 +2,7 @@ import udiskstestcase
 import dbus
 import os
 import six
-from distutils.spawn import find_executable
+import shutil
 
 from config_h import UDISKS_MODULES_ENABLED
 
@@ -106,19 +106,19 @@ class UdisksBaseTest(udiskstestcase.UdisksTestCase):
             self.assertEqual(util, '')
         else:
             self.assertEqual(util, 'mkfs.xfs')
-        self.assertEqual(avail, find_executable('mkfs.xfs') is not None)
+        self.assertEqual(avail, shutil.which('mkfs.xfs') is not None)
         avail, util = manager.CanFormat('f2fs')
         if avail:
             self.assertEqual(util, '')
         else:
             self.assertEqual(util, 'mkfs.f2fs')
-        self.assertEqual(avail, find_executable('mkfs.f2fs') is not None)
+        self.assertEqual(avail, shutil.which('mkfs.f2fs') is not None)
         avail, util = manager.CanFormat('ext4')
         if avail:
             self.assertEqual(util, '')
         else:
             self.assertEqual(util, 'mkfs.ext4')
-        self.assertEqual(avail, find_executable('mkfs.ext4') is not None)
+        self.assertEqual(avail, shutil.which('mkfs.ext4') is not None)
         for fs in map(str, self.get_property(self.manager_obj, '.Manager', 'SupportedFilesystems').value):
             avail, util = manager.CanFormat(fs)
             # currently UDisks relies on executables for filesystem creation
@@ -143,20 +143,20 @@ class UdisksBaseTest(udiskstestcase.UdisksTestCase):
             self.assertEqual(util, '')
         else:
             self.assertEqual(util, 'xfs_growfs')
-        self.assertEqual(avail, find_executable('xfs_growfs') is not None)
+        self.assertEqual(avail, shutil.which('xfs_growfs') is not None)
         avail, mode, util = manager.CanResize('ext4')
         self.assertEqual(mode, offline_shrink | offline_grow | online_grow)
         if avail:
             self.assertEqual(util, '')
         else:
             self.assertEqual(util, 'resize2fs')
-        self.assertEqual(avail, find_executable('resize2fs') is not None)
+        self.assertEqual(avail, shutil.which('resize2fs') is not None)
         avail, mode, util = manager.CanResize('vfat')
         if avail:
             self.assertEqual(util, '')
         else:
             self.assertEqual(util, 'vfat-resize')
-        self.assertEqual(avail, find_executable('vfat-resize') is not None)
+        self.assertEqual(avail, shutil.which('vfat-resize') is not None)
 
     def test_40_can_repair(self):
         '''Test for installed filesystem repair utility with CanRepair'''
@@ -168,13 +168,13 @@ class UdisksBaseTest(udiskstestcase.UdisksTestCase):
             self.assertEqual(util, '')
         else:
             self.assertEqual(util, 'xfs_repair')
-        self.assertEqual(avail, find_executable('xfs_repair') is not None)
+        self.assertEqual(avail, shutil.which('xfs_repair') is not None)
         avail, util = manager.CanRepair('ext4')
         if avail:
             self.assertEqual(util, '')
         else:
             self.assertEqual(util, 'e2fsck')
-        self.assertEqual(avail, find_executable('e2fsck') is not None)
+        self.assertEqual(avail, shutil.which('e2fsck') is not None)
         avail, util = manager.CanRepair('vfat')
         self.assertTrue(avail)  # libparted, no executable
         self.assertEqual(util, '')
@@ -189,13 +189,13 @@ class UdisksBaseTest(udiskstestcase.UdisksTestCase):
             self.assertEqual(util, '')
         else:
             self.assertEqual(util, 'xfs_db')
-        self.assertEqual(avail, find_executable('xfs_db') is not None)
+        self.assertEqual(avail, shutil.which('xfs_db') is not None)
         avail, util = manager.CanCheck('ext4')
         if avail:
             self.assertEqual(util, '')
         else:
             self.assertEqual(util, 'e2fsck')
-        self.assertEqual(avail, find_executable('e2fsck') is not None)
+        self.assertEqual(avail, shutil.which('e2fsck') is not None)
         avail, util = manager.CanCheck('vfat')
         self.assertTrue(avail)  # libparted, no executable
         self.assertEqual(util, '')

--- a/src/tests/dbus-tests/test_19_lsm.py
+++ b/src/tests/dbus-tests/test_19_lsm.py
@@ -4,8 +4,7 @@ import six
 import dbus
 import unittest
 import tempfile
-
-from distutils.spawn import find_executable
+import shutil
 
 import udiskstestcase
 
@@ -34,7 +33,7 @@ class UdisksLSMTestCase(udiskstestcase.UdisksTestCase):
         udiskstestcase.UdisksTestCase.setUpClass()
 
         # sqlite3 is needed to hack the lsm sim db
-        if not find_executable('sqlite3'):
+        if not shutil.which('sqlite3'):
             udiskstestcase.UdisksTestCase.tearDownClass()
             raise unittest.SkipTest('LSM: sqlite3 executable not found in $PATH, skipping.')
 

--- a/src/tests/dbus-tests/test_20_LVM.py
+++ b/src/tests/dbus-tests/test_20_LVM.py
@@ -4,7 +4,7 @@ import re
 import time
 import unittest
 
-from distutils.version import LooseVersion
+from packaging.version import Version
 
 import udiskstestcase
 
@@ -28,7 +28,7 @@ class UDisksLVMTestBase(udiskstestcase.UdisksTestCase):
         m = re.search(r'LVM version:.* ([\d\.]+)', out)
         if not m or len(m.groups()) != 1:
             raise RuntimeError('Failed to determine LVM version from: %s' % out)
-        return LooseVersion(m.groups()[0])
+        return Version(m.groups()[0])
 
     def _create_vg(self, vgname, devices):
         manager = self.get_object('/Manager')
@@ -425,7 +425,7 @@ class UdisksLVMVDOTest(UDisksLVMTestBase):
             raise unittest.SkipTest('VDO kernel module not available, skipping.')
 
         lvm_version = cls._get_lvm_version()
-        if lvm_version < LooseVersion('2.3.07'):
+        if lvm_version < Version('2.3.07'):
             udiskstestcase.UdisksTestCase.tearDownClass()
             raise unittest.SkipTest('LVM >= 2.3.07 is needed for LVM VDO, skipping.')
 

--- a/src/tests/dbus-tests/test_70_encrypted.py
+++ b/src/tests/dbus-tests/test_70_encrypted.py
@@ -13,7 +13,7 @@ import gi
 gi.require_version('BlockDev', '2.0')
 from gi.repository import BlockDev
 
-from distutils.version import LooseVersion
+from packaging.version import Version
 
 import udiskstestcase
 
@@ -26,7 +26,7 @@ def _get_cryptsetup_version():
     m = re.search(r'cryptsetup ([\d\.]+)', out)
     if not m or len(m.groups()) != 1:
         raise RuntimeError('Failed to determine cryptsetup version from: %s' % out)
-    return LooseVersion(m.groups()[0])
+    return Version(m.groups()[0])
 
 
 def _get_blkid_version():
@@ -34,7 +34,7 @@ def _get_blkid_version():
     m = re.search(r'blkid from util-linux ([\d\.]+)', out)
     if not m or len(m.groups()) != 1:
         raise RuntimeError('Failed to determine blkid version from: %s' % out)
-    return LooseVersion(m.groups()[0])
+    return Version(m.groups()[0])
 
 
 class UdisksEncryptedTest(udiskstestcase.UdisksTestCase):
@@ -515,7 +515,7 @@ class UdisksEncryptedTestLUKS2(UdisksEncryptedTest):
 
     def setUp(self):
         cryptsetup_version = _get_cryptsetup_version()
-        if cryptsetup_version < LooseVersion('2.0.0'):
+        if cryptsetup_version < Version('2.0.0'):
             self.skipTest('LUKS2 not supported')
 
         super(UdisksEncryptedTestLUKS2, self).setUp()
@@ -616,7 +616,7 @@ class UdisksEncryptedTestLUKS2(UdisksEncryptedTest):
         passwd = 'test'
 
         cryptsetup_version = _get_cryptsetup_version()
-        if cryptsetup_version < LooseVersion('2.2.0'):
+        if cryptsetup_version < Version('2.2.0'):
             self.skipTest('Integrity devices are not marked as internal in cryptsetup < 2.2.0')
 
         device = self.get_device(self.vdevs[0])
@@ -674,11 +674,11 @@ class UdisksEncryptedTestBITLK(udiskstestcase.UdisksTestCase):
 
     def setUp(self):
         cryptsetup_version = _get_cryptsetup_version()
-        if cryptsetup_version < LooseVersion('2.3.0'):
+        if cryptsetup_version < Version('2.3.0'):
             self.skipTest('BITLK not supported by cryptsetup')
 
         blkid_version = _get_blkid_version()
-        if blkid_version < LooseVersion('2.33'):
+        if blkid_version < Version('2.33'):
             self.skipTest('BITLK not supported by blkid')
 
         self.manager = self.get_interface('/Manager', '.Manager')

--- a/src/tests/dbus-tests/test_80_filesystem.py
+++ b/src/tests/dbus-tests/test_80_filesystem.py
@@ -8,7 +8,7 @@ import tempfile
 import unittest
 import time
 from distutils.spawn import find_executable
-from distutils.version import LooseVersion
+from packaging.version import Version
 
 from multiprocessing import Process, Pipe
 
@@ -66,7 +66,7 @@ class UdisksFSTestCase(udiskstestcase.UdisksTestCase):
         m = re.search(r'libmount ([\d\.]+)', out)
         if not m or len(m.groups()) != 1:
             raise RuntimeError('Failed to determine libmount version from: %s' % out)
-        return LooseVersion(m.groups()[0])
+        return Version(m.groups()[0])
 
     def _get_mount_options_conf_path(self):
         if os.environ["UDISKS_TESTS_ARG_SYSTEM"] == "1":
@@ -699,7 +699,7 @@ class UdisksFSTestCase(udiskstestcase.UdisksTestCase):
 
     def test_userspace_mount_options(self):
         libmount_version = self._get_libmount_version()
-        if libmount_version < LooseVersion('2.30'):
+        if libmount_version < Version('2.30'):
             self.skipTest('userspace mount options are not supported with libmount < 2.30')
 
         if not self._can_create:
@@ -996,11 +996,11 @@ class VFATTestCase(UdisksFSTestCase):
         m = re.search(r"mkfs\.fat ([\d\.]+)", out)
         if not m or len(m.groups()) != 1:
             raise RuntimeError("Failed to determine dosfstools version from: %s" % out)
-        return LooseVersion(m.groups()[0])
+        return Version(m.groups()[0])
 
     def _creates_protective_part_table(self):
         # dosfstools >= 4.2 create fake MBR partition table
-        return self._get_dosfstools_version() >= LooseVersion('4.2')
+        return self._get_dosfstools_version() >= Version('4.2')
 
     def _invalid_label(self, disk):
         label = 'a' * 12  # at most 11 characters
@@ -1375,12 +1375,12 @@ class UDFTestCase(UdisksFSTestCase):
         _ret, out = self.run_command('mkudffs 2>&1 | grep "mkudffs from udftools"')
         m = re.search(r'from udftools ([\d\.]+)', out)
         if not m or len(m.groups()) != 1:
-            return LooseVersion("0")
-        return LooseVersion(m.groups()[0])
+            return Version("0")
+        return Version(m.groups()[0])
 
     def _creates_protective_part_table(self):
         # udftools >= 2.0 create fake MBR partition table
-        return self._get_mkudffs_version() >= LooseVersion('2.0')
+        return self._get_mkudffs_version() >= Version('2.0')
 
 
 class FailsystemTestCase(UdisksFSTestCase):

--- a/src/tests/dbus-tests/test_80_filesystem.py
+++ b/src/tests/dbus-tests/test_80_filesystem.py
@@ -7,7 +7,6 @@ import shutil
 import tempfile
 import unittest
 import time
-from distutils.spawn import find_executable
 from packaging.version import Version
 
 from multiprocessing import Process, Pipe
@@ -1487,7 +1486,7 @@ class FailsystemTestCase(UdisksFSTestCase):
 
 class UdisksISO9660TestCase(udiskstestcase.UdisksTestCase):
     def _create_iso9660_on_dev(self, dev):
-        if not find_executable("genisoimage"):
+        if not shutil.which("genisoimage"):
             self.skipTest("Cannot create an iso9660 file system")
 
         tmp = tempfile.mkdtemp()

--- a/src/tests/dbus-tests/test_btrfs.py
+++ b/src/tests/dbus-tests/test_btrfs.py
@@ -9,7 +9,7 @@ import unittest
 from bytesize import bytesize
 from collections import namedtuple
 from contextlib import contextmanager
-from distutils.version import LooseVersion
+from packaging.version import Version
 
 import udiskstestcase
 
@@ -65,7 +65,7 @@ class UdisksBtrfsTest(udiskstestcase.UdisksTestCase):
         m = re.search(r'[Bb]trfs.* v([\d\.]+)', out)
         if not m or len(m.groups()) != 1:
             raise RuntimeError('Failed to determine btrfs version from: %s' % out)
-        return LooseVersion(m.groups()[0])
+        return Version(m.groups()[0])
 
     def test__manager_interface(self):
         '''Test for module D-Bus Manager interface presence'''
@@ -164,7 +164,7 @@ class UdisksBtrfsTest(udiskstestcase.UdisksTestCase):
     def test_subvolumes(self):
 
         btrfs_version = self._get_btrfs_version()
-        if btrfs_version == LooseVersion('4.13.2'):
+        if btrfs_version == Version('4.13.2'):
             self.skipTest('subvolumes list is broken with btrfs-progs v4.13.2')
 
         dev = self._get_devices(1)[0]

--- a/src/tests/dbus-tests/test_zram.py
+++ b/src/tests/dbus-tests/test_zram.py
@@ -207,8 +207,8 @@ class UdisksZRAMTest(udiskstestcase.UdisksTestCase):
 
         # test some properties
         # location of some sysfs files we use is different since linux 4.11
-        kernel_version = os.uname()[2]
-        if Version(kernel_version) >= Version("4.11"):
+        ver = BlockDev.utils_get_linux_version()
+        if Version("%d.%d.%d" % (ver.major, ver.minor, ver.micro)) >= Version("4.11"):
             self._test_zram_properties_fedora(zram, zram_name)
         else:
             self._test_zram_properties_centos(zram, zram_name)

--- a/src/tests/dbus-tests/test_zram.py
+++ b/src/tests/dbus-tests/test_zram.py
@@ -7,7 +7,7 @@ import gi
 gi.require_version('BlockDev', '2.0')
 from gi.repository import BlockDev
 
-from distutils.version import LooseVersion
+from packaging.version import Version
 
 import udiskstestcase
 
@@ -208,7 +208,7 @@ class UdisksZRAMTest(udiskstestcase.UdisksTestCase):
         # test some properties
         # location of some sysfs files we use is different since linux 4.11
         kernel_version = os.uname()[2]
-        if LooseVersion(kernel_version) >= LooseVersion("4.11"):
+        if Version(kernel_version) >= Version("4.11"):
             self._test_zram_properties_fedora(zram, zram_name)
         else:
             self._test_zram_properties_centos(zram, zram_name)

--- a/src/tests/integration-test
+++ b/src/tests/integration-test
@@ -36,8 +36,8 @@ import sys
 import os
 import contextlib
 import signal
+import shutil
 from os.path import dirname
-from distutils.spawn import find_executable
 
 srcdir = dirname(dirname(dirname(os.path.realpath(__file__))))
 libdir = os.path.join(srcdir, 'udisks', '.libs')
@@ -495,7 +495,7 @@ class UDisksTestCase(unittest.TestCase):
         Newer udftools ship an udev rule that calls pktsetup to create a /dev/pktcdvd/
         device on every cd-rom device. So if there's no pktsetup tool in the system,
         the attached device wouldn't most likely exist either. """
-        if os.path.exists(cd_device) and find_executable("pktsetup"):
+        if os.path.exists(cd_device) and shutil.which("pktsetup"):
             try:
                 rdev = os.stat(cd_device).st_rdev
                 subprocess.call(['pktsetup', '-d', '%d:%d' % (os.major(rdev), os.minor(rdev))])


### PR DESCRIPTION
Basically same change as https://github.com/storaged-project/libblockdev/pull/657, we are using some helper functions from `distutils` in tests.