### PR TITLE
Fix using label as DM name when unlocking encrypted devices

### DIFF
--- a/src/tests/dbus-tests/test_70_encrypted.py
+++ b/src/tests/dbus-tests/test_70_encrypted.py
@@ -917,6 +917,17 @@ class UdisksEncryptedTestBITLK(udiskstestcase.UdisksTestCase):
         dbus_fs = self.get_property(crypt_dev, '.Block', 'IdType')
         dbus_fs.assertEqual("ntfs")
 
+        dbus_label = self.get_property_raw(self.loop, '.Block', 'IdLabel')
+        bitlk_path = self.get_property(crypt_dev, '.Block', 'PreferredDevice')
+        if dbus_label:
+            # has label (and we know it): label with '/' and spaces replaced by '_' should be used for DM name
+            dm_path = '/dev/mapper/%s' % dbus_label.replace('/', '_').replace(' ', '_')
+        else:
+            # no label: bitlk-<UUID> should be used for DM name
+            dm_path = '/dev/mapper/bitlk-8f595209-f5b9-49a0-85d4-cb8f80258c27'
+            self.assertTrue(os.path.exists(dm_path))
+        bitlk_path.assertEqual(self.str_to_ay(dm_path))
+
         self.loop.Lock(self.no_options, dbus_interface=self.iface_prefix + '.Encrypted')
 
         dbus_cleartext = self.get_property(self.loop, '.Encrypted', 'CleartextDevice')

--- a/src/udiskslinuxencrypted.c
+++ b/src/udiskslinuxencrypted.c
@@ -324,6 +324,14 @@ has_option (const gchar *options,
   return ret;
 }
 
+static gchar *
+label_to_safe_dm_name (const gchar *label)
+{
+  if (strlen (label) >= 128)
+    return g_strndup (label, 127);
+  return g_strdelimit (g_strdup (label), "/ ", '_');
+}
+
 /* ---------------------------------------------------------------------------------------------------- */
 
 /* runs in thread dedicated to handling @invocation */
@@ -526,8 +534,8 @@ handle_unlock (UDisksEncrypted        *encrypted,
     name = g_strdup (crypttab_name);
   else {
     label = udisks_block_get_id_label (block);
-    if (label && !is_bitlk)
-      name = g_strdup (label);
+    if (label)
+      name = label_to_safe_dm_name (label);
     else
       {
         if (is_luks)


### PR DESCRIPTION
'/' which is allowed in labels is not allowed in DM names so this replaces '/' with underscore and also makes sure the name is shorter than 128 characters.

See also #1404 where we disabled using labels for the unlocked device name for BitLocker because BitLocker labels have slashes by default (including our test image).

Note: I also decided to replace spaces with underscore here. Spaces are allowed in DM names, I just thought it looks better, especially in the `/dev/mapper` path without spaces.