### PR TITLE
lvm: Also look at symlinks for segment PVs

### DIFF
--- a/modules/lvm2/udiskslinuxlogicalvolume.c
+++ b/modules/lvm2/udiskslinuxlogicalvolume.c
@@ -145,14 +145,21 @@ build_segment (UDisksDaemon *daemon,
   g_variant_builder_init (&seg_builder, G_VARIANT_TYPE ("(tto)"));
   g_variant_builder_add (&seg_builder, "t", seg->pv_start_pe * extent_size);
   g_variant_builder_add (&seg_builder, "t", seg->size_pe * extent_size);
-  block_object = udisks_daemon_find_block_by_device_file (daemon, seg->pvdev);
-  if (block_object)
+  if (seg->pvdev == NULL)
     {
-      g_variant_builder_add (&seg_builder, "o", g_dbus_object_get_object_path (G_DBUS_OBJECT (block_object)));
-      g_object_unref (block_object);
+      g_variant_builder_add (&seg_builder, "o", "/");
     }
   else
-    g_variant_builder_add (&seg_builder, "o", "/");
+    {
+      block_object = udisks_daemon_find_block_by_device_file_and_symlinks (daemon, seg->pvdev);
+      if (block_object)
+        {
+          g_variant_builder_add (&seg_builder, "o", g_dbus_object_get_object_path (G_DBUS_OBJECT (block_object)));
+          g_object_unref (block_object);
+        }
+      else
+        g_variant_builder_add (&seg_builder, "o", "/notfound");
+    }
   return g_variant_builder_end (&seg_builder);
 }
 

--- a/src/udisksdaemon.h
+++ b/src/udisksdaemon.h
@@ -97,6 +97,9 @@ UDisksObject             *udisks_daemon_find_block            (UDisksDaemon     
 UDisksObject             *udisks_daemon_find_block_by_device_file (UDisksDaemon *daemon,
                                                                    const gchar  *device_file);
 
+UDisksObject             *udisks_daemon_find_block_by_device_file_and_symlinks (UDisksDaemon *daemon,
+                                                                                const gchar  *device_file);
+
 UDisksObject             *udisks_daemon_find_block_by_sysfs_path (UDisksDaemon *daemon,
                                                                   const gchar  *sysfs_path);
 


### PR DESCRIPTION
When a PV is on a LUKS device, lvm reports that device as "/dev/mapper/luks-1234...", which is a symlink to the real device. UDisks2 would miss this and report the segment as having lost its backing PV.

In addition to looking harder for devices, UDisks2 now also distinguises between "PV is gone" and "PV is there but I can't find a D-Bus object for it".