### PR TITLE
ci: Add Packit configuration for RPM builds on PRs

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -1,0 +1,44 @@
+actions:
+  create-archive:
+    - './autogen.sh --disable-modules --disable-daemon'
+    # FIXME: just calling `make dist` doesn't build udisks/libudisks2.la for gtk-doc
+    - 'make'
+    - 'make dist'
+    - 'bash -c "ls *.tar*"'
+
+jobs:
+- job: copr_build
+  branch: master
+  trigger: pull_request
+  targets:
+    - fedora-rawhide-aarch64
+    - fedora-rawhide-ppc64le
+    - fedora-rawhide-x86_64
+    - fedora-latest-aarch64
+    - fedora-latest-ppc64le
+    - fedora-latest-x86_64
+    - fedora-latest-stable-aarch64
+    - fedora-latest-stable-ppc64le
+    - fedora-latest-stable-x86_64
+  additional_repos:
+  - "copr://@storage/udisks-daily"
+
+srpm_build_deps:
+ - gcc
+ - make
+ - libtool
+ - autoconf
+ - automake
+ - glib2-devel
+ - gtk-doc
+ - gobject-introspection-devel
+ - polkit-devel
+ - systemd
+ - systemd-devel
+ - systemd-rpm-macros
+ - gettext-devel
+ - redhat-rpm-config
+ - libmount-devel
+
+downstream_package_name: udisks2
+specfile_path: packaging/udisks2.spec

--- a/data/Makefile.am
+++ b/data/Makefile.am
@@ -1,24 +1,25 @@
 
 NULL =
 
+dbusconf_in_files = org.freedesktop.UDisks2.conf.in
+dbusservice_in_files = org.freedesktop.UDisks2.service.in
+polkit_in_files  = org.freedesktop.UDisks2.policy.in
+systemdservice_in_files = udisks2.service.in
+
 if ENABLE_DAEMON
 SUBDIRS = tmpfiles.d
 
 dbusservicedir       = $(datadir)/dbus-1/system-services
-dbusservice_in_files = org.freedesktop.UDisks2.service.in
 dbusservice_DATA     = $(dbusservice_in_files:.service.in=.service)
 
 $(dbusservice_DATA): $(dbusservice_in_files) Makefile
 	@sed -e "s|\@udisksdprivdir\@|$(libexecdir)/udisks2|" $< > $@
 
 dbusconfdir = $(datadir)/dbus-1/system.d
-dbusconf_in_files = org.freedesktop.UDisks2.conf.in
 dbusconf_DATA = $(dbusconf_in_files:.conf.in=.conf)
 
 $(dbusconf_DATA): $(dbusconf_in_files) Makefile
 	cp $< $@
-
-systemdservice_in_files = udisks2.service.in
 
 if HAVE_SYSTEMD
 systemdservicedir       = $(systemdsystemunitdir)
@@ -32,7 +33,6 @@ udevrulesdir = $(udevdir)/rules.d
 udevrules_DATA = 80-udisks2.rules
 
 polkitdir        = $(datadir)/polkit-1/actions
-polkit_in_files  = org.freedesktop.UDisks2.policy.in
 polkit_DATA      = $(polkit_in_files:.policy.in=.policy)
 
 $(polkit_DATA): $(polkit_in_files)

--- a/modules/btrfs/data/Makefile.am
+++ b/modules/btrfs/data/Makefile.am
@@ -1,10 +1,11 @@
 
 NULL =
 
+polkit_in_files  = org.freedesktop.UDisks2.btrfs.policy.in
+
 if ENABLE_DAEMON
 
 polkitdir        = $(datadir)/polkit-1/actions
-polkit_in_files  = org.freedesktop.UDisks2.btrfs.policy.in
 polkit_DATA      = $(polkit_in_files:.policy.in=.policy)
 
 $(polkit_DATA): $(polkit_in_files)

--- a/modules/iscsi/data/Makefile.am
+++ b/modules/iscsi/data/Makefile.am
@@ -1,10 +1,11 @@
 
 NULL =
 
+polkit_in_files  = org.freedesktop.UDisks2.iscsi.policy.in
+
 if ENABLE_DAEMON
 
 polkitdir        = $(datadir)/polkit-1/actions
-polkit_in_files  = org.freedesktop.UDisks2.iscsi.policy.in
 polkit_DATA      = $(polkit_in_files:.policy.in=.policy)
 
 $(polkit_DATA): $(polkit_in_files)

--- a/modules/lsm/data/Makefile.am
+++ b/modules/lsm/data/Makefile.am
@@ -1,10 +1,11 @@
 
 NULL =
 
+polkit_in_files  = org.freedesktop.UDisks2.lsm.policy.in
+
 if ENABLE_DAEMON
 
 polkitdir        = $(datadir)/polkit-1/actions
-polkit_in_files  = org.freedesktop.UDisks2.lsm.policy.in
 polkit_DATA      = $(polkit_in_files:.policy.in=.policy)
 
 $(polkit_DATA): $(polkit_in_files)

--- a/modules/lvm2/data/Makefile.am
+++ b/modules/lvm2/data/Makefile.am
@@ -1,10 +1,11 @@
 
 NULL =
 
+polkit_in_files  = org.freedesktop.UDisks2.lvm2.policy.in
+
 if ENABLE_DAEMON
 
 polkitdir        = $(datadir)/polkit-1/actions
-polkit_in_files  = org.freedesktop.UDisks2.lvm2.policy.in
 polkit_DATA      = $(polkit_in_files:.policy.in=.policy)
 
 $(polkit_DATA): $(polkit_in_files)


### PR DESCRIPTION
Configure with minimal options, so that we can build a dist tarball without too many extra dependencies. In particular, we want to avoid libblockdev, as we usually need the latest upstream master one, not the distro package.

---

This is a fixed replacement of PR #1080. I got a [successful build](https://copr.fedorainfracloud.org/coprs/packit/martinpitt-udisks-1/build/6233660/) on my [fork PR](https://github.com/martinpitt/udisks/pull/1). 

Note that this currently uses the default transient packit COPR to build the packages. I would strongly recommend to use them, unless you have a good reason to use your custom one.

If you want "daily builds" done by packit, this needs to happen in a `trigger: commit` (on master branch) job. These are *different* from this `trigger: pull_request` builds, which are done from the proposed forks/branches. They should *not* land in the user-facing COPR that "daily" is. It should be fairly obvious how to set these up, but if you want me to, I'm happy to send a follow-up PR which sets this up.