### PR TITLE
modules/btrfs: add SetDefaultSubvolumeID

### DIFF
--- a/modules/btrfs/data/org.freedesktop.UDisks2.btrfs.xml
+++ b/modules/btrfs/data/org.freedesktop.UDisks2.btrfs.xml
@@ -233,6 +233,21 @@
       <arg name="options" type="a{sv}" direction="in"/>
     </method>
 
+    <!--
+        SetDefaultSubvolumeID:
+        @id: New default subvolume id.
+        @options: Additional options.
+        @since: 2.11.0
+
+        Sets the default subvolume id.
+
+        No additional options are currently defined.
+    -->
+    <method name="SetDefaultSubvolumeID">
+      <arg name="id" direction="in" type="u"/>
+      <arg name="options" type="a{sv}" direction="in"/>
+    </method>
+
     <property name="label" type="s" access="read"/>
     <property name="uuid" type="s" access="read"/>
     <property name="num_devices" type="t" access="read"/>

--- a/src/tests/dbus-tests/test_btrfs.py
+++ b/src/tests/dbus-tests/test_btrfs.py
@@ -382,7 +382,7 @@ class UdisksBtrfsTest(udiskstestcase.UdisksTestCase):
         dbus_mnt = self.ay_to_str(dbus_mounts.value[0])  # mountpoints are arrays of bytes
         self.assertEqual(dbus_mnt, mnt_path)
 
-    def test_get_default_subvolume_id(self):
+    def test_default_subvolume_id(self):
         dev = self._get_devices(1)[0]
         self.addCleanup(self._clean_format, dev.obj)
 
@@ -396,6 +396,13 @@ class UdisksBtrfsTest(udiskstestcase.UdisksTestCase):
         fstype.assertEqual('btrfs')
 
         with self._temp_mount(dev.path):
+            default_id = dev.obj.GetDefaultSubvolumeID(self.no_options,
+                             dbus_interface=self.iface_prefix + '.Filesystem.BTRFS')
+            self.assertEqual(default_id, 5)
+
+            dev.obj.SetDefaultSubvolumeID(dbus.UInt32(5), self.no_options,
+                                          dbus_interface=self.iface_prefix + '.Filesystem.BTRFS')
+
             default_id = dev.obj.GetDefaultSubvolumeID(self.no_options,
                              dbus_interface=self.iface_prefix + '.Filesystem.BTRFS')
             self.assertEqual(default_id, 5)


### PR DESCRIPTION
libblockdev provides a method to set the default subvolume id since
2014. This method does requires administrative privileges as it changes the default mount target subvolume of a btrfs volume.

---

Turns out I was wrong and thought libblockdev did not provide a method for it but it has a slightly different name.