### PR TITLE
tests: Mark loop partscan tests as unstable

### DIFF
--- a/src/tests/dbus-tests/test_loop.py
+++ b/src/tests/dbus-tests/test_loop.py
@@ -189,6 +189,7 @@ class UdisksManagerLoopDeviceTest(udiskstestcase.UdisksTestCase):
         ro = self.get_property(loop_dev_obj, ".Block", "ReadOnly")
         ro.assertTrue()
 
+    @udiskstestcase.tag_test(udiskstestcase.TestTags.UNSTABLE)
     def test_50_create_no_part_scan(self):
         # create a partition on the file (future loop device)
         ret, out = self.run_command("parted %s mklabel msdos" % self.LOOP_DEVICE_FILENAME)


### PR DESCRIPTION
There's a bug in the kernel 5.18.4+ versions introduced by
https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/commit/?h=v5.18.4&id=4c10e26c35634bf9e9b625e4dd48d21d26c7ed1d

The unset LO_FLAGS_PARTSCAN flag is not honoured and partitions
are scanned either way.