### PR TITLE
lvm2: Add "stripes" and "mirrors" options for creation

### DIFF
--- a/modules/lvm2/data/org.freedesktop.UDisks2.lvm2.xml
+++ b/modules/lvm2/data/org.freedesktop.UDisks2.lvm2.xml
@@ -302,7 +302,8 @@
          type on the given physical volumes.  It is okay to leave
          "pvs" empty; LVM2 will then choose suitable ones on its own.
 
-         No additional options are currently defined.
+         The "stripes" (u) and "mirrors" (u) options work like the
+         "stripes" and "mirrors" options of "lvcreate".
     -->
     <method name="CreatePlainVolumeWithLayout">
       <arg name="name" type="s" direction="in"/>

--- a/modules/lvm2/jobhelpers.h
+++ b/modules/lvm2/jobhelpers.h
@@ -38,6 +38,8 @@ typedef struct {
   const gchar **new_lv_pvs;
   const gchar *pool_name;
   guint64 new_lv_size;
+  guint32 new_lv_stripes;
+  guint32 new_lv_mirrors;
   guint64 virtual_size;
   guint64 extent_size;
   gboolean resize_fs;

--- a/modules/lvm2/udiskslinuxvolumegroup.c
+++ b/modules/lvm2/udiskslinuxvolumegroup.c
@@ -1016,6 +1016,12 @@ handle_create_volume (UDisksVolumeGroup              *_group,
           goto out;
         }
 
+      data.new_lv_stripes = 0;
+      g_variant_lookup (options, "stripes", "u", &data.new_lv_stripes);
+
+      data.new_lv_mirrors = 0;
+      g_variant_lookup (options, "mirrors", "u", &data.new_lv_mirrors);
+
       data.new_lv_layout = arg_layout;
       if (arg_pvs)
         {


### PR DESCRIPTION
I have ignored the --stripes and --mirrors options for too long... This finally adds both "stripes" and "mirrors" since raid10 requires both.  (In theory at least, in practice lvcreate can't create raid10 with more than two mirror halves.)

It would be nice to get this into the same release as CreatePlainVolumeWithLayout itself.  If it's too late, that's fine but then we need some feature flags so that Cockpit can know whether it can use these options.

Alternative in #1083 