### PR TITLE
Use BDFSResizeFlags instead of BDFsResizeFlags

### DIFF
--- a/data/org.freedesktop.UDisks2.xml
+++ b/data/org.freedesktop.UDisks2.xml
@@ -87,7 +87,7 @@
 
         Tests for availability to resize the given filesystem.
         The mode flags indicate if growing and/or shriking resize is available if mounted/unmounted.
-        The mode corresponds to bitwise-OR combined BDFsResizeFlags of the libblockdev FS plugin:
+        The mode corresponds to bitwise-OR combined BDFSResizeFlags of the libblockdev FS plugin:
         BD_FS_OFFLINE_SHRINK = 2, shrinking resize allowed when unmounted
         BD_FS_OFFLINE_GROW = 4, growing resize allowed when unmounted
         BD_FS_ONLINE_SHRINK = 8, shrinking resize allowed when mounted

--- a/src/udiskslinuxfilesystem.c
+++ b/src/udiskslinuxfilesystem.c
@@ -1881,7 +1881,7 @@ handle_resize (UDisksFilesystem      *filesystem,
   UDisksState *state = NULL;
   const gchar *probed_fs_usage = NULL;
   const gchar *probed_fs_type = NULL;
-  BDFsResizeFlags mode = 0;
+  BDFSResizeFlags mode = 0;
   const gchar *action_id = NULL;
   const gchar *message = NULL;
   uid_t caller_uid;

--- a/src/udiskslinuxmanager.c
+++ b/src/udiskslinuxmanager.c
@@ -1063,7 +1063,7 @@ handle_can_resize (UDisksManager         *object,
 {
   GError *error = NULL;
   gchar *required_utility = NULL;
-  BDFsResizeFlags mode;
+  BDFSResizeFlags mode;
   gboolean ret;
 
   ret = bd_fs_can_resize (type, &mode, &required_utility, &error);


### PR DESCRIPTION
One more API change in the upcoming libblockdev 3.0.