### PR TITLE
integration-test: Force --bitmap=none on mdraid creation

### DIFF
--- a/src/tests/integration-test
+++ b/src/tests/integration-test
@@ -1827,7 +1827,7 @@ class MDRaid(UDisksTestCase):
 
         self.md_legs = self.devices[:2]
         create = ['mdadm', '--create', self.md_device, '--level=1',
-                  '--metadata=0.90', '--raid-devices=2']
+                  '--metadata=0.90', '--raid-devices=2', '--bitmap=none']
         create.extend(self.md_legs)
         self.assertEqual(subprocess.call(create), 0)
         self.sync()


### PR DESCRIPTION
Introduced in mdadm-4.4, this interactive prompt is being displayed:

```
  test_md_raid_methods (__main__.MDRaid.test_md_raid_methods) ...
  To optimalize recovery speed, it is recommended to enable write-indent bitmap, do you want to enable it now? [y/N]?
```