### PR TITLE
tests: start the polkitd mock with the corresponding user if it exists

### DIFF
--- a/src/tests/test_polkitd.py
+++ b/src/tests/test_polkitd.py
@@ -21,6 +21,7 @@ import argparse
 import unittest
 import signal
 import time
+import pwd
 
 import dbus
 import dbus.service
@@ -194,4 +195,10 @@ def main():
     _run(args.allowed_actions.split(','), args.bus_address)
 
 if __name__ == '__main__':
+    # use the right user to start the service
+    try:
+        uid = pwd.getpwnam('polkitd').pw_uid
+        os.setuid(uid)
+    except KeyError:
+        pass
     main()


### PR DESCRIPTION
Similar to https://gitlab.gnome.org/GNOME/gvfs/-/merge_requests/167

I was trying to debug the tests failing on current Ubuntu and though it might be the issue but it's not, the problem was  #1112 with linux 6.3. For some reason test_polkitd.py doesn't error out in the testsuite here but it fails if started manually and it should still be the correct behaviour