### PR TITLE
tests: Fix test_mountpoint_utf8 with EXFAT

### DIFF
--- a/src/tests/dbus-tests/test_80_filesystem.py
+++ b/src/tests/dbus-tests/test_80_filesystem.py
@@ -949,11 +949,6 @@ class UdisksFSTestCase(udiskstestcase.UdisksTestCase):
         if self._fs_signature == "vfat":
             self.skipTest("vfat does not support UTF-8 labels")
 
-        # TODO: exFAT does support Unicode but mkfs.exfat relies on
-        # the current locale ("invalid character sequence in current locale")
-        if self._fs_signature == "exfat":
-            self.skipTest("UTF-8 labels are currently not supported in exfat")
-
         self._test_mountpoint('УДИСКС', 'УДИСКС')
 
 class Ext2TestCase(UdisksFSTestCase):


### PR DESCRIPTION
This works fine since it was fixed in libblockdev:

https://github.com/storaged-project/libblockdev/commit/e97c6cb40fb31a6bc0d3470c32b661885db2187e 
https://github.com/storaged-project/libblockdev/commit/a56c88c8e05377bbc5277aa7836da5cf09f3f9a8