### PR TITLE
udiskslinuxnvmenamespace: Include errno.h to fix compilation on CentOS 8

### DIFF
--- a/src/udiskslinuxnvmenamespace.c
+++ b/src/udiskslinuxnvmenamespace.c
@@ -21,6 +21,7 @@
 #include "config.h"
 #include <glib/gi18n-lib.h>
 
+#include <errno.h>
 #include <sys/types.h>
 #include <string.h>
 


### PR DESCRIPTION
Interestingly this is needed only on CentOS/RHEL 8, I guess on other systems errno.h is brought in with some of the other includes.