### PR TITLE
Mount options fixes

### DIFF
--- a/src/tests/dbus-tests/test_80_filesystem.py
+++ b/src/tests/dbus-tests/test_80_filesystem.py
@@ -1422,6 +1422,13 @@ class NTFSCommonTestCase(UdisksFSTestCase):
     _can_label = True
     _can_relabel = True and UdisksFSTestCase.command_exists('ntfslabel')
     _can_mount = True
+    _have_ntfs3g = UdisksFSTestCase.command_exists('ntfs-3g')
+
+    @classmethod
+    def setUpClass(cls):
+        udiskstestcase.UdisksTestCase.setUpClass()
+        if not BlockDev.utils_have_kernel_module('ntfs3') and not BlockDev.utils_have_kernel_module('ntfs3') and not cls._have_ntfs3g:
+            raise unittest.SkipTest('No ntfs/ntfs3/ntfs3g implementation available, skipping.')
 
     def test_mount_auto_configurable_mount_options(self):
         raise unittest.SkipTest('Not applicable for the common NTFS test case, skipping.')

--- a/src/udiskslinuxfilesystem.c
+++ b/src/udiskslinuxfilesystem.c
@@ -1127,8 +1127,7 @@ handle_mount_dynamic (UDisksDaemon          *daemon,
                         (*mount_options_i)->options,
                         NULL, &error))
         {
-          if (g_error_matches (error, BD_FS_ERROR, BD_FS_ERROR_UNKNOWN_FS) &&
-              *(mount_options_i + sizeof (void *)))
+          if (g_error_matches (error, BD_FS_ERROR, BD_FS_ERROR_UNKNOWN_FS) && *(mount_options_i + 1))
             {
               /* Unknown filesystem, continue to the next one unless this is the last entry */
               g_clear_error (&error);


### PR DESCRIPTION
Issues found by the CI, though not obvious on the first sight, reproduced only by a slightly different test set. Just another example of issues that are hidden in certain sequential test execution order, would be nice to randomize the tests.