### PR TITLE
tests: Skip exFAT UUID tests also on Fedora 39

### DIFF
--- a/src/tests/dbus-tests/skip.yml
+++ b/src/tests/dbus-tests/skip.yml
@@ -33,5 +33,5 @@
 - test: test_80_filesystem.EXFATTestCase.test_uuid
   skip_on:
     - distro: "fedora"
-      version: ["40", "41"]
+      version: ["39", "40", "41"]
       reason: Setting UUID with LC_ALL=C.UTF-8 is broken with recent exfatprogs


### PR DESCRIPTION
Latest exfatprogs was backported to 39 too.