### PR TITLE
tests: Restart iscsid on every InitiatorName change

### DIFF
--- a/modules/iscsi/data/org.freedesktop.UDisks2.iscsi.xml
+++ b/modules/iscsi/data/org.freedesktop.UDisks2.iscsi.xml
@@ -82,7 +82,12 @@
         @options: Additional options.
         @since: 2.1.3
 
-        Sets a new iSCSI initiator name.
+        Sets a new iSCSI initiator name. This is typically done by populating the
+        <filename>/etc/iscsi/initiatorname.iscsi</filename> file.
+
+        The iscsid service needs to be restarted afterwards to reflect the change
+        (if running). This is however distribution-specific and not performed
+        by UDisks at this moment.
 
         No additional options are currently defined.
     -->


### PR DESCRIPTION
The test LIO target config expects a specific initiator name as set by the ACLs. However the iscsid daemon only seems to be reading the InitiatorName string on startup and in case the service is running with a different name, the auth tests will fail.

As a workaround, restart the iscsid service after each change. A proper way through libiscsi or libopeniscsiusr would be nice -> TODO.