### PR TITLE
tests: Create required directories for integration tests

### DIFF
--- a/src/tests/integration-test
+++ b/src/tests/integration-test
@@ -405,13 +405,10 @@ class UDisksTestCase(unittest.TestCase):
                 else:
                     break
 
-        # check localstatedir
+        # create localstatedirs
         for d in (os.path.join(make_vars['localstatedir'], 'run', 'udisks2'),
                   os.path.join(make_vars['localstatedir'], 'lib', 'udisks2')):
-            if not os.path.exists(d):
-                sys.stderr.write('The directory %s does not exist; please '
-                                 'create it before running these tests.\n' % d)
-                sys.exit(1)
+            os.makedirs(d, exist_ok=True)
 
     @classmethod
     def setup_vdev(cls):


### PR DESCRIPTION
Not sure whether this should use the configured prefix or not. Haven't even found where this message comes from:

```
make integration-tests
make[1]: Entering directory '/home/jenkins/workspace/udisks-pr/arch/x86_64/distro/centos_8s/type/udisks'
make all &>/dev/null
cd src/tests && sudo python3 ./integration-test | tee -a ../../integration_tests_output.log \
       && echo "integration-tests: SUCCESS" >> ../../RESULTS || echo "integration-tests: FAILED" >> ../../RESULTS
The directory /usr/local/var/run/udisks2 does not exist; please create it before running these tests.
Testing binaries from local build tree
```