### PR TITLE
spec: Bump required version of libblockdev to 3.4

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -172,7 +172,7 @@ if test "x$enable_daemon" = "xyes"; then
   AC_SUBST(GMODULE_CFLAGS)
   AC_SUBST(GMODULE_LIBS)
 
-  PKG_CHECK_MODULES(BLOCKDEV, [blockdev >= 3.0])
+  PKG_CHECK_MODULES(BLOCKDEV, [blockdev >= 3.4])
   AC_SUBST(BLOCKDEV_CFLAGS)
   AC_SUBST(BLOCKDEV_LIBS)
 

--- a/packaging/udisks2.spec
+++ b/packaging/udisks2.spec
@@ -4,7 +4,7 @@
 %global systemd_version                 208
 %global dbus_version                    1.4.0
 %global with_gtk_doc                    1
-%global libblockdev_version             3.2
+%global libblockdev_version             3.4
 
 %define with_btrfs                      1
 %define with_lsm                        1


### PR DESCRIPTION
(Should be released later today.)