### PR TITLE
udiskslinuxloop: Avoid warnings on empty loop devices

### DIFF
--- a/src/udiskslinuxloop.c
+++ b/src/udiskslinuxloop.c
@@ -137,11 +137,14 @@ udisks_linux_loop_update (UDisksLinuxLoop        *loop,
         {
           if (error != NULL)
             {
-              udisks_warning ("Error getting '%s' information: %s (%s, %d)",
-                              g_udev_device_get_name (device->udev_device),
-                              error->message,
-                              g_quark_to_string (error->domain),
-                              error->code);
+              if (! g_error_matches (error, BD_LOOP_ERROR, BD_LOOP_ERROR_DEVICE))
+                {
+                  udisks_warning ("Error getting '%s' information: %s (%s, %d)",
+                                  g_udev_device_get_name (device->udev_device),
+                                  error->message,
+                                  g_quark_to_string (error->domain),
+                                  error->code);
+                }
               g_clear_error (&error);
             }
           udisks_loop_set_backing_file (UDISKS_LOOP (loop), "");


### PR DESCRIPTION
By default no device node is created upon loading the 'loop' kernel module unless overriden by the max_loop module parameter in which case device nodes are created up to the specified limit. This causes udisks to report nasty warning about as ENXIO is reported upon calling a LOOP_GET_STATUS64 ioctl().

Needs https://github.com/storaged-project/libblockdev/pull/941