### PR TITLE
udiskslinuxprovider: Properly finalize GTaskThreadFunc

### DIFF
--- a/src/udiskslinuxdriveata.c
+++ b/src/udiskslinuxdriveata.c
@@ -1779,6 +1779,7 @@ apply_configuration_thread_func (GTask        *task,
  out:
   if (fd != -1)
     close (fd);
+  g_task_return_boolean (task, TRUE);
 }
 
 /**

--- a/src/udiskslinuxprovider.c
+++ b/src/udiskslinuxprovider.c
@@ -944,6 +944,7 @@ perform_initial_housekeeping_for_drive (GTask           *task,
                       error->message, g_quark_to_string (error->domain), error->code);
       g_clear_error (&error);
     }
+  g_task_return_boolean (task, TRUE);
 }
 
 /* ---------------------------------------------------------------------------------------------------- */
@@ -1588,6 +1589,7 @@ housekeeping_thread_func (GTask           *task,
   G_LOCK (provider_lock);
   provider->housekeeping_running = FALSE;
   G_UNLOCK (provider_lock);
+  g_task_return_boolean (task, TRUE);
 }
 
 /* called from the main thread on start-up and every 10 minutes or so */


### PR DESCRIPTION
No real world difference as nobody cares about the result, only added to fully conform to Gio specs and to get rid of these debugging warnings (G_MESSAGES_DEBUG=all):

  (udisksd:32988): GLib-GIO-DEBUG: 05:51:26.255: GTask 0x5607c9739930 (source object: 0x5607c97395d0, source tag: (nil)) finalized without ever returning (using g_task_return_*()). This potentially indicates a bug in the program.