### PR TITLE
tests: Mark LVM RAID tests as unstable

### DIFF
--- a/src/tests/dbus-tests/test_20_LVM.py
+++ b/src/tests/dbus-tests/test_20_LVM.py
@@ -212,6 +212,7 @@ class UdisksLVMTest(UDisksLVMTestBase):
         objects = udisks.GetManagedObjects(dbus_interface='org.freedesktop.DBus.ObjectManager')
         self.assertNotIn(new_lvpath, objects.keys())
 
+    @udiskstestcase.tag_test(udiskstestcase.TestTags.UNSTABLE)
     def test_15_raid(self):
         '''Test raid volumes functionality'''
 


### PR DESCRIPTION
Forcefully yanking out devices and trying to get them back turned out to be unreliable, breaking the rest of the testing process. I'm out of ideas, so mark it as unstable and limit the damage.