### PR TITLE
Extend Filesystem.Mount() to allow mounting on behalf of another user

### DIFF
--- a/data/org.freedesktop.UDisks2.policy.in
+++ b/data/org.freedesktop.UDisks2.policy.in
@@ -44,6 +44,17 @@
     </defaults>
   </action>
 
+  <!-- mount a device on behalf of another user -->
+  <action id="org.freedesktop.udisks2.filesystem-mount-other-user">
+    <description>Mount a filesystem on behalf of another user</description>
+    <message>Authentication is required to mount the filesystem</message>
+    <defaults>
+      <allow_any>auth_admin</allow_any>
+      <allow_inactive>auth_admin</allow_inactive>
+      <allow_active>auth_admin_keep</allow_active>
+    </defaults>
+  </action>
+
   <!-- mount a device referenced in the /etc/fstab file with the x-udisks-auth option -->
   <action id="org.freedesktop.udisks2.filesystem-fstab">
     <description>Mount/unmount filesystems defined in the fstab file with the x-udisks-auth option</description>

--- a/data/org.freedesktop.UDisks2.xml
+++ b/data/org.freedesktop.UDisks2.xml
@@ -2582,7 +2582,7 @@
 
     <!--
         Mount:
-        @options: Options - known options (in addition to <link linkend="udisks-std-options">standard options</link>) includes <parameter>fstype</parameter> (of type 's') and <parameter>options</parameter> (of type 's').
+        @options: Options - known options (in addition to <link linkend="udisks-std-options">standard options</link>) includes <parameter>fstype</parameter> (of type 's'), <parameter>as-user</parameter> (of type 's') and <parameter>options</parameter> (of type 's').
         @mount_path: The filesystem path where the device was mounted.
 
         Mounts the filesystem.
@@ -2606,6 +2606,12 @@
         by default determined by the #org.freedesktop.UDisks2.Block:IdType
         property. The @fstype option doesn't typically need to be
         specified, primarily intended as an override in corner cases.
+
+        If the <parameter>as-user</parameter> option is set, the
+        filesystem is mounted on behalf of the specified user instead
+        of the calling one. This has usually an effect on the returned
+        @mount_path and it also allows that user to unmount the
+        filesystem later. This option expects a user name, not a UID.
 
         If the device in question is referenced in the
         <filename>/etc/fstab</filename> file, the

--- a/src/tests/dbus-tests/test_80_filesystem.py
+++ b/src/tests/dbus-tests/test_80_filesystem.py
@@ -956,6 +956,86 @@ class UdisksFSTestCase(udiskstestcase.UdisksTestCase):
 
         self._test_mountpoint('УДИСКС', 'УДИСКС')
 
+    def _unmount_as_user(self, pipe, uid, gid, device):
+        """ Try to unmount @device as user with given @uid and @gid."""
+        os.setresgid(gid, gid, gid)
+        os.setresuid(uid, uid, uid)
+
+        try:
+            safe_dbus.call_sync(self.iface_prefix,
+                                self.path_prefix + '/block_devices/' + os.path.basename(device),
+                                self.iface_prefix + '.Filesystem',
+                                'Unmount',
+                                GLib.Variant('(a{sv})', ({},)))
+        except Exception as e:
+            pipe.send([False, 'Unmount DBus call failed: %s' % str(e)])
+            pipe.close()
+            return
+
+        pipe.send([True, ''])
+        pipe.close()
+
+    @udiskstestcase.tag_test(udiskstestcase.TestTags.UNSAFE)
+    def test_mount_as_user(self):
+        """ Test mounting a filesystem on behalf of a different user."""
+        if not self._can_create:
+            self.skipTest('Cannot create %s filesystem' % self._fs_signature)
+
+        if not self._can_label:
+            self.skipTest('Cannot set label when creating %s filesystem' % self._fs_signature)
+
+        if not self._can_mount:
+            self.skipTest('Cannot mount %s filesystem' % self._fs_signature)
+
+        disk = self.get_object('/block_devices/' + os.path.basename(self.vdevs[0]))
+        self.assertIsNotNone(disk)
+
+        # create filesystem with label
+        d = dbus.Dictionary(signature='sv')
+        d['label'] = 'UDISKS'
+        disk.Format(self._fs_signature, d, dbus_interface=self.iface_prefix + '.Block')
+        self.addCleanup(self.wipe_fs, self.vdevs[0])
+
+        # get real block object for the newly created filesystem
+        block_fs, block_fs_dev = self._get_formatted_block_object(self.vdevs[0])
+        self.assertIsNotNone(block_fs)
+        self.assertIsNotNone(block_fs_dev)
+
+        # create user for our test
+        self.addCleanup(self._remove_user, self.username)
+        uid, gid = self._add_user(self.username)
+
+        # prepare the mount options
+        d = dbus.Dictionary(signature='sv')
+        d['options'] = 'ro'
+        if self._fs_name:
+            d['fstype'] = self._fs_name
+
+        # try to mount it now: first with a nonexistent user
+        d['as-user'] = 'nonexistent'
+        with six.assertRaisesRegex(self, dbus.exceptions.DBusException, "User with name nonexistent does not exist"):
+            block_fs.Mount(d, dbus_interface=self.iface_prefix + '.Filesystem')
+
+        # now mount it with the actual user
+        d['as-user'] = self.username
+        mnt_path = block_fs.Mount(d, dbus_interface=self.iface_prefix + '.Filesystem')
+        self.addCleanup(self.try_unmount, block_fs_dev)
+        self.addCleanup(self.try_unmount, self.vdevs[0])
+
+        # check that the name of the mount point matches the expectation
+        self.assertTrue(mnt_path.endswith("%s/UDISKS" % self.username))
+
+        # try to unmount it as the other user
+        parent_conn, child_conn = Pipe()
+        proc = Process(target=self._unmount_as_user, args=(child_conn, int(uid), int(gid), block_fs_dev))
+        proc.start()
+        res = parent_conn.recv()
+        parent_conn.close()
+        proc.join()
+
+        if not res[0]:
+            self.fail(res[1])
+
 class Ext2TestCase(UdisksFSTestCase):
     _fs_signature = 'ext2'
     _can_create = True and UdisksFSTestCase.command_exists('mke2fs')

--- a/src/udisksdaemonutil.h
+++ b/src/udisksdaemonutil.h
@@ -94,6 +94,12 @@ gboolean udisks_daemon_util_get_user_info (const uid_t   uid,
                                            gchar       **out_user_name,
                                            GError      **error);
 
+gboolean
+udisks_daemon_util_get_user_info_by_name (const gchar  *user_name,
+                                          uid_t        *out_uid,
+                                          gid_t        *out_gid,
+                                          GError      **error);
+
 gboolean udisks_daemon_util_get_caller_uid_sync (UDisksDaemon            *daemon,
                                                  GDBusMethodInvocation   *invocation,
                                                  GCancellable            *cancellable,


### PR DESCRIPTION
Here's my first attempt to implement this. Note that this a draft so the documentation and tests are still missing. First I would like to know if you are happy with this approach or if you prefer a different one.

In short:

* `Filesystem.Mount()` gets a new parameter: `as-user` (I'm open to other names). This is a user name, not a uid.
* If it is set and the user exists then a new action is used: `filesystem-mount-other-user`. This has `auth_admin_keep` for the active user. 
* This new action is used also for all drives (system and non-system ones). Do we need `filesystem-mount-system-other-user`?

I also thought about not adding any new action and instead of that requesting authentication with the existing actions when the `as-user` parameter is set. However I think that this would require us to add a PolkitDetail to the action and a new `rules` file where it can be checked, or at least I'm not aware of a different way to do that. In the end I thought that using a new action was cleaner and resulted in a much simpler patch.

Fixes #1065