### PR TITLE
client: document NULL return for udisks_client_get_partition_table

### DIFF
--- a/udisks/udisksclient.c
+++ b/udisks/udisksclient.c
@@ -1423,7 +1423,8 @@ udisks_client_get_partitions (UDisksClient         *client,
  *
  * Gets the #UDisksPartitionTable corresponding to @partition.
  *
- * Returns: (transfer full): A #UDisksPartitionTable. Free with g_object_unref().
+ * Returns: (transfer full): A #UDisksPartitionTable or %NULL if there is no #UDisksPartitionTable for @partition.
+ * Free with g_object_unref().
  */
 UDisksPartitionTable *
 udisks_client_get_partition_table (UDisksClient     *client,


### PR DESCRIPTION
Documents that `udisks_client_get_partition_table` can return NULL. This is similar to functions like [`udisks_client_get_drive_for_block`](https://storaged.org/doc/udisks2-api/latest/UDisksClient.html#udisks-client-get-drive-for-block) which document the possible NULL returns.