### PR TITLE
udiskslinuxdriveata:Fix reading IO stats on ata_refresh_smart_sync

### DIFF
--- a/src/udiskslinuxdriveata.c
+++ b/src/udiskslinuxdriveata.c
@@ -601,11 +601,11 @@ udisks_linux_drive_ata_refresh_smart_sync (UDisksLinuxDriveAta  *drive,
     {
       guchar count;
       gboolean noio = FALSE;
+      if (drive->standby_enabled)
+        noio = update_io_stats (drive, device);
       if (!get_pm_state (device, error, &count))
         goto out;
       awake = count == 0xFF || count == 0x80;
-      if (drive->standby_enabled)
-        noio = update_io_stats (drive, device);
       /* don't wake up disk unless specically asked to */
       if (nowakeup && (!awake || noio))
         {


### PR DESCRIPTION
When checking IO stats after get_pm_state the noio bool will never become true
because get_pm_state() reads from the disk. If we perform the check earlier and
there was no IO on the disk, noio will become true and smart update refresh will be canceled.

This fixes the problem with StandbyTimeout not working if the timeout is bigger then 10 minutes.