### PR TITLE
udiskslinuxfilesystem: Make 'size' property retrieval on demand

### DIFF
--- a/doc/udisks2-sections.txt.daemon.sections.in
+++ b/doc/udisks2-sections.txt.daemon.sections.in
@@ -269,6 +269,8 @@ UDisksAtaCommandProtocol
 UDisksAtaCommandInput
 UDisksAtaCommandOutput
 udisks_ata_send_command_sync
+udisks_ata_get_pm_state
+UDISKS_ATA_PM_STATE_AWAKE
 </SECTION>
 
 <SECTION>

--- a/doc/udisks2-sections.txt.daemon.sections.in
+++ b/doc/udisks2-sections.txt.daemon.sections.in
@@ -161,7 +161,6 @@ udisks_linux_drive_ata_smart_selftest_sync
 udisks_linux_drive_ata_apply_configuration
 udisks_linux_drive_ata_secure_erase_sync
 udisks_linux_drive_ata_get_pm_state
-UDISKS_LINUX_DRIVE_ATA_IS_AWAKE
 <SUBSECTION Standard>
 UDISKS_LINUX_DRIVE_ATA
 UDISKS_IS_LINUX_DRIVE_ATA

--- a/src/udisksata.h
+++ b/src/udisksata.h
@@ -73,6 +73,16 @@ struct _UDisksAtaCommandOutput
   guchar *buffer;
 };
 
+/**
+ * UDISKS_ATA_PM_STATE_AWAKE:
+ * @pm_state: The power state value.
+ *
+ * Decodes the power state value as returned by #udisks_ata_get_pm_state.
+ *
+ * Returns: %TRUE when the drive is awake, %FALSE when sleeping.
+*/
+#define UDISKS_ATA_PM_STATE_AWAKE(pm_state) (pm_state >= 0x41)
+
 gboolean udisks_ata_send_command_sync (gint                       fd,
                                        gint                       timeout_msec,
                                        UDisksAtaCommandProtocol   protocol,
@@ -80,6 +90,9 @@ gboolean udisks_ata_send_command_sync (gint                       fd,
                                        UDisksAtaCommandOutput    *output,
                                        GError                   **error);
 
+gboolean udisks_ata_get_pm_state      (const gchar               *device,
+                                       GError                   **error,
+                                       guchar                    *count);
 
 G_END_DECLS
 

--- a/src/udiskslinuxdriveata.h
+++ b/src/udiskslinuxdriveata.h
@@ -29,16 +29,6 @@ G_BEGIN_DECLS
 #define UDISKS_LINUX_DRIVE_ATA(o)    (G_TYPE_CHECK_INSTANCE_CAST ((o), UDISKS_TYPE_LINUX_DRIVE_ATA, UDisksLinuxDriveAta))
 #define UDISKS_IS_LINUX_DRIVE_ATA(o) (G_TYPE_CHECK_INSTANCE_TYPE ((o), UDISKS_TYPE_LINUX_DRIVE_ATA))
 
-/**
- * UDISKS_LINUX_DRIVE_ATA_IS_AWAKE:
- * @pm_state: The power state value.
- *
- * Decodes the power state value as returned by #udisks_linux_drive_ata_get_pm_state.
- *
- * Returns: %TRUE when the drive is awake, %FALSE when sleeping.
-*/
-#define         UDISKS_LINUX_DRIVE_ATA_IS_AWAKE(pm_state) (pm_state >= 0x41)
-
 GType           udisks_linux_drive_ata_get_type           (void) G_GNUC_CONST;
 UDisksDriveAta *udisks_linux_drive_ata_new                (void);
 gboolean        udisks_linux_drive_ata_update             (UDisksLinuxDriveAta     *drive,


### PR DESCRIPTION
Filesystem size value retrieval is very expensive as it typically calls
filesystem tools that read superblock -> doing some I/O. Other
filesystem properties are typically retrieved from existing stateful
sources, either udev or sysfs.

This change overrides the gdbus-codegen-generated GDBusInterfaceSkeleton
property retrieval and adds a custom hook that retrieves the filesystem
size value when actually requested.

One limitation of such approach is that the hook is called with
the GDBusObjectManager lock held and thus the hook needs to be as minimal
as possible and needs to avoid any access to any GDBusObject.

TODO: handle ATA power management.

Fixes #946
Fixes #911
Fixes #871
Fixes #868