### PR TITLE
lvm2: Properly initialize stack-allocated structs

### DIFF
--- a/modules/lvm2/udiskslinuxlogicalvolume.c
+++ b/modules/lvm2/udiskslinuxlogicalvolume.c
@@ -557,7 +557,7 @@ handle_delete (UDisksLogicalVolume   *_volume,
   uid_t caller_uid;
   gboolean teardown_flag = FALSE;
   UDisksLinuxVolumeGroupObject *group_object;
-  LVJobData data;
+  LVJobData data = {0,};
   struct WaitData wait_data;
 
   g_variant_lookup (options, "tear-down", "b", &teardown_flag);
@@ -639,7 +639,7 @@ handle_repair (UDisksLogicalVolume   *_volume,
   UDisksDaemon *daemon = NULL;
   uid_t caller_uid;
   UDisksLinuxVolumeGroupObject *group_object;
-  LVJobData data = {0};
+  LVJobData data = {0,};
   g_auto(GStrv) pvs = NULL;
 
   if (!common_setup (volume, invocation, options,
@@ -743,7 +743,7 @@ handle_rename (UDisksLogicalVolume   *_volume,
   uid_t caller_uid;
   UDisksLinuxVolumeGroupObject *group_object;
   const gchar *lv_objpath;
-  LVJobData data;
+  LVJobData data = {0,};
 
   if (!common_setup (volume, invocation, options,
                      N_("Authentication is required to rename a logical volume"),
@@ -805,7 +805,7 @@ handle_resize (UDisksLogicalVolume   *_volume,
   UDisksDaemon *daemon;
   uid_t caller_uid;
   UDisksLinuxVolumeGroupObject *group_object;
-  LVJobData data;
+  LVJobData data = {0,};
   gchar **opt_pvs = NULL;
   g_auto(GStrv) pvs = NULL;
 
@@ -915,7 +915,7 @@ handle_activate (UDisksLogicalVolume *_volume,
   uid_t caller_uid;
   UDisksLinuxVolumeGroupObject *group_object;
   UDisksObject *block_object = NULL;
-  LVJobData data;
+  LVJobData data = {0,};
 
   if (!common_setup (volume, invocation, options,
                      N_("Authentication is required to activate a logical volume"),
@@ -983,7 +983,7 @@ handle_deactivate (UDisksLogicalVolume   *_volume,
   UDisksDaemon *daemon;
   uid_t caller_uid;
   UDisksLinuxVolumeGroupObject *group_object;
-  LVJobData data;
+  LVJobData data = {0,};
 
   if (!common_setup (volume, invocation, options,
                      N_("Authentication is required to deactivate a logical volume"),
@@ -1050,7 +1050,7 @@ handle_create_snapshot (UDisksLogicalVolume   *_volume,
   uid_t caller_uid;
   UDisksLinuxVolumeGroupObject *group_object;
   const gchar *lv_objpath = NULL;
-  LVJobData data;
+  LVJobData data = {0,};
 
   if (!common_setup (volume, invocation, options,
                      N_("Authentication is required to create a snapshot of a logical volume"),
@@ -1111,7 +1111,7 @@ handle_cache_attach (UDisksLogicalVolume   *volume_,
   UDisksDaemon *daemon;
   uid_t caller_uid;
   UDisksLinuxVolumeGroupObject *group_object;
-  LVJobData data;
+  LVJobData data = {0,};
 
   if (!common_setup (volume, invocation, options,
                      N_("Authentication is required to convert logical volume to cache"),
@@ -1162,7 +1162,7 @@ handle_cache_detach_or_split (UDisksLogicalVolume    *volume_,
   UDisksDaemon *daemon;
   uid_t caller_uid;
   UDisksLinuxVolumeGroupObject *group_object;
-  LVJobData data;
+  LVJobData data = {0,};
 
   if (!common_setup (volume, invocation, options,
                      N_("Authentication is required to split cache pool LV off of a cache LV"),

--- a/modules/lvm2/udiskslinuxmanagerlvm2.c
+++ b/modules/lvm2/udiskslinuxmanagerlvm2.c
@@ -384,7 +384,8 @@ handle_volume_group_create (UDisksManagerLVM2     *_object,
       UDisksObject *object_for_block;
       object_for_block = udisks_daemon_util_dup_object (block, &error);
       if (object_for_block != NULL)
-        udisks_linux_block_object_trigger_uevent (UDISKS_LINUX_BLOCK_OBJECT (object_for_block));
+        udisks_linux_block_object_trigger_uevent_sync (UDISKS_LINUX_BLOCK_OBJECT (object_for_block),
+                                                       UDISKS_DEFAULT_WAIT_TIMEOUT);
       g_object_unref (object_for_block);
     }
 

--- a/modules/lvm2/udiskslinuxvdovolume.c
+++ b/modules/lvm2/udiskslinuxvdovolume.c
@@ -236,7 +236,7 @@ _set_compression_deduplication (UDisksVDOVolume       *_volume,
   UDisksDaemon *daemon = NULL;
   uid_t caller_uid;
   UDisksLinuxVolumeGroupObject *group_object = NULL;
-  LVJobData data;
+  LVJobData data = {0,};
 
   object = udisks_daemon_util_dup_object (volume, &error);
   if (object == NULL)
@@ -318,7 +318,7 @@ _vdo_resize (UDisksLinuxLogicalVolumeObject *object,
   UDisksDaemon *daemon = NULL;
   UDisksLinuxVolumeGroupObject *group_object = NULL;
   uid_t caller_uid;
-  LVJobData data;
+  LVJobData data = {0,};
   gboolean success = FALSE;
 
   if (!common_setup (object, invocation, options,

--- a/src/tests/dbus-tests/test_20_LVM.py
+++ b/src/tests/dbus-tests/test_20_LVM.py
@@ -575,6 +575,7 @@ class UdisksLVMVDOTest(UDisksLVMTestBase):
         self.addCleanup(self._remove_vg, vg)
 
         vg_free = self.get_property(vg, '.VolumeGroup', 'FreeSize')
+        vg_free.assertGreater(0)
         lv_name = 'udisks_test_vdovlv'
         pool_name = 'udisks_test_vdopool'
         psize = vg_free.value
@@ -637,6 +638,7 @@ class UdisksLVMVDOTest(UDisksLVMTestBase):
         self.addCleanup(self._remove_vg, vg)
 
         vg_free = self.get_property(vg, '.VolumeGroup', 'FreeSize')
+        vg_free.assertGreater(0)
         lv_name = 'udisks_test_vdovlv'
         pool_name = 'udisks_test_vdopool'
         psize = vg_free.value
@@ -688,10 +690,11 @@ class UdisksLVMVDOTest(UDisksLVMTestBase):
         self.addCleanup(self._remove_vg, vg)
 
         vg_free = self.get_property(vg, '.VolumeGroup', 'FreeSize')
+        vg_free.assertGreater(0)
         lv_name = 'udisks_test_vdovlv'
         pool_name = 'udisks_test_vdopool'
         psize = vg_free.value
-        vsize = psize
+        vsize = psize * 2
         lv_path = vg.CreateVDOVolume(lv_name, pool_name, dbus.UInt64(psize), dbus.UInt64(vsize),
                                      dbus.UInt64(0), True, True, "auto", self.no_options,
                                      dbus_interface=self.iface_prefix + '.VolumeGroup')
@@ -714,6 +717,7 @@ class UdisksLVMVDOTest(UDisksLVMTestBase):
         self.addCleanup(self._remove_vg, vg)
 
         vg_free = self.get_property(vg, '.VolumeGroup', 'FreeSize')
+        vg_free.assertGreater(2 * 1024**3)
         lv_name = 'udisks_test_vdovlv'
         pool_name = 'udisks_test_vdopool'
         psize = vg_free.value - 2 * 1024**3


### PR DESCRIPTION
A consequence of commit b24141f17d44238d5489ecb1336d71658ecd054f

==850== Process terminating with default action of signal 11 (SIGSEGV): dumping core ==850==  Access not within mapped region at address 0x5
==850==    at 0x4847C46: strlen (vg_replace_strmem.c:501)
==850==    by 0x4DF99DC: g_strdup (gstrfuncs.c:362)
==850==    by 0x48B1C56: UnknownInlinedFun (gstrfuncs.h:321)
==850==    by 0x48B1C56: bd_extra_arg_new (extra_arg.c:86)
==850==    by 0x9BCE55A: lvresize_job_func (jobhelpers.c:159)
==850==    by 0x14EEB5: run_task_job (udisksthreadedjob.c:214)

==850== Use of uninitialised value of size 8
==850==    at 0x9BCE563: lvresize_job_func (jobhelpers.c:158)
==850==    by 0x14EEB5: run_task_job (udisksthreadedjob.c:214)
==850==  Uninitialised value was created by a stack allocation
==850==    at 0x9BD8A40: _vdo_resize (udiskslinuxvdovolume.c:315)