### PR TITLE
udiskslinuxfilesystem: Tighten the fallback for kernels without ACL

### DIFF
--- a/src/udiskslinuxfilesystem.c
+++ b/src/udiskslinuxfilesystem.c
@@ -558,7 +558,7 @@ add_acl (const gchar  *path,
       udisks_warning(
                    "Adding read ACL for uid %d to `%s' failed: %m",
                    (gint) uid, path);
-      chown(path, uid, -1);
+      chown (path, uid, -1);
     }
 
   ret = TRUE;


### PR DESCRIPTION
The fallbacks for the lack of POSIX Access Control Lists support in the kernel [1] and the absence of libacl as a build-time dependency [2] were different.  The former fell back to changing the ownership of the directory to the user's UID and latter changed it to the GID.

Changing the ownership of /run/media/$USER to the user's GID is slightly better [3] because it allows the user to still navigate inside the directory but prevents them from creating arbitrary files in it or changing the permissions.  However, it's still not as good as ACLs because other users belonging to the same GID will also have the same level of access.

To achieve the above, /run/media/$USER is always created as 0750, even when libacl is present as a build-time dependency.  Otherwise, changing it's ownership to the user's GID as a fallback when the kernel doesn't support ACLs won't have the desired effect.

This should be fine, because, on a stock Fedora 36 with its default umask of 0022 and full ACL support, the permissions of /run/media/$USER are already set to 0750:
```
  $ ls -ld /run/media/$USER
  drwxr-x---+ 3 root root 60 Nov  2 18:02 /run/media/rishi
```

[1] Commit 86bcf135519742eb
    https://github.com/storaged-project/udisks/commit/86bcf135519742eb

[2] Commit 21fba0298b298c31
    https://github.com/storaged-project/udisks/commit/21fba0298b298c31

[3] https://lists.freedesktop.org/archives/devkit-devel/2014-March/001583.html