### PR TITLE
Add 'mkfs-args' to Block.Format()

### DIFF
--- a/data/org.freedesktop.UDisks2.xml
+++ b/data/org.freedesktop.UDisks2.xml
@@ -2081,7 +2081,7 @@
     <!--
         Format:
         @type: The type of file system, partition table or other content to format the device with.
-        @options: Options - known options (in addition to <link linkend="udisks-std-options">standard options</link>) includes <parameter>label</parameter> (of type 's'), <parameter>take-ownership</parameter> (of type 'b'), <parameter>encrypt.passphrase</parameter> (of type 's' or 'ay'), <parameter>encrypt.type</parameter> (of type 's'), <parameter>erase</parameter> (of type 's'), <parameter>no-block</parameter> (of type 'b') and <parameter>update-partition-type</parameter> (of type 'b').
+        @options: Options - known options (in addition to <link linkend="udisks-std-options">standard options</link>) includes <parameter>label</parameter> (of type 's'), <parameter>take-ownership</parameter> (of type 'b'), <parameter>encrypt.passphrase</parameter> (of type 's' or 'ay'), <parameter>encrypt.type</parameter> (of type 's'), <parameter>erase</parameter> (of type 's'), <parameter>mkfs-args</parameter> (of type 'as'), <parameter>no-block</parameter> (of type 'b') and <parameter>update-partition-type</parameter> (of type 'b').
 
         Formats the device with a file system, partition table or
         other well-known content.
@@ -2146,6 +2146,20 @@
         <parameter>no-block</parameter> is %TRUE. Note that the block
         device has already been modified (wiped) when the dry run
         check is called.
+
+        If the option <parameter>mkfs-args</parameter> is set then the
+        caller can provide a list of additional command-line arguments
+        that will be passed to the mkfs program. The arguments
+        specified in this way are not validated by UDisks, and the
+        user is responsible for making sure that the available mkfs
+        program for that filesystem supports them and that they work
+        for the intended purpose. Note that UDisks can also pass its
+        own additional arguments to mkfs, and they may vary between
+        releases, with no guarantees of stability in this regard. The
+        position in which the user-provided arguments are appended to
+        the final mkfs command line is also not defined. Because of
+        all this, <parameter>mkfs-args</parameter> should only be used
+        as a last resort when no other dedicated option is available.
 
         If the option <parameter>no-discard</parameter> is set to
         %TRUE then Udisks tells the formatting utility not to issue

--- a/src/tests/dbus-tests/test_80_filesystem.py
+++ b/src/tests/dbus-tests/test_80_filesystem.py
@@ -1091,6 +1091,21 @@ class Ext4TestCase(Ext2TestCase):
         self.assertEqual(sys_stat.st_uid, int(uid))
         self.assertEqual(sys_stat.st_gid, int(gid))
 
+    def test_create_format_mkfs_args(self):
+        if not self._can_create:
+            self.skipTest('Cannot create %s filesystem' % self._fs_signature)
+
+        disk = self.get_object('/block_devices/' + os.path.basename(self.vdevs[0]))
+        self.assertIsNotNone(disk)
+        self.addCleanup(self.wipe_fs, self.vdevs[0])
+
+        options = dbus.Dictionary(signature='sv')
+        options['mkfs-args'] = ['-O', 'nonexistent']
+        with six.assertRaisesRegex(self, dbus.exceptions.DBusException, 'Invalid filesystem option set: nonexistent'):
+            self._create_format(disk, options=options)
+
+        options['mkfs-args'] = ['-O', 'encrypt']
+        self._create_format(disk, options=options)
 
 class XFSTestCase(UdisksFSTestCase):
     _fs_signature = 'xfs'


### PR DESCRIPTION
This allows the user to pass an arbitrary set of command-line options to the mkfs tool.

Although mkfs options are generally stable and backward compatible, UDisks itself provides no guarantees and it's the responsibility of the user to make sure that the provided options actually work with the versions of the software available in the system.

Fixes #583