### PR TITLE
Add gzipped log files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 *.la
 *.lo
 *.log
+*.log.gz
 *.o
 *.pot
 *.sign


### PR DESCRIPTION
Some of our test logs are now compressed so we should ignore these too.

See also #1284