### PR TITLE
ci: Update Fedora versions for RPM build tests

### DIFF
--- a/.github/workflows/rpmbuild.yml
+++ b/.github/workflows/rpmbuild.yml
@@ -1,7 +1,7 @@
 name: Build RPM packages
 
 env:
-  MOCK_CHROOTS: "fedora-rawhide fedora-36 fedora-35"
+  MOCK_CHROOTS: "fedora-rawhide fedora-37 fedora-36"
 
 on:
   pull_request:


### PR DESCRIPTION
I need to figure out either how to automate this or move the definition of Fedora versions to one place. Updating three repositories every 6 months isn't that bad, but still could be easier.