### PR TITLE
lvm: Manually remove removed PVs from the LVM devices file

### DIFF
--- a/modules/lvm2/udiskslinuxvolumegroup.c
+++ b/modules/lvm2/udiskslinuxvolumegroup.c
@@ -362,6 +362,12 @@ handle_delete (UDisksVolumeGroup     *_group,
               udisks_warning ("Failed to wipe PV %s: %s", device_file, error->message);
               g_clear_error (&error);
             }
+          if (bd_lvm_is_tech_avail (BD_LVM_TECH_DEVICES, 0, NULL) &&
+              !bd_lvm_devices_delete (device_file, NULL, NULL, &error))
+            {
+              udisks_warning ("Failed to remove %s from LVM devices file: %s", device_file, error->message);
+              g_clear_error (&error);
+            }
         }
     }
 

--- a/src/tests/dbus-tests/test_20_LVM.py
+++ b/src/tests/dbus-tests/test_20_LVM.py
@@ -12,6 +12,9 @@ from packaging.version import Version
 import udiskstestcase
 
 
+LVM_DEVICES_FILE = "/etc/lvm/devices/system.devices"
+
+
 class UDisksLVMTestBase(udiskstestcase.UdisksTestCase):
 
     @classmethod
@@ -106,6 +109,11 @@ class UdisksLVMTest(UDisksLVMTestBase):
 
         fstype = self.get_property(dev_obj, '.Block', 'IdType')
         fstype.assertEqual('')
+
+        # check that PV was removed from the LVM devices file
+        if os.path.exists(LVM_DEVICES_FILE):
+            devices_file = self.read_file(LVM_DEVICES_FILE)
+            self.assertNotIn(self.vdevs[0], devices_file)
 
     def test_10_linear(self):
         '''Test linear (plain) LV functionality'''


### PR DESCRIPTION
'pvremove' doesn't do that which is apparently intentional so we need to do that ourselves.