### PR TITLE
Remove the separate configure option for LVM cache support

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ To build UDisks with (a) chosen module(s), provide or leave these
 configuration options for the `configure` script:
 
     $ ./configure --enable-btrfs --enable-iscsi --enable-lsm
-                  --enable-lvm2 --enable-lvmcache
+                  --enable-lvm2
 
 It is possible to enable all the modules at once:
 

--- a/configure.ac
+++ b/configure.ac
@@ -310,23 +310,6 @@ if test "x$enable_lvm2" = "xyes" \
 fi
 AM_CONDITIONAL(HAVE_LVM2, [test "$have_lvm2" = "yes"])
 
-# LVMCache
-have_lvmcache=no
-AC_ARG_ENABLE(lvmcache, AS_HELP_STRING([--enable-lvmcache], [enable LVMCache support]))
-if test "x$enable_lvmcache" = "xyes" \
-     -o "x$enable_modules" = "xyes" \
-     -o "x$enable_available_modules" = "xyes"; then
-
-  if test "x$have_lvm2" = "xno"; then
-     if test "x$enable_lvmcache" = "xyes" -o "x$enable_modules" = "xyes"; then
-         AC_MSG_ERROR([lvmcache support requested, but lvm2 module not enabled])
-     fi
-  fi
-  have_lvmcache=yes
-  AC_DEFINE(HAVE_LVMCACHE, 1, [Define if lvmcache is available])
-fi
-AM_CONDITIONAL(HAVE_LVMCACHE, [test "$have_lvmcache" = "yes"])
-
 # iSCSI module
 have_iscsi=no
 have_libiscsi_session_info="no"
@@ -712,6 +695,5 @@ echo "
         BTRFS module:               ${have_btrfs}
         iSCSI module:               ${have_iscsi}${have_libiscsi_session_info_msg}
         LVM2  module:               ${have_lvm2}
-        LVMCache:                   ${have_lvmcache}
         LibStorageMgmt module:      ${have_lsm}
 "

--- a/modules/lvm2/udiskslinuxlogicalvolume.c
+++ b/modules/lvm2/udiskslinuxlogicalvolume.c
@@ -1088,16 +1088,6 @@ handle_cache_attach (UDisksLogicalVolume   *volume_,
                      const gchar           *cache_name,
                      GVariant              *options)
 {
-#ifndef HAVE_LVMCACHE
-
-  g_dbus_method_invocation_return_error (invocation,
-                                         UDISKS_ERROR,
-                                         UDISKS_ERROR_FAILED,
-                                         N_("LVMCache not enabled at compile time."));
-  return TRUE;
-
-#else
-
   GError *error = NULL;
   UDisksLinuxLogicalVolume *volume = UDISKS_LINUX_LOGICAL_VOLUME (volume_);
   UDisksLinuxLogicalVolumeObject *object = NULL;
@@ -1140,8 +1130,6 @@ out:
   g_clear_object (&object);
 
   return TRUE;
-
-#endif /* HAVE_LVMCACHE */
 }
 
 
@@ -1151,16 +1139,6 @@ handle_cache_detach_or_split (UDisksLogicalVolume    *volume_,
                               GVariant               *options,
                               gboolean                destroy)
 {
-#ifndef HAVE_LVMCACHE
-
-  g_dbus_method_invocation_return_error (invocation,
-                                         UDISKS_ERROR,
-                                         UDISKS_ERROR_FAILED,
-                                         N_("LVMCache not enabled at compile time."));
-  return TRUE;
-
-#else
-
   GError *error = NULL;
   UDisksLinuxLogicalVolume *volume = UDISKS_LINUX_LOGICAL_VOLUME (volume_);
   UDisksLinuxLogicalVolumeObject *object = NULL;
@@ -1203,8 +1181,6 @@ out:
   g_clear_object (&object);
 
   return TRUE;
-
-#endif /* HAVE_LVMCACHE */
 }
 
 static gboolean

--- a/packaging/udisks2.spec
+++ b/packaging/udisks2.spec
@@ -9,7 +9,6 @@
 
 %define with_btrfs                      1
 %define with_lsm                        1
-%define with_lvmcache                   1
 
 %define is_fedora                       0%{?rhel} == 0
 %define is_git                          %(git show > /dev/null 2>&1 && echo 1 || echo 0)
@@ -208,9 +207,6 @@ autoreconf -ivf
 %endif
 %if 0%{?with_lsm}
     --enable-lsm      \
-%endif
-%if 0%{?with_lvmcache}
-    --enable-lvmcache \
 %endif
     --enable-lvm2     \
     --enable-iscsi


### PR DESCRIPTION
We don't need any special dependency for LVM cache so it doesn't make sense to make the support optional.