### PR TITLE
Do not use label for DM name when unlocking BitLocker devices

### DIFF
--- a/src/udiskslinuxencrypted.c
+++ b/src/udiskslinuxencrypted.c
@@ -526,7 +526,7 @@ handle_unlock (UDisksEncrypted        *encrypted,
     name = g_strdup (crypttab_name);
   else {
     label = udisks_block_get_id_label (block);
-    if (label)
+    if (label && !is_bitlk)
       name = g_strdup (label);
     else
       {


### PR DESCRIPTION
The labels on BitLocker can have characters that are not supported in DM names (like '/' which is used in the default label by Windows).

-----

This is just a quick fix, we should check LUKS labels for characters not allowed by device mapper and do some escaping/sanitization there as well. For BitLocker this started to be a problem because util-linux/blkid added support for parsing labels on BitLocker and we automatically pick labels from udev.