### PR TITLE
modules/btrfs: add GetDefaultSubvolumeID

### DIFF
--- a/modules/btrfs/data/org.freedesktop.UDisks2.btrfs.xml
+++ b/modules/btrfs/data/org.freedesktop.UDisks2.btrfs.xml
@@ -219,6 +219,20 @@
       <arg name="options" type="a{sv}" direction="in"/>
     </method>
 
+    <!--
+        GetDefaultSubvolumeID:
+        @options: Additional options.
+        @since: 2.11.0
+
+        Returns the default subvolume id.
+
+        No additional options are currently defined.
+    -->
+    <method name="GetDefaultSubvolumeID">
+      <arg name="id" direction="out" type="u"/>
+      <arg name="options" type="a{sv}" direction="in"/>
+    </method>
+
     <property name="label" type="s" access="read"/>
     <property name="uuid" type="s" access="read"/>
     <property name="num_devices" type="t" access="read"/>


### PR DESCRIPTION
libblockdev provides a method to get the default subvolume id since 2014, with no way to change it. This method does not require any administrative privileges but requires it for setting.


This feels more logical as a property but it requires a method call and I intend to also add a Setter for this. But that requires a libblockdev patch.
---

P.S. I hope the tests succeed. I'm unable to get the tests running on Arch Linux as it uses `lsb_release` and `targetcli`. Targetcli is not available as a package.