### PR TITLE
Do not overwrite CPPFLAGS

### DIFF
--- a/modules/btrfs/Makefile.am
+++ b/modules/btrfs/Makefile.am
@@ -4,7 +4,7 @@ SUBDIRS = data
 
 NULL =
 
-CPPFLAGS =                                                                     \
+AM_CPPFLAGS =                                                                  \
 	-I$(top_builddir) -I$(top_srcdir)                                      \
 	-DPACKAGE_LIBEXEC_DIR=\""$(libexecdir)"\"                              \
 	-DPACKAGE_SYSCONF_DIR=\""$(sysconfdir)"\"                              \
@@ -51,7 +51,7 @@ libudisks2_btrfs_la_SOURCES =                                                  \
 	$(NULL)
 
 libudisks2_btrfs_la_CPPFLAGS =                                                 \
-	$(CPPFLAGS)                                                            \
+	$(AM_CPPFLAGS)                                                         \
 	-DG_LOG_DOMAIN=\"libudisks2-btrfs\"                                    \
 	$(NULL)
 

--- a/modules/iscsi/Makefile.am
+++ b/modules/iscsi/Makefile.am
@@ -4,7 +4,7 @@ SUBDIRS = data
 
 NULL =
 
-CPPFLAGS =                                                                     \
+AM_CPPFLAGS =                                                                  \
 	-I$(top_builddir) -I$(top_srcdir)                                      \
 	-DPACKAGE_LIBEXEC_DIR=\""$(libexecdir)"\"                              \
 	-DPACKAGE_SYSCONF_DIR=\""$(sysconfdir)"\"                              \
@@ -56,7 +56,7 @@ libudisks2_iscsi_la_SOURCES +=                                                 \
 endif # BUILD_ISCSI_SESSION_OBJECT
 
 libudisks2_iscsi_la_CPPFLAGS =                                                 \
-	$(CPPFLAGS)                                                            \
+	$(AM_CPPFLAGS)                                                         \
 	-DG_LOG_DOMAIN=\"libudisks2-iscsi\"                                    \
 	$(NULL)
 

--- a/modules/lsm/Makefile.am
+++ b/modules/lsm/Makefile.am
@@ -4,7 +4,7 @@ SUBDIRS = data
 
 NULL =
 
-CPPFLAGS =                                                                     \
+AM_CPPFLAGS =                                                                  \
 	-I$(top_builddir) -I$(top_srcdir)                                      \
 	-DPACKAGE_LIBEXEC_DIR=\""$(libexecdir)"\"                              \
 	-DPACKAGE_SYSCONF_DIR=\""$(sysconfdir)"\"                              \
@@ -48,7 +48,7 @@ libudisks2_lsm_la_SOURCES =                                                    \
 	$(NULL)
 
 libudisks2_lsm_la_CPPFLAGS =                                                   \
-	$(CPPFLAGS)                                                            \
+	$(AM_CPPFLAGS)                                                         \
 	-DG_LOG_DOMAIN=\"libudisks2-lsm\"                                      \
 	$(NULL)
 

--- a/modules/lvm2/Makefile.am
+++ b/modules/lvm2/Makefile.am
@@ -4,7 +4,7 @@ SUBDIRS = data
 
 NULL =
 
-CPPFLAGS =                                                                     \
+AM_CPPFLAGS =                                                                  \
 	-I$(top_builddir) -I$(top_srcdir)                                      \
 	-DPACKAGE_LIBEXEC_DIR=\""$(libexecdir)"\"                              \
 	-DPACKAGE_SYSCONF_DIR=\""$(sysconfdir)"\"                              \
@@ -55,7 +55,7 @@ libudisks2_lvm2_la_SOURCES =                                                   \
 	$(NULL)
 
 libudisks2_lvm2_la_CPPFLAGS =                                                  \
-	$(CPPFLAGS)                                                            \
+	$(AM_CPPFLAGS)                                                         \
 	-DG_LOG_DOMAIN=\"libudisks2-lvm2\"                                     \
 	$(NULL)
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -8,7 +8,7 @@ EXTRA_DIST =
 
 CLEANFILES =
 
-CPPFLAGS =                                                                     \
+AM_CPPFLAGS =                                                                  \
 	-I$(top_builddir) -I$(top_srcdir)                                      \
 	-DPACKAGE_LIBEXEC_DIR=\""$(libexecdir)"\"                              \
 	-DPACKAGE_SYSCONF_DIR=\""$(sysconfdir)"\"                              \


### PR DESCRIPTION
Use AM_CPPFLAGS instead of ovewriting CPPFLAGS.
CPPFLAGS is a user variable reserved for local modifications. See
https://www.gnu.org/software/automake/manual/html_node/Flag-Variables-Ordering.html