### PR TITLE
 docs(mdraid): update link to kernel docs 

### DIFF
--- a/data/org.freedesktop.UDisks2.xml
+++ b/data/org.freedesktop.UDisks2.xml
@@ -3106,7 +3106,7 @@
       @since: 2.0.0
 
       Objects implementing this interface represent
-      <ulink url="https://raid.wiki.kernel.org/index.php/Linux_Raid">Linux Software RAID arrays</ulink>
+      <ulink url="https://docs.kernel.org/admin-guide/md.html">Linux Software RAID arrays</ulink>
       detected on the system. Both running and not-running arrays are represented.
 
       Block devices point to objects implementing this interface, see


### PR DESCRIPTION
Updates the MDRaid documentation link, as the current one leads to a 404 page. I presume that https://docs.kernel.org/admin-guide/md.html is the new location of the page.