### PR TITLE
udiskslinuxswapspace: Trigger uevent on swap start/stop

### DIFF
--- a/src/udiskslinuxswapspace.c
+++ b/src/udiskslinuxswapspace.c
@@ -216,6 +216,8 @@ handle_start (UDisksSwapspace        *swapspace,
       goto out;
     }
 
+  udisks_linux_block_object_trigger_uevent_sync (UDISKS_LINUX_BLOCK_OBJECT (object),
+                                                 UDISKS_DEFAULT_WAIT_TIMEOUT);
   udisks_swapspace_complete_start (swapspace, invocation);
 
  out:
@@ -312,6 +314,8 @@ handle_stop (UDisksSwapspace        *swapspace,
       goto out;
     }
 
+  udisks_linux_block_object_trigger_uevent_sync (UDISKS_LINUX_BLOCK_OBJECT (object),
+                                                 UDISKS_DEFAULT_WAIT_TIMEOUT);
   udisks_swapspace_complete_stop (swapspace, invocation);
 
  out:


### PR DESCRIPTION
No idea why but I've recently noticed failing `test_90_swapspace.UdisksSwapSpaceTest.test_20_start_stop` tests. Looking at the code this was one of the few remaining places where an explicit uevent was not trigerred.