### PR TITLE
ntfs3 driver support

### DIFF
--- a/data/builtin_mount_options.conf
+++ b/data/builtin_mount_options.conf
@@ -8,8 +8,9 @@ vfat_allow=uid=$UID,gid=$GID,flush,utf8,shortname,umask,dmask,fmask,codepage,ioc
 exfat_defaults=uid=$UID,gid=$GID,iocharset=utf8,errors=remount-ro
 exfat_allow=uid=$UID,gid=$GID,dmask,errors,fmask,iocharset,namecase,umask
 
+# ntfs3, ntfs-3g and the legacy ntfs kernel driver options
 ntfs_defaults=uid=$UID,gid=$GID,windows_names
-ntfs_allow=uid=$UID,gid=$GID,umask,dmask,fmask,locale,norecover,ignore_case,windows_names,compression,nocompression,big_writes
+ntfs_allow=uid=$UID,gid=$GID,umask,dmask,fmask,locale,norecover,ignore_case,windows_names,compression,nocompression,big_writes,nls,nohidden,sys_immutable,sparse,showmeta,prealloc
 
 iso9660_defaults=uid=$UID,gid=$GID,iocharset=utf8,mode=0400,dmode=0500
 iso9660_allow=uid=$UID,gid=$GID,norock,nojoliet,iocharset,mode,dmode

--- a/src/udiskslinuxfilesystem.c
+++ b/src/udiskslinuxfilesystem.c
@@ -1128,6 +1128,15 @@ handle_mount (UDisksFilesystem      *filesystem,
                                          0,
                                          NULL /* cancellable */);
 
+  if (g_strcmp0 (fs_type_to_use, "ntfs") == 0)
+    {
+      /* Prefer the new 'ntfs3' kernel driver and fall back to generic 'ntfs'
+       * (ntfs3g or the legacy kernel 'ntfs' driver) if not available.
+       */
+      g_free (fs_type_to_use);
+      fs_type_to_use = g_strdup ("ntfs3,ntfs");
+    }
+
   if (!bd_fs_mount (device, mount_point_to_use, fs_type_to_use, mount_options_to_use, NULL, &error))
     {
       /* ugh, something went wrong.. we need to clean up the created mount point */


### PR DESCRIPTION
This is a simple quirk allowing the use of the kernel `ntfs3` driver. I'd still prefer `util-linux` to handle this seamlessly.

Resolves #798