### PR TITLE
tests: Force Python to use 'fork' method to start child processes

### DIFF
--- a/src/tests/dbus-tests/run_tests.py
+++ b/src/tests/dbus-tests/run_tests.py
@@ -320,8 +320,6 @@ if __name__ == '__main__':
 
     args = parse_args()
 
-    setup_vdevs()
-
     if args.logfile:
         daemon_log = open(args.logfile, mode='w')
 
@@ -423,6 +421,8 @@ if __name__ == '__main__':
         runner = unittest.TextTestRunner(verbosity=2, failfast=args.failfast, resultclass=DebugTestResult)
     else:
         runner = unittest.TextTestRunner(verbosity=2, failfast=args.failfast)
+
+    setup_vdevs()
 
     result = runner.run(suite)
 

--- a/src/tests/dbus-tests/udiskstestcase.py
+++ b/src/tests/dbus-tests/udiskstestcase.py
@@ -6,6 +6,7 @@ import time
 import re
 import shutil
 import sys
+import multiprocessing
 from datetime import datetime
 from enum import Enum
 from systemd import journal
@@ -17,6 +18,8 @@ from gi.repository import GUdev
 
 test_devs = None
 FLIGHT_RECORD_FILE = "flight_record.log"
+
+multiprocessing.set_start_method("fork")
 
 
 def run_command(command):


### PR DESCRIPTION
Since Python 3.14 the default changed to 'forkserver' which requires all shared objects to be picklable which causes some of our filesystem tests that run process as a different user to fail.