### PR TITLE
modules/btrfs: Add missing dependency

### DIFF
--- a/modules/bcache/Makefile.am
+++ b/modules/bcache/Makefile.am
@@ -71,6 +71,7 @@ libudisks2_bcache_la_LDFLAGS =                                                \
 	$(NULL)
 
 libudisks2_bcache_la_LIBADD =                                                 \
+	$(top_builddir)/src/libudisks-daemon.la                               \
 	$(GLIB_LIBS)                                                          \
 	$(GIO_LIBS)                                                           \
 	$(GUDEV_LIBS)                                                         \

--- a/modules/btrfs/Makefile.am
+++ b/modules/btrfs/Makefile.am
@@ -73,6 +73,7 @@ libudisks2_btrfs_la_LDFLAGS =                                                  \
 	$(NULL)
 
 libudisks2_btrfs_la_LIBADD =                                                   \
+	$(top_builddir)/src/libudisks-daemon.la                                \
 	$(GLIB_LIBS)                                                           \
 	$(GIO_LIBS)                                                            \
 	$(GUDEV_LIBS)                                                          \

--- a/modules/lvm2/Makefile.am
+++ b/modules/lvm2/Makefile.am
@@ -76,6 +76,7 @@ libudisks2_lvm2_la_LDFLAGS =                                                   \
 	$(NULL)
 
 libudisks2_lvm2_la_LIBADD =                                                    \
+	$(top_builddir)/src/libudisks-daemon.la                                \
 	$(GLIB_LIBS)                                                           \
 	$(GIO_LIBS)                                                            \
 	$(GUDEV_LIBS)                                                          \


### PR DESCRIPTION
When building udisks with `--enable-btrfs` using slibtool instead of GNU libtool the build will fail with undefined references.

This is because of a missing dependency for `libudisks2_btrfs.so` and GNU libtool will hide this issue by silently ignoring `-no-undefined` while slibtool does not.

Note that this is reproducible with GNU libtool if the `-no-undefined` for `libudisks2_btrfs_la_LDFLAGS` is changed to `-Wl,-no-undefined` where it is then explicitly passed to the linker.

Gentoo Bug: https://bugs.gentoo.org/782061

Full build log: [udisks.slibtool.log](https://github.com/storaged-project/udisks/files/8663463/udisks.slibtool.log)
