### PR TITLE
tests: Fix FailsystemTestCase availability detection

### DIFF
--- a/src/tests/dbus-tests/test_80_filesystem.py
+++ b/src/tests/dbus-tests/test_80_filesystem.py
@@ -1726,15 +1726,14 @@ class FailsystemTestCase(UdisksFSTestCase):
 
     def test_relabel(self):
         # we need some filesystem that doesn't support setting label after creating it
-        fs = F2FSTestCase
-
-        fs._check_can_create(fs)
+        self._fs_signature = 'f2fs'
+        self._check_can_create()
 
         disk = self.get_object('/block_devices/' + os.path.basename(self.vdevs[0]))
         self.assertIsNotNone(disk)
 
         # create minix filesystem without label and try to set it later
-        disk.Format(fs._fs_signature, self.no_options, dbus_interface=self.iface_prefix + '.Block')
+        disk.Format(self._fs_signature, self.no_options, dbus_interface=self.iface_prefix + '.Block')
         self.addCleanup(self.wipe_fs, self.vdevs[0])
 
         msg = "org.freedesktop.UDisks2.Error.Failed: Setting the label of filesystem 'f2fs' is not supported."
@@ -1743,14 +1742,13 @@ class FailsystemTestCase(UdisksFSTestCase):
 
     def test_mount_auto(self):
         # we need some mountable filesystem, ext4 should do the trick
-        fs = Ext4TestCase
-
-        fs._check_can_create(fs)
+        self._fs_signature = 'ext4'
+        self._check_can_create()
 
         disk = self.get_object('/block_devices/' + os.path.basename(self.vdevs[0]))
         self.assertIsNotNone(disk)
 
-        disk.Format(fs._fs_signature, self.no_options, dbus_interface=self.iface_prefix + '.Block')
+        disk.Format(self._fs_signature, self.no_options, dbus_interface=self.iface_prefix + '.Block')
         self.addCleanup(self.wipe_fs, self.vdevs[0])
         self.addCleanup(self.try_unmount, self.vdevs[0])  # paranoid cleanup
 
@@ -1779,11 +1777,6 @@ class FailsystemTestCase(UdisksFSTestCase):
         with six.assertRaisesRegex(self, dbus.exceptions.DBusException, msg):
             disk.Unmount(self.no_options, dbus_interface=self.iface_prefix + '.Filesystem')
 
-    def test_mount_fstab(self):
-        pass
-
-    def test_size(self):
-        pass
 
 class UdisksISO9660TestCase(udiskstestcase.UdisksTestCase):
     def _create_iso9660_on_dev(self, dev):


### PR DESCRIPTION
Fixes

```
======================================================================
ERROR: test_relabel (test_80_filesystem.FailsystemTestCase)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/jenkins/workspace/udisks-pr/arch/x86_64/distro/centos_9s/type/udisks/src/tests/dbus-tests/test_80_filesystem.py", line 1731, in test_relabel
    fs._check_can_create(fs)
  File "/home/jenkins/workspace/udisks-pr/arch/x86_64/distro/centos_9s/type/udisks/src/tests/dbus-tests/test_80_filesystem.py", line 99, in _check_can_create
    self.skipTest('Cannot create filesystem %s: required command `%s` not found' % (self._fs_signature, util))
TypeError: skipTest() missing 1 required positional argument: 'reason'
```