### PR TITLE
udev: Also ignore "zram*" block devices

### DIFF
--- a/data/80-udisks2.rules
+++ b/data/80-udisks2.rules
@@ -185,3 +185,4 @@ ENV{ID_PART_TABLE_TYPE}=="dos", ENV{ID_PART_ENTRY_TYPE}=="0x0|0x17", ENV{ID_PART
 
 # Explicitly ignore ram block devices, they don't work with udev
 KERNEL=="ram*", ENV{UDISKS_IGNORE}="1"
+KERNEL=="zram*", ENV{UDISKS_IGNORE}="1"


### PR DESCRIPTION
Just like "ram*" block devices, they are better not shown to the user since they don't behave as expected of block devices.