### PR TITLE
Sanitize label to fix duplicate mountpoints with spaces and parentheses (#1415)

### DIFF
--- a/src/udiskslinuxencrypted.c
+++ b/src/udiskslinuxencrypted.c
@@ -329,7 +329,7 @@ label_to_safe_dm_name (const gchar *label)
 {
   if (strlen (label) >= 128)
     return g_strndup (label, 127);
-  return g_strdelimit (g_strdup (label), "/ ", '_');
+  return g_strdelimit (g_strdup (label), "/() ", '_');
 }
 
 /* ---------------------------------------------------------------------------------------------------- */


### PR DESCRIPTION
This pull request enhances label sanitization for device-mapper names and mount points. Spaces and parentheses in filesystem labels are now replaced with underscores, preventing duplicate mountpoints and ensuring correct mount state reporting.
Fixes #1415.