### PR TITLE
Fix tests config with no modules enabled

### DIFF
--- a/src/tests/dbus-tests/Makefile.am
+++ b/src/tests/dbus-tests/Makefile.am
@@ -31,11 +31,11 @@ MODULES += bcache
 endif
 
 $(CONFIG_H_PY):
-	echo -n 'UDISKS_MODULES_ENABLED = { ' > $(CONFIG_H_PY)
+	echo -n 'UDISKS_MODULES_ENABLED = set([' > $(CONFIG_H_PY)
 	for i in $(MODULES); do \
 		echo -n "'$$i', " >> $(CONFIG_H_PY); \
 	done
-	echo '}' >> $(CONFIG_H_PY)
+	echo '])' >> $(CONFIG_H_PY)
 
 all:
 


### PR DESCRIPTION
With no modules enabled the UDISKS_MODULES_ENABLED variable is set
to "{ }" which is interpreted as empty dict by Python and not an
empty set as expected by the test suite.