### PR TITLE
udisksstate: Always allocate store buffer for empty variants

### DIFF
--- a/src/udisksstate.c
+++ b/src/udisksstate.c
@@ -2386,7 +2386,7 @@ udisks_state_set (UDisksState          *state,
   g_variant_ref_sink (value);
   normalized = g_variant_get_normal_form (value);
   size = g_variant_get_size (normalized);
-  data = g_malloc (size);
+  data = g_malloc (size ? size : 1); /* ensure the buffer is allocated even if size=0 */
   g_variant_store (normalized, data);
 
   path = get_state_file_path (key);


### PR DESCRIPTION
The recent glib change added a g_variant_store() safeguard checking for non-NULL buffer:
https://gitlab.gnome.org/GNOME/glib/-/commit/39c05b13123b12622ee2c93c170dbf20b573f6ac

For empty variants, their size is zero and g_variant_store() doesn't actually serialize anything in the buffer. This used to work for ages and a NULL buffer pointer was simply ignored and unused.

Work this around by always allocating a buffer even though zero bytes are then stored in the file.

Fixes #1380