### PR TITLE
tests: Fix running tests on systems without fstab and crypttab

### DIFF
--- a/src/tests/dbus-tests/test_50_block.py
+++ b/src/tests/dbus-tests/test_50_block.py
@@ -2,6 +2,7 @@ import copy
 import dbus
 import glob
 import fcntl
+import shutil
 import os
 import time
 
@@ -172,8 +173,7 @@ class UdisksBlockTest(udiskstestcase.UdisksTestCase):
     def test_configuration_fstab(self):
 
         # this test will change /etc/fstab, we might want to revert the changes when it finishes
-        fstab = self.read_file('/etc/fstab')
-        self.addCleanup(self.write_file, '/etc/fstab', fstab)
+        self._conf_backup('/etc/fstab')
 
         # format the disk
         disk = self.get_object('/block_devices/' + os.path.basename(self.vdevs[0]))
@@ -237,8 +237,7 @@ class UdisksBlockTest(udiskstestcase.UdisksTestCase):
     def test_configuration_crypttab(self):
 
         # this test will change /etc/crypttab, we might want to revert the changes when it finishes
-        crypttab = self.read_file('/etc/crypttab')
-        self.addCleanup(self.write_file, '/etc/crypttab', crypttab)
+        self._conf_backup('/etc/crypttab')
 
         # format the disk
         disk = self.get_object('/block_devices/' + os.path.basename(self.vdevs[0]))
@@ -394,8 +393,7 @@ class UdisksBlockRemovableTest(udiskstestcase.UdisksTestCase):
     def test_configuration_fstab_removable(self):
 
         # this test will change /etc/fstab, we might want to revert the changes when it finishes
-        fstab = self.read_file('/etc/fstab')
-        self.addCleanup(self.write_file, '/etc/fstab', fstab)
+        self._conf_backup('/etc/fstab')
 
         # this might fail in case of stray udev rules or records in /etc/fstab
         hint_auto = self.get_property_raw(self.cd_device, '.Block', 'HintAuto')

--- a/src/tests/dbus-tests/test_70_encrypted.py
+++ b/src/tests/dbus-tests/test_70_encrypted.py
@@ -370,10 +370,8 @@ class UdisksEncryptedTest(udiskstestcase.UdisksTestCase):
     def test_configuration_track_parents(self):
         # this test will change /etc/crypttab and /etc/fstab, we might want to revert the changes
         # in case something goes wrong
-        crypttab = self.read_file('/etc/crypttab')
-        self.addCleanup(self.write_file, '/etc/crypttab', crypttab)
-        fstab = self.read_file('/etc/fstab')
-        self.addCleanup(self.write_file, '/etc/fstab', fstab)
+        self._conf_backup('/etc/fstab')
+        self._conf_backup('/etc/crypttab')
 
         disk_name = os.path.basename(self.vdevs[0])
         disk = self.get_object('/block_devices/' + disk_name)
@@ -742,10 +740,8 @@ class UdisksEncryptedTestLUKS2(UdisksEncryptedTest):
     @udiskstestcase.tag_test(udiskstestcase.TestTags.UNSAFE)
     def test_teardown_locked(self):
         # based on https://github.com/storaged-project/udisks/issues/1204
-        crypttab = self.read_file('/etc/crypttab')
-        self.addCleanup(self.write_file, '/etc/crypttab', crypttab)
-        fstab = self.read_file('/etc/fstab')
-        self.addCleanup(self.write_file, '/etc/fstab', fstab)
+        self._conf_backup('/etc/fstab')
+        self._conf_backup('/etc/crypttab')
 
         disk_name = os.path.basename(self.vdevs[0])
         disk = self.get_object('/block_devices/' + disk_name)

--- a/src/tests/dbus-tests/test_80_filesystem.py
+++ b/src/tests/dbus-tests/test_80_filesystem.py
@@ -709,7 +709,6 @@ class UdisksFSTestCase(udiskstestcase.UdisksTestCase):
             test_custom_option(self, False, None, True,  "[defaults]\nvfat_defaults=uid=,gid=,shortname=mixed,utf8=1,showexec\n", udev_rules_content = { "UDISKS_MOUNT_OPTIONS_VFAT_DEFAULTS": "uid=,gid=,shortname=mixed,utf8=1,showexec,flush" }, match_mount_option="flush")
             test_custom_option(self, False, None, True,  "[defaults]\nvfat_defaults=xxxxx\n\n[%s]\nvfat_defaults=yyyyyy\n" % block_fs_dev, udev_rules_content = { "UDISKS_MOUNT_OPTIONS_VFAT_DEFAULTS": "uid=,gid=,shortname=mixed,utf8=1,showexec,flush" }, match_mount_option="flush")
 
-
     def _test_fstab_label(self, disk_obj_path, label, fstab_label_str, mount_should_fail):
         self._check_can_create()
 
@@ -722,8 +721,7 @@ class UdisksFSTestCase(udiskstestcase.UdisksTestCase):
             self.skipTest('Cannot mount %s filesystem' % self._fs_signature)
 
         # this test will change /etc/fstab, we might want to revert the changes after it finishes
-        fstab = self.read_file('/etc/fstab')
-        self.addCleanup(self.write_file, '/etc/fstab', fstab)
+        self._conf_backup('/etc/fstab')
 
         disk = self.get_object(disk_obj_path)
         self.assertIsNotNone(disk)
@@ -1499,8 +1497,7 @@ class NonPOSIXTestCase(UdisksFSTestCase):
             self.skipTest('Cannot mount %s filesystem' % self._fs_signature)
 
         # this test will change /etc/fstab, we might want to revert the changes after it finishes
-        fstab = self.read_file('/etc/fstab')
-        self.addCleanup(self.write_file, '/etc/fstab', fstab)
+        self._conf_backup('/etc/fstab')
 
         # create filesystem
         disk.Format(self._fs_signature, self.no_options, dbus_interface=self.iface_prefix + '.Block')

--- a/src/tests/dbus-tests/udiskstestcase.py
+++ b/src/tests/dbus-tests/udiskstestcase.py
@@ -4,6 +4,7 @@ import subprocess
 import os
 import time
 import re
+import shutil
 import sys
 from datetime import datetime
 from enum import Enum
@@ -365,6 +366,18 @@ class UdisksTestCase(unittest.TestCase):
                 break
             time.sleep(0.5)
         self.fail('Failed to unmount %s: %s' % (path, out))
+
+    def _conf_backup(self, conf_file):
+        """ Backup and restore @conf_file during cleanup. If @conf_file doesn't exist, it
+            will be removed during cleanup
+        """
+        if os.path.exists(conf_file):
+            # conf file exists -> backup and restore
+            contents = self.read_file(conf_file)
+            self.addCleanup(self.write_file, conf_file, contents)
+        else:
+            # conf file doesn't exist -> remove during cleanup
+            self.addCleanup(shutil.rmtree, conf_file, True)
 
     @classmethod
     def read_file(self, filename):


### PR DESCRIPTION
Multiple DBus tests are trying to backup (and later restore) fstab and crypttab which fails on systems where these config files don't exist.

Fixes: #1364