### PR TITLE
udiskslinuxfilesystem: Add squashfs to well_known_filesystems

### DIFF
--- a/src/udiskslinuxfilesystem.c
+++ b/src/udiskslinuxfilesystem.c
@@ -134,6 +134,7 @@ static const gchar *well_known_filesystems[] =
   "reiserfs",
   "reiser4",
   "reiser5",
+  "squashfs",
   "umsdos",
   "vfat",
   "xfs",


### PR DESCRIPTION
We already had erofs in the list, squashfs was missing.