### PR TITLE
Fix typo

### DIFF
--- a/doc/configurable_mount_options.xml
+++ b/doc/configurable_mount_options.xml
@@ -196,7 +196,7 @@ ENV{DM_UDEV_DISABLE_OTHER_RULES_FLAG}=="?*", GOTO="udisks_mount_options_end"
 #
 # Mount all USB devices read-only
 #
-# SUBSYSTEMS="usb", ENV{ID_FS_USAGE}=="filesystem", ENV{UDISKS_MOUNT_OPTIONS_DEFAULTS}="ro"
+# SUBSYSTEMS=="usb", ENV{ID_FS_USAGE}=="filesystem", ENV{UDISKS_MOUNT_OPTIONS_DEFAULTS}="ro"
 
 LABEL="udisks_mount_options_end"
 </programlisting>


### PR DESCRIPTION
While working with udev I found this documentation and it's missing an '=' on the example to mount all USB devices as read-only.