### PR TITLE
mdraid: Add 'bitmap' option to MDRaidCreate method

### DIFF
--- a/data/org.freedesktop.UDisks2.xml
+++ b/data/org.freedesktop.UDisks2.xml
@@ -148,7 +148,7 @@
         @level: The RAID level for the array.
         @name: The name for the array.
         @chunk: The chunk size (in bytes) or 0 if @level is <quote>raid1</quote>.
-        @options: Options (currently unused except for <link linkend="udisks-std-options">standard options</link>).
+        @options: Options - known options (in addition to <link linkend="udisks-std-options">standard options</link>) include <parameter>bitmap</parameter> (of type 'ay').
         @resulting_array: An object path to the object implementing the #org.freedesktop.UDisks2.MDRaid interface.
         @since: 2.0.0
 
@@ -165,6 +165,12 @@
         Before the array is created, all devices in @blocks are
         erased. Once created (but before the method returns), the RAID
         array will be erased.
+
+        The @bitmap option specifies the write-intent bitmap type, currently
+        only 'none' and 'internal' values are supported. When this option
+        is not present, it is up to <literal>mdadm</literal> to decide
+        whether to create an internal bitmap (typically for arrays larger
+        than 100 GB) or not.
     -->
     <method name="MDRaidCreate">
       <arg name="blocks" direction="in" type="ao"/>

--- a/src/udiskslinuxmanager.c
+++ b/src/udiskslinuxmanager.c
@@ -561,6 +561,7 @@ handle_mdraid_create (UDisksManager         *_object,
   const gchar **disks = NULL;
   guint disks_top = 0;
   gboolean success = FALSE;
+  const gchar *option_bitmap = NULL;
 
   if (!udisks_daemon_util_get_caller_uid_sync (manager->daemon,
                                                invocation,
@@ -765,7 +766,8 @@ handle_mdraid_create (UDisksManager         *_object,
     }
   disks[disks_top] = NULL;
 
-  if (!bd_md_create (array_name, arg_level, disks, 0, NULL, FALSE, arg_chunk, NULL, &error))
+  g_variant_lookup (arg_options, "bitmap", "^&ay", &option_bitmap);
+  if (!bd_md_create (array_name, arg_level, disks, 0, NULL, option_bitmap, arg_chunk, NULL, &error))
     {
       g_prefix_error (&error, "Error creating RAID array: ");
       udisks_simple_job_complete (UDISKS_SIMPLE_JOB (job), FALSE, error->message);


### PR DESCRIPTION
Enhanced version of #1124, reflecting API changes in https://github.com/storaged-project/libblockdev/pull/901

I've removed the validation, even though a filename value is undocumented and unsupported, it can still be passed down to `bd_md_create()` and `mdadm` and it will likely work fine.

The default when no option specified is still 'auto' as before.

Fixes #1124 