### PR TITLE
docs: Update links to documentation on storaged.org

### DIFF
--- a/doc/udisks2-docs.xml.in.in
+++ b/doc/udisks2-docs.xml.in.in
@@ -9,7 +9,7 @@
     <releaseinfo>
       For version &version; — the latest version of this
       documentation can be found at <ulink role="online-location"
-      url="http://storaged.org/doc/udisks2-api/latest/">http://storaged.org/doc/udisks2-api/latest/</ulink>.
+      url="https://storaged.org/udisks/docs/">https://storaged.org/udisks/docs/</ulink>.
     </releaseinfo>
   </bookinfo>
 

--- a/udisks/mount_options.conf.in
+++ b/udisks/mount_options.conf.in
@@ -6,7 +6,7 @@
 # and 'fs_driver' is (optionally) the filesystem type (a kernel driver) passed
 # to the mount call. The 'key' is either "defaults", "allow" or "drivers".
 #
-# Refer to http://storaged.org/doc/udisks2-api/latest/mount_options.html
+# Refer to https://storaged.org/udisks/docs/mount_options.html
 #
 
 ### Simple global overrides


### PR DESCRIPTION
The old "latest" links still work but only as a redirect, it's better to point to the new URLs.