### PR TITLE
modify default mount options for vfat filesystem

### DIFF
--- a/data/builtin_mount_options.conf
+++ b/data/builtin_mount_options.conf
@@ -1,7 +1,7 @@
 [defaults]
 allow=exec,noexec,nodev,nosuid,atime,noatime,nodiratime,relatime,strictatime,lazytime,ro,rw,sync,dirsync,noload,acl,nosymfollow
 
-vfat_defaults=uid=$UID,gid=$GID,shortname=mixed,utf8=1,showexec,flush
+vfat_defaults=uid=$UID,gid=$GID,shortname=mixed,utf8=1,showexec,flush,usefree
 vfat_allow=uid=$UID,gid=$GID,flush,utf8,shortname,umask,dmask,fmask,codepage,iocharset,usefree,showexec
 
 # common options for both the native kernel driver and exfat-fuse

--- a/doc/configurable_mount_options.xml
+++ b/doc/configurable_mount_options.xml
@@ -129,7 +129,7 @@ defaults=ro
 allow=exec,noexec,nodev,nosuid,atime,noatime,nodiratime,ro,rw,sync,dirsync,noload
 
 # specific filesystem type options
-vfat_defaults=uid=$UID,gid=$GID,shortname=mixed,utf8=1,showexec,flush
+vfat_defaults=uid=$UID,gid=$GID,shortname=mixed,utf8=1,showexec,flush,usefree
 vfat_allow=uid=$UID,gid=$GID,flush,utf8,shortname,umask,dmask,fmask,codepage,iocharset,usefree,showexec
 ntfs_defaults=uid=$UID,gid=$GID,windows_names
 ntfs_allow=uid=$UID,gid=$GID,umask,dmask,fmask,locale,norecover,ignore_case,windows_names
@@ -191,7 +191,7 @@ ENV{DM_UDEV_DISABLE_OTHER_RULES_FLAG}=="?*", GOTO="udisks_mount_options_end"
 # Use specific charset for FAT filesystems
 #
 # ENV{ID_FS_TYPE}=="vfat", \
-# ENV{UDISKS_MOUNT_OPTIONS_VFAT_DEFAULTS}="uid=$UID,gid=$GID,shortname=mixed,utf8=0,iocharset=iso8859-15,showexec,flush"
+# ENV{UDISKS_MOUNT_OPTIONS_VFAT_DEFAULTS}="uid=$UID,gid=$GID,shortname=mixed,utf8=0,iocharset=iso8859-15,showexec,flush,usefree"
 
 #
 # Mount all USB devices read-only

--- a/udisks/mount_options.conf.in
+++ b/udisks/mount_options.conf.in
@@ -10,7 +10,7 @@
 # allow=exec,noexec,nodev,nosuid,atime,noatime,nodiratime,ro,rw,sync,dirsync,noload
 
 ### Specific filesystem type options
-# vfat_defaults=uid=$UID,gid=$GID,shortname=mixed,utf8=1,showexec,flush
+# vfat_defaults=uid=$UID,gid=$GID,shortname=mixed,utf8=1,showexec,flush,usefree
 # vfat_allow=uid=$UID,gid=$GID,flush,utf8,shortname,umask,dmask,fmask,codepage,iocharset,usefree,showexec
 # ntfs_defaults=uid=$UID,gid=$GID,windows_names
 # ntfs_allow=uid=$UID,gid=$GID,umask,dmask,fmask,locale,norecover,ignore_case,windows_names,compression,nocompression,big_writes


### PR DESCRIPTION
While mounting a vfat filesystem device with command "udiskctl mount -b", if there is no "usefree" option, it will take a long time to mount.
The udisks mount process is blocked by calling function bd_fs_xfs_get_info, and all the mount process must take over than 20s until there is UDISKS_DEFAULT_WAIT_TIMEOUT timeout.
According to mount manual,  'usefree' options is used for vfat filesysystem. If there is no 'usefree' option, there must be a scanning disk operation while mounting a vfat filesystem device.  Which leading a unreasonable phenomenon, mounting device must be dependent on UDISKS_DEFAULT_WAIT_TIMEOUT timeout, meanwhile, the udisks process can not get the device information by calling bd_fs_xfs_get_info because there is no enough time to scan all the disk device.

``
       usefree
              Use the "free clusters" value stored on FSINFO.  It'll be used to determine number of free clusters without scanning disk.  But it's not used by default, because recent Windows don't update  it
              correctly in some case.  If you are sure the "free clusters" on FSINFO is correct, by this option you can avoid scanning disk.
``