### PR TITLE
lvm2: Prevent a segfault on discarded probe output

### DIFF
--- a/modules/lvm2/jobhelpers.c
+++ b/modules/lvm2/jobhelpers.c
@@ -367,6 +367,10 @@ void lv_list_free (BDLVMLVdata **lv_list) {
 }
 
 void vgs_pvs_data_free (VGsPVsData *data) {
+  if (!data)
+    /* nothing to do */
+    return;
+
   vg_list_free (data->vgs);
   pv_list_free (data->pvs);
   g_free (data);


### PR DESCRIPTION
Commit 28c3978 brought a possible NULL-dereference and some memleaks. Hard to hit in real world, difficult to debug.

```
 #0  0x00007fe74823badd in vgs_pvs_data_free () at ../udisks/modules/libudisks2_lvm2.so
 #1  0x00007fe74822e933 in lvm_update_vgs () at ..//udisks/modules/libudisks2_lvm2.so
 #2  0x00007fe74ba0966c in g_task_return_now (task=0x1eded590 [GTask]) at ../gio/gtask.c:1363
 #3  0x00007fe74ba096a5 in complete_in_idle_cb (task=task@entry=0x1eded590) at ../gio/gtask.c:1377
```