### PR TITLE
Remove unused functions from safe_dbus 

### DIFF
--- a/src/tests/dbus-tests/test_job.py
+++ b/src/tests/dbus-tests/test_job.py
@@ -36,7 +36,7 @@ class UdisksJobTest(udiskstestcase.UdisksTestCase):
             self.exception = e
 
     def _wait_for_job_thread(self, operation, device_path):
-        t = threading.currentThread()
+        t = threading.current_thread()
 
         while getattr(t, "run", True):
             objects = self._get_objects()


### PR DESCRIPTION
I considered replacing safe_dbus with dasbus (which is what I did in blivet), but I didn't want to introduce a new test dependency. After removing the unused functions, it's just a relatively simple module that should not be that hard to maintain.