### PR TITLE
Fix docstring for udisks_spawned_job_start

### DIFF
--- a/src/udisksspawnedjob.c
+++ b/src/udisksspawnedjob.c
@@ -897,7 +897,7 @@ udisks_spawned_job_release_resources (UDisksSpawnedJob *job)
  * Connect to the #UDisksSpawnedJob::spawned-job-completed or
  * #UDisksJob::completed signals to get notified when the job is done.
  *
- * */
+ */
 void udisks_spawned_job_start (UDisksSpawnedJob *job)
 {
   GError *error;


### PR DESCRIPTION
Without proper end gtkdoc will include the function in the generated documentation as well.