### PR TITLE
block: Survive a missing /etc/fstab

### DIFF
--- a/src/udiskslinuxblock.c
+++ b/src/udiskslinuxblock.c
@@ -1541,7 +1541,15 @@ add_remove_fstab_entry (UDisksBlock *block,
                             &contents,
                             NULL,
                             error))
-    goto out;
+    {
+      if (g_error_matches (*error, G_FILE_ERROR, G_FILE_ERROR_NOENT))
+        {
+          contents = g_strdup ("");
+          g_clear_error (error);
+        }
+      else
+        goto out;
+    }
 
   lines = g_strsplit (contents, "\n", 0);
 


### PR DESCRIPTION
This is similar to b79f6840ca82551e672156153b7e13328f0ba19d, which solved the same problem for /etc/crypttab.