### PR TITLE
tests: Trigger uevent for newly added scsi_debug device in the Drive tests

### DIFF
--- a/src/tests/dbus-tests/test_40_drive.py
+++ b/src/tests/dbus-tests/test_40_drive.py
@@ -19,6 +19,7 @@ class UdisksDriveTest(udiskstestcase.UdisksTestCase):
         # ptype=5 - created device will be CD drive, one new target and host
         res, _ = self.run_command('modprobe scsi_debug ptype=5 num_tgts=1 add_host=1')
         self.assertEqual(res, 0)
+        self.run_command('udevadm trigger --settle')
         self.udev_settle()
         dirs = []
         # wait until directory appears
@@ -46,6 +47,7 @@ class UdisksDriveTest(udiskstestcase.UdisksTestCase):
                 time.sleep(0.1)
             self.udev_settle()
             self.run_command('modprobe -r scsi_debug')
+            self.run_command('udevadm trigger --settle')
 
     def test_10_eject(self):
         ''' Test of Drive.Eject method '''
@@ -86,8 +88,10 @@ class UdisksDriveTest(udiskstestcase.UdisksTestCase):
         ''' Test of Drive properties values '''
 
         sys_dirs = glob.glob('/sys/bus/pseudo/drivers/scsi_debug/adapter*/host*/target*/*:*/')
+        print(sys_dirs)
         self.assertEqual(len(sys_dirs), 1)
         sys_dir = sys_dirs[0]
+        print(sys_dir)
 
         def read_sys_file(value):
             return self.read_file(os.path.join(sys_dir, value)).strip()

--- a/src/tests/dbus-tests/test_40_drive.py
+++ b/src/tests/dbus-tests/test_40_drive.py
@@ -101,6 +101,10 @@ class UdisksDriveTest(udiskstestcase.UdisksTestCase):
 
         rotational = read_sys_file("block/%s/queue/rotational" % os.path.basename(self.cd_dev))
 
+        res, _ = self.run_command('udisksctl dump')
+        print (_)
+
+
         # values expected are preset by scsi_debug and do not change
         expected_prop_vals = {
             'MediaCompatibility': ['optical_cd'],

--- a/src/tests/dbus-tests/test_40_drive.py
+++ b/src/tests/dbus-tests/test_40_drive.py
@@ -15,6 +15,7 @@ class UdisksDriveTest(udiskstestcase.UdisksTestCase):
         return drive_object
 
     def setUp(self):
+        self.run_command('echo setUp > /dev/kmsg')
         # make sure scsi_debug is not loaded
         res, _ = self.run_command('rmmod scsi_debug')
         self.assertEqual(res, 1)
@@ -52,6 +53,7 @@ class UdisksDriveTest(udiskstestcase.UdisksTestCase):
             res, _ = self.run_command('modprobe -r scsi_debug')
             self.assertEqual(res, 0)
             self.run_command('udevadm trigger --settle')
+            self.run_command('echo tearDown > /dev/kmsg')
 
     def test_10_eject(self):
         ''' Test of Drive.Eject method '''
@@ -108,6 +110,10 @@ class UdisksDriveTest(udiskstestcase.UdisksTestCase):
         print(rotational)
 
         res, _ = self.run_command('udisksctl dump')
+        print (_)
+        res, _ = self.run_command('udevadm info %s' % self.cd_dev)
+        print (_)
+        res, _ = self.run_command('dmesg')
         print (_)
 
 


### PR DESCRIPTION
```
  ======================================================================
  FAIL: test_40_properties (test_40_drive.UdisksDriveTest.test_40_properties)
  Test of Drive properties values
  ----------------------------------------------------------------------
  Traceback (most recent call last):
    File "/var/ARTIFACTS/work-testsd3_d7qry/plans/tests/tree/src/tests/dbus-tests/test_40_drive.py", line 123, in test_40_properties
      actual_val.assertEqual(expected_val)
      ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^
    File "/var/ARTIFACTS/work-testsd3_d7qry/plans/tests/tree/src/tests/dbus-tests/udiskstestcase.py", line 141, in assertEqual
      raise AssertionError('%s != %s' % (self._value, value))
  AssertionError: dbus.Array([], signature=dbus.Signature('s'), variant_level=1) != ['optical_cd']
```