### PR TITLE
 Add proper detection of CRYPT-PLAIN devices as crypto devices

### DIFF
--- a/src/udiskslinuxblock.c
+++ b/src/udiskslinuxblock.c
@@ -1028,7 +1028,7 @@ udisks_linux_block_update (UDisksLinuxBlock       *block,
       gchar *dm_uuid;
       dm_uuid = get_sysfs_attr (device->udev_device, "dm/uuid");
       if (dm_uuid != NULL &&
-           (g_str_has_prefix (dm_uuid, "CRYPT-LUKS") || g_str_has_prefix (dm_uuid, "CRYPT-BITLK") || g_str_has_prefix (dm_uuid, "CRYPT-TCRYPT")))
+           (g_str_has_prefix (dm_uuid, "CRYPT-LUKS") || g_str_has_prefix (dm_uuid, "CRYPT-BITLK") || g_str_has_prefix (dm_uuid, "CRYPT-TCRYPT") || g_str_has_prefix(dm_uuid, "CRYPT-PLAIN") ))
         {
           gchar *slave_sysfs_path;
           slave_sysfs_path = get_slave_sysfs_path (g_udev_device_get_sysfs_path (device->udev_device));


### PR DESCRIPTION
Add detection of plaintext encrypted devices in the same manner as a LUKS2 device would be detected.

The detection method stays the same, with a prefix match, in this case "CRYPT-PLAIN".

Using this fix, plaintext encrypted devices should have the CryptoBackingDevice properly set, and the Encrypted sections for the backing device(s).

In a similar manner to #1339, this fixes #916 and an issue with how fwupd checks for encrypted swap, as using a plaintext device using a random key for encrypted swap is a recommended way in the Arch wiki. 
The fwupd issue is [fwupd/fwupd#6407](https://github.com/fwupd/fwupd/issues/6407).

I used a VM to test the patch, with this partition layout:
```
[test@archlinux-test ~]$ lsblk
NAME     MAJ:MIN RM  SIZE RO TYPE  MOUNTPOINTS
sr0       11:0    1  1.4G  0 rom   
vda      254:0    0   40G  0 disk  
├─vda1   254:1    0  500M  0 part  /boot/efi
├─vda2   254:2    0   35G  0 part  /
└─vda3   254:3    0    4G  0 part  
  └─swap 253:0    0    4G  0 crypt [SWAP]
```

This is the output of udisksctl info for both the mapped device and the backing device on a VM without the patch:
```
[test@archlinux-test ~]$ udisksctl info -b /dev/mapper/swap 
/org/freedesktop/UDisks2/block_devices/dm_2d0:
  org.freedesktop.UDisks2.Block:
    Configuration:              []
    CryptoBackingDevice:        '/'
    Device:                     /dev/dm-0
    DeviceNumber:               64768
    Drive:                      '/'
    HintAuto:                   false
    HintIconName:               
    HintIgnore:                 false
    HintName:                   
    HintPartitionable:          false
    HintSymbolicIconName:       
    HintSystem:                 true
    Id:                         by-id-dm-name-swap
    IdLabel:                    swap
    IdType:                     swap
    IdUUID:                     ba88bc44-54a4-4196-beaf-6926ec76b692
    IdUsage:                    other
    IdVersion:                  1
    MDRaid:                     '/'
    MDRaidMember:               '/'
    PreferredDevice:            /dev/mapper/swap
    ReadOnly:                   false
    Size:                       4294967296
    Symlinks:                   /dev/disk/by-designator/swap
                                /dev/disk/by-diskseq/4
                                /dev/disk/by-id/dm-name-swap
                                /dev/disk/by-id/dm-uuid-CRYPT-PLAIN-swap
                                /dev/disk/by-label/swap
                                /dev/disk/by-uuid/ba88bc44-54a4-4196-beaf-6926ec76b692
                                /dev/mapper/swap
    UserspaceMountOptions:      
  org.freedesktop.UDisks2.Swapspace:
    Active:             true


[test@archlinux-test ~]$ udisksctl info -b /dev/vda3
/org/freedesktop/UDisks2/block_devices/vda3:
  org.freedesktop.UDisks2.Block:
    Configuration:              []
    CryptoBackingDevice:        '/'
    Device:                     /dev/vda3
    DeviceNumber:               65027
    Drive:                      '/org/freedesktop/UDisks2/drives/VirtIO_Disk'
    HintAuto:                   false
    HintIconName:               
    HintIgnore:                 false
    HintName:                   
    HintPartitionable:          true
    HintSymbolicIconName:       
    HintSystem:                 true
    Id:                         
    IdLabel:                    
    IdType:                     
    IdUUID:                     
    IdUsage:                    
    IdVersion:                  
    MDRaid:                     '/'
    MDRaidMember:               '/'
    PreferredDevice:            /dev/vda3
    ReadOnly:                   false
    Size:                       4294967296
    Symlinks:                   /dev/disk/by-diskseq/1-part3
                                /dev/disk/by-partuuid/814fa85f-bc83-4985-bf38-dce01577f1c3
                                /dev/disk/by-path/pci-0000:04:00.0-part/by-partnum/3
                                /dev/disk/by-path/pci-0000:04:00.0-part/by-partuuid/814fa85f-bc83-4985-bf38-dce01577f1c3
                                /dev/disk/by-path/pci-0000:04:00.0-part3
                                /dev/disk/by-path/virtio-pci-0000:04:00.0-part3
    UserspaceMountOptions:      
  org.freedesktop.UDisks2.Partition:
    Flags:              0
    IsContained:        false
    IsContainer:        false
    Name:               
    Number:             3
    Offset:             38106300416
    Size:               4294967296
    Table:              '/org/freedesktop/UDisks2/block_devices/vda'
    Type:               0fc63daf-8483-4772-8e79-3d69d8477de4
    UUID:               814fa85f-bc83-4985-bf38-dce01577f1c3
```

This is the output with the patch:
```
[test@archlinux-test ~]$ udisksctl info -b /dev/mapper/swap 
/org/freedesktop/UDisks2/block_devices/dm_2d0:
  org.freedesktop.UDisks2.Block:
    Configuration:              []
    CryptoBackingDevice:        '/org/freedesktop/UDisks2/block_devices/vda3'
    Device:                     /dev/dm-0
    DeviceNumber:               64768
    Drive:                      '/'
    HintAuto:                   false
    HintIconName:               
    HintIgnore:                 false
    HintName:                   
    HintPartitionable:          false
    HintSymbolicIconName:       
    HintSystem:                 true
    Id:                         by-id-dm-name-swap
    IdLabel:                    swap
    IdType:                     swap
    IdUUID:                     c29983cc-6057-4734-9f68-25441704e8f2
    IdUsage:                    other
    IdVersion:                  1
    MDRaid:                     '/'
    MDRaidMember:               '/'
    PreferredDevice:            /dev/mapper/swap
    ReadOnly:                   false
    Size:                       4294967296
    Symlinks:                   /dev/disk/by-designator/swap
                                /dev/disk/by-diskseq/4
                                /dev/disk/by-id/dm-name-swap
                                /dev/disk/by-id/dm-uuid-CRYPT-PLAIN-swap
                                /dev/disk/by-label/swap
                                /dev/disk/by-uuid/c29983cc-6057-4734-9f68-25441704e8f2
                                /dev/mapper/swap
    UserspaceMountOptions:      
  org.freedesktop.UDisks2.Swapspace:
    Active:             true


[test@archlinux-test ~]$ udisksctl info -b /dev/vda3
/org/freedesktop/UDisks2/block_devices/vda3:
  org.freedesktop.UDisks2.Block:
    Configuration:              []
    CryptoBackingDevice:        '/'
    Device:                     /dev/vda3
    DeviceNumber:               65027
    Drive:                      '/org/freedesktop/UDisks2/drives/VirtIO_Disk'
    HintAuto:                   false
    HintIconName:               
    HintIgnore:                 false
    HintName:                   
    HintPartitionable:          true
    HintSymbolicIconName:       
    HintSystem:                 true
    Id:                         
    IdLabel:                    
    IdType:                     
    IdUUID:                     
    IdUsage:                    
    IdVersion:                  
    MDRaid:                     '/'
    MDRaidMember:               '/'
    PreferredDevice:            /dev/vda3
    ReadOnly:                   false
    Size:                       4294967296
    Symlinks:                   /dev/disk/by-diskseq/1-part3
                                /dev/disk/by-partuuid/814fa85f-bc83-4985-bf38-dce01577f1c3
                                /dev/disk/by-path/pci-0000:04:00.0-part/by-partnum/3
                                /dev/disk/by-path/pci-0000:04:00.0-part/by-partuuid/814fa85f-bc83-4985-bf38-dce01577f1c3
                                /dev/disk/by-path/pci-0000:04:00.0-part3
                                /dev/disk/by-path/virtio-pci-0000:04:00.0-part3
    UserspaceMountOptions:      
  org.freedesktop.UDisks2.Partition:
    Flags:              0
    IsContained:        false
    IsContainer:        false
    Name:               
    Number:             3
    Offset:             38106300416
    Size:               4294967296
    Table:              '/org/freedesktop/UDisks2/block_devices/vda'
    Type:               0fc63daf-8483-4772-8e79-3d69d8477de4
    UUID:               814fa85f-bc83-4985-bf38-dce01577f1c3

```

As you can see, the output now displays the crypto backing device properly.

