### PR TITLE
udiskslinuxfilesystem: Use ID_FS_SIZE for filesystems that are not known to report ID_FS_LASTBLOCK

### DIFF
--- a/data/org.freedesktop.UDisks2.xml
+++ b/data/org.freedesktop.UDisks2.xml
@@ -2715,11 +2715,12 @@
     </method>
 
     <!-- Size: The size of the filesystem.  This is the amount of
-         bytes used on the block device.  If this is smaller than
-         org.freedesktop.Udisks2.Block.Size, then the filesystem can
-         be made larger with Resize.
+         bytes used on the block device representing an outer filesystem
+         boundary. If this is smaller than org.freedesktop.Udisks2.Block.Size,
+         then the filesystem can be made larger with Resize.
 
-         If the size is unknown, the property is zero.
+         If the size is unknown, the property is zero. Currently limited
+         to xfs and ext filesystems only.
 
          Please note that reading value of this property typically causes
          some I/O to read the filesystem superblock. Unlike the rest

--- a/src/tests/dbus-tests/test_80_filesystem.py
+++ b/src/tests/dbus-tests/test_80_filesystem.py
@@ -1758,6 +1758,18 @@ class UDFTestCase(UdisksFSTestCase):
     def _gen_uuid(self):
         return str.format("%016x" % random.randint(0, 0xffffffffffffffff))
 
+    @udiskstestcase.tag_test(udiskstestcase.TestTags.UNSTABLE)
+    def test_mount_fstab_complex_label(self):
+        super(UDFTestCase, self).test_mount_fstab_complex_label()
+
+    @udiskstestcase.tag_test(udiskstestcase.TestTags.UNSTABLE)
+    def test_mount_fstab_complex_label2(self):
+        super(UDFTestCase, self).test_mount_fstab_complex_label2()
+
+    @udiskstestcase.tag_test(udiskstestcase.TestTags.UNSTABLE)
+    def test_mount_fstab_complex_label_bad(self):
+        super(UDFTestCase, self).test_mount_fstab_complex_label_bad()
+
 
 class FailsystemTestCase(UdisksFSTestCase):
     # test that not supported operations fail 'nicely'


### PR DESCRIPTION
Looking at the util-linux-2.39.1 sources only xfs, ext and btrfs probes do have support for reporting filesystem last block. There are many others however that do report filesystem size that would still be beneficial for UDisks to use.
    
However, for filesystems that we know the two values differ and that are proven to work fine with bd_fs_get_size(), we should still avoid using ID_FS_SIZE. Let's maintain a short internal whitelist.

----

See the previous discussion in #1114 and the feedback in #1139.

Taking `vfat` and `ntfs` as an example, the filesystem size computation looks roughly similar. For the moment it looks like a best effort. The whitelist introduced serves also a blacklist for ID_FS_SIZE for some filesystems.

Fixes #1139
Cc: @mvollmer