### PR TITLE
misc: align structs for modern 64-bit platforms

### DIFF
--- a/src/udisksbasejob.c
+++ b/src/udisksbasejob.c
@@ -50,11 +50,11 @@ struct _UDisksBaseJobPrivate
   GCancellable *cancellable;
   UDisksDaemon *daemon;
 
-  gboolean auto_estimate;
-  gulong notify_progress_signal_handler_id;
-
   Sample *samples;
   guint num_samples;
+
+  gboolean auto_estimate;
+  gulong notify_progress_signal_handler_id;
 };
 
 static void job_iface_init (UDisksJobIface *iface);

--- a/src/udisksdaemonutil.c
+++ b/src/udisksdaemonutil.c
@@ -1716,8 +1716,8 @@ typedef struct
 {
   UDisksDaemon *daemon;
   GMainLoop *main_loop;
-  guint serial;
   gchar *uevent_path;
+  guint serial;
   gboolean success;
 } SynthUeventData;
 

--- a/src/udiskslinuxdriveata.c
+++ b/src/udiskslinuxdriveata.c
@@ -74,15 +74,15 @@ struct _UDisksLinuxDriveAta
 {
   UDisksDriveAtaSkeleton parent_instance;
 
-  gboolean     smart_is_from_blob;
-  guint64      smart_updated;
-  BDSmartATA  *smart_data;
-
   UDisksThreadedJob *selftest_job;
 
   gboolean     secure_erase_in_progress;
   unsigned long drive_read, drive_write;
   gboolean     standby_enabled;
+
+  gboolean     smart_is_from_blob;
+  guint64      smart_updated;
+  BDSmartATA  *smart_data;
 };
 
 struct _UDisksLinuxDriveAtaClass


### PR DESCRIPTION
Affected structs:

- _UDisksLinuxDriveAta
- SynthUeventData
- _UDisksBaseJobPrivate