### PR TITLE
udiskslinuxdrive: Calculate drive size from all attached NVMe namespaces

### DIFF
--- a/doc/udisks2-sections.txt.daemon.sections.in
+++ b/doc/udisks2-sections.txt.daemon.sections.in
@@ -143,6 +143,7 @@ udisks_linux_drive_object_should_include_device
 UDisksLinuxDrive
 udisks_linux_drive_new
 udisks_linux_drive_update
+udisks_linux_drive_recalculate_nvme_size
 <SUBSECTION Standard>
 UDISKS_LINUX_DRIVE
 UDISKS_IS_LINUX_DRIVE
@@ -283,6 +284,7 @@ udisks_linux_device_read_sysfs_attr_as_int
 udisks_linux_device_read_sysfs_attr_as_uint64
 udisks_linux_device_subsystem_is_nvme
 udisks_linux_device_nvme_is_fabrics
+udisks_linux_device_nvme_tnvmcap_supported
 <SUBSECTION Standard>
 UDISKS_TYPE_LINUX_DEVICE
 UDISKS_LINUX_DEVICE

--- a/src/tests/dbus-tests/test_nvme.py
+++ b/src/tests/dbus-tests/test_nvme.py
@@ -267,7 +267,7 @@ class UdisksNVMeTest(udiskstestcase.UdisksTestCase):
         id = self.get_property_raw(drive_obj, '.Drive', 'Id')
         self.assertTrue(id.startswith('Linux-'))
         size = self.get_property_raw(drive_obj, '.Drive', 'Size')
-        self.assertEqual(size, 0)
+        self.assertEqual(size, self.NS_SIZE * self.NUM_NS)
 
         ctrl_id = self.get_property_raw(drive_obj, '.NVMe.Controller', 'ControllerID')
         self.assertGreater(ctrl_id, 0)

--- a/src/udiskslinuxdevice.c
+++ b/src/udiskslinuxdevice.c
@@ -463,3 +463,24 @@ udisks_linux_device_nvme_is_fabrics (UDisksLinuxDevice *device)
 
   return FALSE;
 }
+
+/**
+ * udisks_linux_device_nvme_tnvmcap_supported:
+ * @device: A #UDisksLinuxDevice.
+ *
+ * Determines whether @device supports Capacity information
+ * in the Identify Controller data structure.
+ *
+ * Returns: %TRUE if capacity reporting is supported, %FALSE otherwise.
+ */
+gboolean
+udisks_linux_device_nvme_tnvmcap_supported (UDisksLinuxDevice *device)
+{
+  if (device->nvme_ctrl_info == NULL)
+    return FALSE;
+
+  /* FIXME: find a more reliable way to detect controller
+   *        capacity reporting capability.
+   */
+  return device->nvme_ctrl_info->size_total > 0;
+}

--- a/src/udiskslinuxdevice.h
+++ b/src/udiskslinuxdevice.h
@@ -74,6 +74,7 @@ guint64            udisks_linux_device_read_sysfs_attr_as_uint64 (UDisksLinuxDev
 
 gboolean           udisks_linux_device_subsystem_is_nvme         (UDisksLinuxDevice  *device);
 gboolean           udisks_linux_device_nvme_is_fabrics           (UDisksLinuxDevice  *device);
+gboolean           udisks_linux_device_nvme_tnvmcap_supported    (UDisksLinuxDevice  *device);
 
 G_END_DECLS
 

--- a/src/udiskslinuxdrive.h
+++ b/src/udiskslinuxdrive.h
@@ -34,6 +34,9 @@ UDisksDrive *udisks_linux_drive_new      (void);
 gboolean     udisks_linux_drive_update   (UDisksLinuxDrive       *drive,
                                           UDisksLinuxDriveObject *object);
 
+void         udisks_linux_drive_recalculate_nvme_size (UDisksLinuxDrive       *drive,
+                                                       UDisksLinuxDriveObject *object);
+
 G_END_DECLS
 
 #endif /* __UDISKS_LINUX_DRIVE_H__ */


### PR DESCRIPTION
In case capacity reporting is not supported by the NVMe controller, calculate the drive size from the currently attached namespaces as a workaround.

This presents a chicken-egg problem when not all block objects are present at the time the drive size calculation is done. So ping the drive object back once a namespace interface is published, and on all subsequent uevents (e.g. as a result of LBA format change). Since the pingback is queued in the main loop, the drive Size property gets updates slightly later.

Fixes #1194

TODO:
- [ ] handle namespace detach (uevent remove) event