### PR TITLE
Fix btrfs lingering mounts

### DIFF
--- a/data/builtin_mount_options.conf
+++ b/data/builtin_mount_options.conf
@@ -29,7 +29,8 @@ udf_allow=uid=$UID,gid=$GID,iocharset,utf8,umask,mode,dmode,unhide,undelete
 hfsplus_defaults=uid=$UID,gid=$GID,nls=utf8
 hfsplus_allow=uid=$UID,gid=$GID,creator,type,umask,session,part,decompose,nodecompose,force,nls
 
-btrfs_allow=compress,compress-force,datacow,nodatacow,datasum,nodatasum,autodefrag,noautodefrag,degraded,device,discard,nodiscard,subvol,subvolid,space_cache
+btrfs_allow=compress,compress-force,datacow,nodatacow,datasum,nodatasum,autodefrag,noautodefrag,degraded,device,discard,nodiscard,subvol,subvolid,space_cache,x-systemd.device-bound
+btrfs_defaults=x-systemd.device-bound
 
 f2fs_allow=discard,nodiscard,compress_algorithm,compress_log_size,compress_extension,compress_chksum,alloc_mode,atgc,gc_merge,nogc_merge
 


### PR DESCRIPTION
Btrfs has an issue where mount can linger after a sudden device disconnect, this is very apparent with USB storage. the psuedo mount option x-systemd.device-bound overrides the default `Requires` dependency to that of `BindsTo` which will automatically stop the mount if the device became inactive. 

Partly fixes https://github.com/storaged-project/udisks/issues/1359

Please list more filesystems susceptible to lingering mounts in https://github.com/storaged-project/udisks/issues/1359 if you know any so they can be covered as well.