### PR TITLE
ci: Packit: Enable failure notifications for cockpit tests

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -30,6 +30,9 @@ jobs:
 - job: tests
   identifier: revdeps
   trigger: pull_request
+  notifications:
+    failure_comment:
+      message: "Cockpit tests failed for commit {commit_sha}. @martinpitt, @jelly, @mvollmer please check."
   targets:
     - fedora-rawhide-x86_64
     - fedora-latest-x86_64

--- a/plans/cockpit.fmf
+++ b/plans/cockpit.fmf
@@ -1,6 +1,6 @@
 # reverse dependency test for https://github.com/cockpit-project/cockpit
-# if this fails in a non-obvious way, please contact the cockpit team in your PR for investigation:
-# @martinpitt, @marusak, @mvollmer
+# packit should automatically notify the cockpit maintainers on failures.
+# For questions, please contact @martinpitt, @jelly, @mvollmer
 enabled: false
 
 adjust+:


### PR DESCRIPTION
Configure packit to automatically notify relevant Cockpit team members when one of the "cockpit-revdeps" tests fails.

See https://packit.dev/docs/configuration/#failure_comment

---

This wil relieve you from the burden of having to ping us manually. See https://packit.dev/posts/weekly/2023/week-37