### PR TITLE
doc: Fix @since: annotations

### DIFF
--- a/data/org.freedesktop.UDisks2.xml
+++ b/data/org.freedesktop.UDisks2.xml
@@ -1802,7 +1802,7 @@
     <!-- Resize:
          @size: New partition size in bytes, 0 for maximal size.
          @options: Options.
-         @since 2.7.2
+         @since: 2.7.2
 
          Resizes the partition.
 

--- a/modules/lvm2/data/org.freedesktop.UDisks2.lvm2.xml
+++ b/modules/lvm2/data/org.freedesktop.UDisks2.lvm2.xml
@@ -321,7 +321,6 @@
          @write_policy: Specifies the write policy.
          @options: Additional options.
          @result: The object path of the new VDO logical volume.
-
          @since: 2.9.0
 
          Create a new VDO logical volume that is backed by a newly created


### PR DESCRIPTION
Recent changes in gdbus-codegen (2.71.1) have introduced parser
issues on malformed annotations.

https://gitlab.gnome.org/GNOME/glib/-/issues/2601