### PR TITLE
Fix some expected error messages in FS integration tests

### DIFF
--- a/src/tests/dbus-tests/test_10_basic.py
+++ b/src/tests/dbus-tests/test_10_basic.py
@@ -102,7 +102,7 @@ class UdisksBaseTest(udiskstestcase.UdisksTestCase):
         with self.assertRaises(dbus.exceptions.DBusException):
             manager.CanFormat('wxyz')
         for fs in ('xfs', 'f2fs', 'ext4'):
-            avail, util = manager.CanFormat('xfs')
+            avail, util = manager.CanFormat(fs)
             if avail:
                 self.assertEqual(util, '')
             else:

--- a/src/tests/dbus-tests/test_80_filesystem.py
+++ b/src/tests/dbus-tests/test_80_filesystem.py
@@ -555,8 +555,8 @@ class UdisksFSTestCase(udiskstestcase.UdisksTestCase):
         if label:
             if not self._can_label:
                 self.skipTest('Cannot set label when creating %s filesystem' % self._fs_signature)
-            if self._fs_signature == 'vfat' and self._creates_protective_part_table():
-                self.skipTest('dosfstools >= 4.2 introduced stricter label rules')
+            if self._fs_signature == 'vfat':
+                self.skipTest('VFAT has strict label rules, skipping')
 
         if not self._can_mount:
             self.skipTest('Cannot mount %s filesystem' % self._fs_signature)

--- a/src/tests/integration-test
+++ b/src/tests/integration-test
@@ -746,7 +746,7 @@ class FS(UDisksTestCase):
             self.fail('Expected failure for bogus file system')
         except GLib.GError as e:
             self.assertIn('UDisks2.Error.NotSupported', e.message)
-            self.assertIn('type bogus', e.message)
+            self.assertIn('\'bogus\' is not supported', e.message)
 
     def test_create_fs_unsupported_label(self):
         """Format() with unsupported label"""
@@ -867,7 +867,8 @@ class FS(UDisksTestCase):
                 self.fs_create(None, fs_type, no_options)
                 self.fail('Expected failure for missing mkfs.' + fs_type)
             except GLib.GError as e:
-                self.assertIn('UDisks2.Error.Failed', e.message)
+                self.assertIn('UDisks2.Error.NotSupported', e.message)
+                self.assertIn('executable %s not found' % mkfs, e.message)
             return
 
         # do checks with command line tools (mkfs/mount/umount)


### PR DESCRIPTION
Some of the errors and messages changed with the rewrite to the libblockdev 3.0 API.