### PR TITLE
nvme: Feature flags

### DIFF
--- a/src/tests/dbus-tests/test_nvme.py
+++ b/src/tests/dbus-tests/test_nvme.py
@@ -376,10 +376,9 @@ class UdisksNVMeTest(udiskstestcase.UdisksTestCase):
         self.assertEqual(attrs['critical_temp_time'], 0);
 
         # Try trigerring a self-test operation
-        msg = 'Unknown self-test type xxx'
+        msg = 'The NVMe controller has no support for self-test operations'
         with six.assertRaisesRegex(self, dbus.exceptions.DBusException, msg):
             drive_obj.SmartSelftestStart('xxx', self.no_options, dbus_interface=self.iface_prefix + '.NVMe.Controller')
-        msg = 'NVMe Get Log Page - Device Self-test Log command error: Invalid Field in Command'
         with six.assertRaisesRegex(self, dbus.exceptions.DBusException, msg):
             drive_obj.SmartSelftestStart('short', self.no_options, dbus_interface=self.iface_prefix + '.NVMe.Controller')
         msg = 'NVMe Device Self-test command error: Invalid Command Opcode'
@@ -415,7 +414,7 @@ class UdisksNVMeTest(udiskstestcase.UdisksTestCase):
         msg = 'Unknown sanitize action xxx'
         with six.assertRaisesRegex(self, dbus.exceptions.DBusException, msg):
             drive_obj.SanitizeStart('xxx', self.no_options, dbus_interface=self.iface_prefix + '.NVMe.Controller')
-        msg = 'NVMe Get Log Page - Sanitize Status Log command error: Invalid Field in Command'
+        msg = r'The NVMe controller has no support for the .* sanitize operation'
         with six.assertRaisesRegex(self, dbus.exceptions.DBusException, msg):
             drive_obj.SanitizeStart('block-erase', self.no_options, dbus_interface=self.iface_prefix + '.NVMe.Controller')
         with six.assertRaisesRegex(self, dbus.exceptions.DBusException, msg):

--- a/src/udiskslinuxnvmenamespace.c
+++ b/src/udiskslinuxnvmenamespace.c
@@ -150,7 +150,9 @@ udisks_linux_nvme_namespace_update (UDisksLinuxNVMeNamespace *ns,
 
   nsid = g_udev_device_get_sysfs_attr_as_int (device->udev_device, "nsid");
   nguid = g_udev_device_get_sysfs_attr (device->udev_device, "nguid");
-  uuid = g_udev_device_get_sysfs_attr (device->udev_device, "uuid");
+  /* not reading the 'uuid' attr to avoid bogus messages from the kernel:
+   *   block nvme0n1: No UUID available providing old NGUID
+   */
   wwn = g_udev_device_get_sysfs_attr (device->udev_device, "wwid");
   if (!wwn)
     wwn = g_udev_device_get_property (device->udev_device, "ID_WWN");


### PR DESCRIPTION
Due to the way how the kernel host nvme driver reports command failures we need to limit the number of commands sent to the device. The most safe way of trying and failing, even with some kind of "not supported" error that can be safely ignored, doesn't unfortunately work as kernel would report the error anyway. The only way to prevent this is to check the controller and namespace feature flags that however don't fully align with the actual calls. But it's the best guess we have.

Broken NVMe standard implementation on the device side will result in bogus errors reported, so let's see what will users report...