### PR TITLE
build: Allow specifying custom housekeeping interval

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -138,6 +138,12 @@ if test "x$fhs_media" = "xyes"; then
   AC_DEFINE([HAVE_FHS_MEDIA], 1, [Define to 1 to use /media for mounting])
 fi
 
+housekeeping_interval=10
+AC_ARG_WITH([housekeeping_interval],
+            AS_HELP_STRING([--with-housekeeping-interval=MIN], [Housekeeping interval in minutes [default=10]]),
+            [housekeeping_interval=$withval], [])
+AC_DEFINE_UNQUOTED([HOUSEKEEPING_INTERVAL], [$housekeeping_interval], [Housekeeping interval])
+
 # Libraries
 #
 

--- a/src/udiskslinuxprovider.c
+++ b/src/udiskslinuxprovider.c
@@ -795,7 +795,7 @@ udisks_linux_provider_start (UDisksProvider *_provider)
   udisks_info ("Initialization complete");
 
   /* schedule housekeeping for every 10 minutes */
-  provider->housekeeping_timeout = g_timeout_add_seconds (10*60,
+  provider->housekeeping_timeout = g_timeout_add_seconds (HOUSEKEEPING_INTERVAL * 60,
                                                           on_housekeeping_timeout,
                                                           provider);
   /* ... and also do an initial run */


### PR DESCRIPTION
This allows to override the default housekeeping interval in configure time via the new --with-housekeeping-interval=MIN option.

Fixes #892
Fixes #407
