### PR TITLE
Fix checking for VFAT resize support with older libblockdev

### DIFF
--- a/src/tests/dbus-tests/test_10_basic.py
+++ b/src/tests/dbus-tests/test_10_basic.py
@@ -152,11 +152,13 @@ class UdisksBaseTest(udiskstestcase.UdisksTestCase):
             self.assertEqual(util, 'resize2fs')
         self.assertEqual(avail, shutil.which('resize2fs') is not None)
         avail, mode, util = manager.CanResize('vfat')
-        if avail:
-            self.assertEqual(util, '')
-        else:
+        # the only valid reason for VFAT not being available is missing vfat-resize
+        # the support is either compiled in (libblockdev 2.x) or via vfat-resize (3.x)
+        if not avail:
             self.assertEqual(util, 'vfat-resize')
-        self.assertEqual(avail, shutil.which('vfat-resize') is not None)
+
+        if shutil.which('vfat-resize') is not None:
+            self.assertTrue(avail)
 
     def test_40_can_repair(self):
         '''Test for installed filesystem repair utility with CanRepair'''


### PR DESCRIPTION
We can't really check for libblockdev version in the tests and
there is a difference between 2.x (compiled in) and 3.x (tool)
support for VFAT resize so the test_40_can_resize test case needs
to be adjusted to work with both.