### PR TITLE
tests: Do not use "echo -e" in tests

### DIFF
--- a/src/tests/dbus-tests/test_loop.py
+++ b/src/tests/dbus-tests/test_loop.py
@@ -204,9 +204,9 @@ class UdisksManagerLoopDeviceTest(udiskstestcase.UdisksTestCase):
     @udiskstestcase.tag_test(udiskstestcase.TestTags.UNSTABLE)
     def test_50_create_no_part_scan(self):
         # create a partition on the file (future loop device)
-        ret, out = self.run_command("echo -e 'label:dos' | sfdisk %s" % self.LOOP_DEVICE_FILENAME)
+        ret, out = self.run_command("echo 'label:dos' | sfdisk %s" % self.LOOP_DEVICE_FILENAME)
         self.assertEqual(ret, 0)
-        ret, out = self.run_command("echo -e 'size=9M, type=L\n' | sfdisk %s" % self.LOOP_DEVICE_FILENAME)
+        ret, out = self.run_command("echo 'size=9M, type=L' | sfdisk %s" % self.LOOP_DEVICE_FILENAME)
         self.assertEqual(ret, 0)
 
         opts = dbus.Dictionary({"no-part-scan": dbus.Boolean(True)}, signature=dbus.Signature('sv'))

--- a/src/tests/integration-test
+++ b/src/tests/integration-test
@@ -1188,9 +1188,9 @@ class Fstab(UDisksTestCase):
         cls.p1label = 'udtestp1'
 
         # create one partition
-        subprocess.check_call("echo -e 'label:gpt' | sfdisk %s" % cls.device,
+        subprocess.check_call("echo 'label:gpt' | sfdisk %s" % cls.device,
                               stdout=subprocess.PIPE, shell=True)
-        subprocess.check_call("echo -e 'size=60M, type=L, name=%s\n' | sfdisk %s" % (cls.p1label, cls.device),
+        subprocess.check_call("echo 'size=60M, type=L, name=%s' | sfdisk %s" % (cls.p1label, cls.device),
                               stdout=subprocess.PIPE, shell=True)
         cls.sync()
         blkid = subprocess.check_output(


### PR DESCRIPTION
echo -e is non-posix extension that doesn't work in all shells.

Fixes: #1413