### PR TITLE
udiskslinuxfilesystem: Sanitize label when creating the mount point

### DIFF
--- a/src/udiskslinuxfilesystem.c
+++ b/src/udiskslinuxfilesystem.c
@@ -571,6 +571,41 @@ add_acl (const gchar  *path,
 #endif
 
 /*
+ * Return mount_dir/label after sanitizing the label. Free with g_free().
+ */
+static gchar *
+sanitize_mount_point (const gchar *mount_dir,
+                      const gchar *label)
+{
+  gchar *s;
+  const gchar *p;
+  GString *str = g_string_new (NULL);
+  g_string_append_printf (str, "%s/", mount_dir);
+  s = ensure_utf8 (label);
+  for (p = s; *p != '\0'; p = g_utf8_next_char (p))
+    {
+      gchar c = *p;
+      if ((guchar) c < 128)
+        {
+          if (!g_ascii_isprint (c) || c == '/' || c == '"' || c == '\'' || c == '\\')
+            g_string_append_c (str, '_');
+          else
+            g_string_append_c (str, c);
+        }
+      else
+        {
+          gunichar uc = g_utf8_get_char (p);
+          if (!g_unichar_isprint (uc))
+            g_string_append_c (str, '_');
+          else
+            g_string_append_unichar (str, uc);
+        }
+    }
+  g_free (s);
+  return g_string_free (str, FALSE);
+}
+
+/*
  * calculate_mount_point: <internal>
  * @daemon: A #UDisksDaemon.
  * @block: A #UDisksBlock.
@@ -603,8 +638,6 @@ calculate_mount_point (UDisksDaemon  *daemon,
   gchar *mount_dir = NULL;
   gchar *mount_point = NULL;
   gchar *orig_mount_point;
-  GString *str;
-  gchar *s;
   guint n;
 
   label = NULL;
@@ -683,42 +716,13 @@ calculate_mount_point (UDisksDaemon  *daemon,
       *persistent = TRUE;
     }
 
-  /* NOTE: UTF-8 has the nice property that valid UTF-8 strings only contains
-   *       the byte 0x2F if it's for the '/' character (U+002F SOLIDUS).
-   *
-   *       See http://en.wikipedia.org/wiki/UTF-8 for details.
-   */
   if (label != NULL && strlen (label) > 0)
     {
-      str = g_string_new (NULL);
-      g_string_append_printf (str, "%s/", mount_dir);
-      s = ensure_utf8 (label);
-      for (n = 0; s[n] != '\0'; n++)
-        {
-          gint c = s[n];
-          if (c == '/')
-            g_string_append_c (str, '_');
-          else
-            g_string_append_c (str, c);
-        }
-      mount_point = g_string_free (str, FALSE);
-      g_free (s);
+      mount_point = sanitize_mount_point (mount_dir, label);
     }
   else if (uuid != NULL && strlen (uuid) > 0)
     {
-      str = g_string_new (NULL);
-      g_string_append_printf (str, "%s/", mount_dir);
-      s = ensure_utf8 (uuid);
-      for (n = 0; s[n] != '\0'; n++)
-        {
-          gint c = s[n];
-          if (c == '/')
-            g_string_append_c (str, '_');
-          else
-            g_string_append_c (str, c);
-        }
-      mount_point = g_string_free (str, FALSE);
-      g_free (s);
+      mount_point = sanitize_mount_point (mount_dir, uuid);
     }
   else
     {


### PR DESCRIPTION
Here's a first attempt at fixing this problem. Apart from non-printable characters I also decided to remove a few other dangerous ones.

Ascii and non-ascii characters are treated separately as an optimization, but it's also possible to get rid of the ascii path altogether.

Fixes #1056