### PR TITLE
Fixed memleak and misprint check for creating second BDCrypto context

### DIFF
--- a/src/udiskslinuxencryptedhelpers.c
+++ b/src/udiskslinuxencryptedhelpers.c
@@ -116,7 +116,7 @@ gboolean luks_change_key_job_func (UDisksThreadedJob  *job,
     return FALSE;
   ncontext = bd_crypto_keyslot_context_new_passphrase ((const guint8 *) data->new_passphrase->str,
                                                        data->new_passphrase->len, error);
-  if (!context)
+  if (!ncontext)
     {
       bd_crypto_keyslot_context_free (context);
       return FALSE;


### PR DESCRIPTION
@vojtechtrefny hi I new contributor.

This fixed also fixes memory leak if `ncontext` is not created, `context` will be created successfully, then `context` malloc not free.