### PR TITLE
clang fixes

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -55,7 +55,6 @@ CC_CHECK_CFLAGS_APPEND([                          \
         -Wformat=2                                \
         -Wimplicit                                \
         -Winit-self                               \
-        -Wlogical-op                              \
         -Wmissing-declarations                    \
         -Wmissing-format-attribute                \
         -Wmissing-include-dirs                    \
@@ -78,8 +77,6 @@ CC_CHECK_CFLAGS_APPEND([                          \
         -Wstrict-prototypes                       \
         -Wundef                                   \
         -Wuninitialized                           \
-        -Wmaybe-uninitialized                     \
-        -Wunsafe-loop-optimizations               \
         -Wvla                                     \
         -Wwrite-strings                           \
         -fdata-sections                           \

--- a/modules/lvm2/jobhelpers.h
+++ b/modules/lvm2/jobhelpers.h
@@ -21,7 +21,7 @@
  */
 
 #ifndef __LVM_JOB_HELPERS_H__
-#define __LVM_JOB_HEPLERS_H__
+#define __LVM_JOB_HELPERS_H__
 
 #include <glib.h>
 #include <blockdev/lvm.h>
@@ -192,4 +192,4 @@ void lvs_task_func (GTask        *task,
 
 G_END_DECLS
 
-#endif  /* __LVM_JOB_HEPLERS_H__ */
+#endif  /* __LVM_JOB_HELPERS_H__ */

--- a/modules/lvm2/udiskslinuxmanagerlvm2.c
+++ b/modules/lvm2/udiskslinuxmanagerlvm2.c
@@ -315,8 +315,7 @@ handle_volume_group_create (UDisksManagerLVM2     *_object,
     }
   blocks = g_list_reverse (blocks);
 
-  /* XXX: is it okay to allocate memory on stack here? */
-  pvs = (const gchar**) alloca (sizeof(gchar*) * n);
+  pvs = (const gchar**) alloca (sizeof (gchar*) * (n + 1));
 
   /* wipe existing devices */
   for (l = blocks; l != NULL; l = l->next)

--- a/src/tests/test.c
+++ b/src/tests/test.c
@@ -323,7 +323,11 @@ test_spawned_job_abnormal_termination (void)
   job = udisks_spawned_job_new (s, NULL, getuid (), geteuid (), NULL, NULL);
   udisks_spawned_job_start (job);
   _g_assert_signal_received (job, "completed", G_CALLBACK (on_completed_expect_failure),
+#ifdef __clang__
+                             (gpointer) "Command-line `./udisks-test-helper 4' was signaled with signal SIGILL (4): "
+#else
                              (gpointer) "Command-line `./udisks-test-helper 4' was signaled with signal SIGSEGV (11): "
+#endif
                              "OK, deliberately causing a segfault\n");
   g_object_unref (job);
   g_free (s);

--- a/src/udisksdaemonutil.c
+++ b/src/udisksdaemonutil.c
@@ -1617,7 +1617,7 @@ udisks_daemon_util_get_free_mdraid_device (void)
 guint16
 udisks_ata_identify_get_word (const guchar *identify_data, guint word_number)
 {
-  const guint16 *words = (const guint16 *) identify_data;
+  const guint16 *words = (const guint16 *) (void *) identify_data;
   guint16 ret = 0;
 
   g_return_val_if_fail (word_number < 256, 0);

--- a/src/udiskslinuxblockobject.c
+++ b/src/udiskslinuxblockobject.c
@@ -942,9 +942,14 @@ on_mount_monitor_mount_added (UDisksMountMonitor  *monitor,
                               UDisksMount         *mount,
                               gpointer             user_data)
 {
-  UDisksLinuxBlockObject *object = UDISKS_LINUX_BLOCK_OBJECT (user_data);
+  UDisksLinuxBlockObject *object;
+
+  object = UDISKS_LINUX_BLOCK_OBJECT (g_object_ref (user_data));
+
   if (udisks_mount_get_dev (mount) == g_udev_device_get_device_number (object->device->udev_device))
     udisks_linux_block_object_uevent (object, NULL, NULL);
+
+  g_object_unref (object);
 }
 
 static void
@@ -952,9 +957,14 @@ on_mount_monitor_mount_removed (UDisksMountMonitor  *monitor,
                                 UDisksMount         *mount,
                                 gpointer             user_data)
 {
-  UDisksLinuxBlockObject *object = UDISKS_LINUX_BLOCK_OBJECT (user_data);
+  UDisksLinuxBlockObject *object;
+
+  object = UDISKS_LINUX_BLOCK_OBJECT (g_object_ref (user_data));
+
   if (udisks_mount_get_dev (mount) == g_udev_device_get_device_number (object->device->udev_device))
     udisks_linux_block_object_uevent (object, NULL, NULL);
+
+  g_object_unref (object);
 }
 
 /* ---------------------------------------------------------------------------------------------------- */

--- a/src/udiskslinuxencryptedhelpers.h
+++ b/src/udiskslinuxencryptedhelpers.h
@@ -21,7 +21,7 @@
  */
 
 #ifndef __UDISKS_LINUX_ENCRYPTED_HELPERS_H__
-#define __UDISKS_LINUX_ENCRYPTED_HEPLERS_H__
+#define __UDISKS_LINUX_ENCRYPTED_HELPERS_H__
 
 #include <glib.h>
 #include <blockdev/crypto.h>

--- a/src/udiskslinuxfilesystemhelpers.h
+++ b/src/udiskslinuxfilesystemhelpers.h
@@ -21,7 +21,7 @@
  */
 
 #ifndef __UDISKS_LINUX_FILESYSTEM_HELPERS_H__
-#define __UDISKS_LINUX_FILESYSTEM_HEPLERS_H__
+#define __UDISKS_LINUX_FILESYSTEM_HELPERS_H__
 
 #include <glib.h>
 #include <glib/gstdio.h>
@@ -41,4 +41,4 @@ gboolean take_filesystem_ownership (const gchar *device,
 G_END_DECLS
 
 
-#endif /* __UDISKS_LINUX_FILESYSTEM_HEPLERS_H__ */
+#endif /* __UDISKS_LINUX_FILESYSTEM_HELPERS_H__ */

--- a/src/udiskslinuxmanager.c
+++ b/src/udiskslinuxmanager.c
@@ -748,8 +748,8 @@ handle_mdraid_create (UDisksManager         *_object,
   if (!bd_md_create (array_name, arg_level, disks, 0, NULL, FALSE, arg_chunk, NULL, &error))
     {
       g_prefix_error (&error, "Error creating RAID array: ");
-      g_dbus_method_invocation_take_error (invocation, error);
       udisks_simple_job_complete (UDISKS_SIMPLE_JOB (job), FALSE, error->message);
+      g_dbus_method_invocation_take_error (invocation, error);
       success = FALSE;
       goto out;
     }

--- a/src/udiskslinuxmanager.c
+++ b/src/udiskslinuxmanager.c
@@ -751,6 +751,7 @@ handle_mdraid_create (UDisksManager         *_object,
       udisks_simple_job_complete (UDISKS_SIMPLE_JOB (job), FALSE, error->message);
       g_dbus_method_invocation_take_error (invocation, error);
       success = FALSE;
+      job = NULL;
       goto out;
     }
 

--- a/src/udiskslinuxmdraidhelpers.h
+++ b/src/udiskslinuxmdraidhelpers.h
@@ -21,7 +21,7 @@
  */
 
 #ifndef __UDISKS_LINUX_MDRAID_HELPERS_H__
-#define __UDISKS_LINUX_MDRAID_HEPLERS_H__
+#define __UDISKS_LINUX_MDRAID_HELPERS_H__
 
 #include <glib.h>
 
@@ -34,4 +34,4 @@ gboolean mdraid_has_stripes (const gchar *raid_level);
 G_END_DECLS
 
 
-#endif /* __UDISKS_LINUX_MDRAID_HEPLERS_H__ */
+#endif /* __UDISKS_LINUX_MDRAID_HELPERS_H__ */


### PR DESCRIPTION
It was certainly interesting to see major differences in code analysis and how different the actual generated code was. Undefined corner cases or silent stack corruption went unnoticed for years with gcc while the same code failed immediatelly in the clang case.

Fixes #891
Closes #853
Closes #852
Closes #806