### PR TITLE
ci: Fix running Cockpit reverse dependency tests

### DIFF
--- a/plans/cockpit.fmf
+++ b/plans/cockpit.fmf
@@ -15,8 +15,12 @@ discover:
 execute:
     how: tmt
 
-# this includes the storage tests
-/optional:
-    summary: Run tests for optional packages
+/storage-basic:
+    summary: Basic storage tests
     discover+:
-        test: /test/browser/optional
+        test: /test/browser/storage-basic
+
+/storage-extra:
+    summary: More expensive storage tests (LVM, LUKS, Anaconda)
+    discover+:
+        test: /test/browser/storage-extra


### PR DESCRIPTION
Cockpit recently renamed/split the optional tests into two storage tests, see https://github.com/cockpit-project/cockpit/pull/20524