### PR TITLE
udiskslinuxdrive: Calculate NVMe controller capacity from attached namespaces

### DIFF
--- a/src/tests/dbus-tests/test_nvme.py
+++ b/src/tests/dbus-tests/test_nvme.py
@@ -373,7 +373,7 @@ class UdisksNVMeTest(udiskstestcase.UdisksTestCase):
         id = self.get_property_raw(drive_obj, '.Drive', 'Id')
         self.assertTrue(id.startswith('Linux-'))
         size = self.get_property_raw(drive_obj, '.Drive', 'Size')
-        self.assertEqual(size, 0)
+        self.assertEqual(size, self.NS_SIZE * self.NUM_NS)
 
         ctrl_id = self.get_property_raw(drive_obj, '.NVMe.Controller', 'ControllerID')
         self.assertGreater(ctrl_id, 0)
@@ -604,7 +604,7 @@ class UdisksNVMeTest(udiskstestcase.UdisksTestCase):
         state.assertEqual('live', timeout=10)
 
         ctrl_size = self.get_property(drive_obj, '.Drive', 'Size')
-        ctrl_size.assertEqual(0)
+        ctrl_size.assertEqual(self.NS_SIZE * self.NUM_NS, timeout=60)
 
         # detach the second namespace
         nsid = self.get_property_raw(ns, '.NVMe.Namespace', 'NSID')
@@ -617,7 +617,7 @@ class UdisksNVMeTest(udiskstestcase.UdisksTestCase):
         state.assertEqual('live', timeout=10)
 
         ctrl_size = self.get_property(drive_obj, '.Drive', 'Size')
-        ctrl_size.assertEqual(0)
+        ctrl_size.assertEqual(self.NS_SIZE, timeout=60)
 
         # attach that namespace back
         disable_target_ns(self.SUBNQN, nsid, enable=True)
@@ -752,7 +752,7 @@ class UdisksNVMeTest(udiskstestcase.UdisksTestCase):
         subnqn = self.get_property(ctrl, '.NVMe.Controller', 'SubsystemNQN')
         subnqn.assertEqual(self.str_to_ay(self.SUBNQN))
         ctrl_size = self.get_property(ctrl, '.Drive', 'Size')
-        ctrl_size.assertEqual(0)
+        ctrl_size.assertEqual(self.NS_SIZE * self.NUM_NS, timeout=60)
 
         # count number of namespaces pointing to our controller
         namespaces = self._find_block_objects_for_ctrl(ctrl_obj_path)
@@ -770,7 +770,7 @@ class UdisksNVMeTest(udiskstestcase.UdisksTestCase):
         namespaces = self._find_block_objects_for_ctrl(ctrl_obj_path)
         self.assertEqual(len(namespaces), 0)
         ctrl_size = self.get_property(ctrl, '.Drive', 'Size')
-        ctrl_size.assertEqual(0)
+        ctrl_size.assertEqual(0, timeout=60)
 
         ctrl.Disconnect(self.no_options, dbus_interface=self.iface_prefix + '.NVMe.Fabrics')
 
@@ -898,7 +898,7 @@ class UdisksNVMeTest(udiskstestcase.UdisksTestCase):
         subnqn = self.get_property(ctrl, '.NVMe.Controller', 'SubsystemNQN')
         subnqn.assertEqual(self.str_to_ay(self.SUBNQN))
         ctrl_size = self.get_property(ctrl, '.Drive', 'Size')
-        ctrl_size.assertEqual(0)
+        ctrl_size.assertEqual(self.NS_SIZE * self.NUM_NS, timeout=60)
 
         transport = self.get_property(ctrl2, '.NVMe.Fabrics', 'Transport')
         transport.assertEqual('tcp')
@@ -907,7 +907,7 @@ class UdisksNVMeTest(udiskstestcase.UdisksTestCase):
         subnqn = self.get_property(ctrl2, '.NVMe.Controller', 'SubsystemNQN')
         subnqn.assertEqual(self.str_to_ay(self.SUBNQN))
         ctrl_size = self.get_property(ctrl2, '.Drive', 'Size')
-        ctrl_size.assertEqual(0)
+        ctrl_size.assertEqual(self.NS_SIZE * self.NUM_NS, timeout=60)
 
         if self._ipv6_available:
             transport = self.get_property(ctrl3, '.NVMe.Fabrics', 'Transport')
@@ -917,7 +917,7 @@ class UdisksNVMeTest(udiskstestcase.UdisksTestCase):
             subnqn = self.get_property(ctrl3, '.NVMe.Controller', 'SubsystemNQN')
             subnqn.assertEqual(self.str_to_ay(self.SUBNQN))
             ctrl_size = self.get_property(ctrl3, '.Drive', 'Size')
-            ctrl_size.assertEqual(0)
+            ctrl_size.assertEqual(self.NS_SIZE * self.NUM_NS, timeout=60)
 
         # count number of namespaces pointing to our controller
         ns_ctrl3 = ()

--- a/src/tests/dbus-tests/test_nvme.py
+++ b/src/tests/dbus-tests/test_nvme.py
@@ -267,6 +267,18 @@ def disable_target_ns(subnqn, nsid, enable=False):
     with open("/sys/kernel/config/nvmet/subsystems/%s/namespaces/%d/enable" % (subnqn, nsid), "w") as f:
         f.write("1" if enable else "0")
 
+    # trigger controller namespace rescan - the kernel AEN for namespace
+    # changes may not be reliably delivered with nvme-loop
+    for ctrl_path in glob.glob("/sys/class/nvme/nvme*/"):
+        subsysnqn_file = os.path.join(ctrl_path, "subsysnqn")
+        try:
+            with open(subsysnqn_file, "r") as f:
+                if f.read().strip() == subnqn:
+                    with open(os.path.join(ctrl_path, "rescan_controller"), "w") as f:
+                        f.write("1")
+        except OSError:
+            pass
+
 
 class UdisksNVMeTest(udiskstestcase.UdisksTestCase):
     SUBNQN = 'udisks_test_subnqn'

--- a/src/udiskslinuxdriveobject.c
+++ b/src/udiskslinuxdriveobject.c
@@ -1380,4 +1380,68 @@ udisks_linux_drive_object_nvme_subsys_uevent (UDisksLinuxDriveObject  *object,
     udisks_linux_nvme_controller_update (UDISKS_LINUX_NVME_CONTROLLER (object->iface_nvme_ctrl), object);
   if (object->iface_nvme_fabrics != NULL)
     udisks_linux_nvme_fabrics_update (UDISKS_LINUX_NVME_FABRICS (object->iface_nvme_fabrics), object);
+
+  /* For controllers that don't report size_total, recalculate the drive size
+   * from the authoritative subsystem blocks list rather than relying on
+   * udisks block object lookup which is subject to race conditions.
+   * Filter namespaces per-controller using sysfs parentage when possible,
+   * falling back to all subsystem blocks for transports where blocks are
+   * not children of the controller (e.g. nvme-loop). */
+  if (object->iface_drive != NULL && subsystem_blocks != NULL)
+    {
+      UDisksLinuxDevice *ctrl_device;
+
+      ctrl_device = udisks_linux_drive_object_get_device (object, TRUE);
+      if (ctrl_device != NULL)
+        {
+          if (ctrl_device->nvme_ctrl_info != NULL &&
+              ctrl_device->nvme_ctrl_info->size_total == 0)
+            {
+              const gchar *ctrl_sysfs_path;
+              gsize ctrl_path_len;
+              UDisksLinuxBlockObject **b;
+              guint64 size = 0;
+              guint64 size_all = 0;
+              gboolean have_prefix_match = FALSE;
+
+              ctrl_sysfs_path = g_udev_device_get_sysfs_path (ctrl_device->udev_device);
+              ctrl_path_len = strlen (ctrl_sysfs_path);
+
+              for (b = subsystem_blocks; *b != NULL; b++)
+                {
+                  UDisksLinuxDevice *blk_device = udisks_linux_block_object_get_device (*b);
+                  if (blk_device != NULL)
+                    {
+                      if (blk_device->nvme_ns_info != NULL &&
+                          blk_device->nvme_ns_info->current_lba_format.data_size > 0)
+                        {
+                          guint64 ns_size;
+
+                          ns_size = (guint64) blk_device->nvme_ns_info->nsize *
+                                    ((guint64) blk_device->nvme_ns_info->current_lba_format.data_size +
+                                     (guint64) blk_device->nvme_ns_info->current_lba_format.metadata_size);
+                          size_all += ns_size;
+                          /* Block devices are typically children of their NVMe controller
+                           * in sysfs. Filter per-controller using sysfs parentage to handle
+                           * "isolated islands" within a subsystem. */
+                          if (g_str_has_prefix (g_udev_device_get_sysfs_path (blk_device->udev_device), ctrl_sysfs_path) &&
+                              g_udev_device_get_sysfs_path (blk_device->udev_device)[ctrl_path_len] == '/')
+                            {
+                              size += ns_size;
+                              have_prefix_match = TRUE;
+                            }
+                        }
+                      g_object_unref (blk_device);
+                    }
+                }
+              /* For transports where block devices are not children of their
+               * controller in sysfs (e.g. nvme-loop, blocks live under
+               * nvme-subsystem), fall back to using all blocks in the subsystem. */
+              if (!have_prefix_match)
+                size = size_all;
+              udisks_drive_set_size (UDISKS_DRIVE (object->iface_drive), size);
+            }
+          g_object_unref (ctrl_device);
+        }
+    }
 }

--- a/src/udiskslinuxprovider.c
+++ b/src/udiskslinuxprovider.c
@@ -1276,7 +1276,11 @@ handle_block_uevent_for_nvme_subsys (UDisksLinuxProvider *provider,
       /* skip partitions */
       if (g_strcmp0 (g_udev_device_get_devtype (device->udev_device), "disk") != 0)
         return;
-      parent = g_udev_device_get_parent_with_subsystem (device->udev_device, "nvme-subsystem", NULL);
+      /* Block devices may be children of their NVMe controller (subsystem "nvme")
+       * or of the NVMe subsystem device (subsystem "nvme-subsystem"). Try both. */
+      parent = g_udev_device_get_parent_with_subsystem (device->udev_device, "nvme", NULL);
+      if (parent == NULL)
+        parent = g_udev_device_get_parent_with_subsystem (device->udev_device, "nvme-subsystem", NULL);
     }
   else
   /* NVMe subsystems and controllers */


### PR DESCRIPTION
With the NVMe subsystem tracking infrastructure in place, the drive object now receives events reflecting the real state of a NVMe subsystem.

In an ideal case we take over the TNVMCAP field from the Identify Controller data structure. In case capacity reporting is not supported by the controller, calculate the drive size from the currently attached namespaces as a simple workaround. This may not entirely reflect the true capacity as e.g. an unallocated capacity is not counted in.

According to the NVM Express Base Specification, rev 2.3, section 3.8.3 Capacity Reporting, capacity reporting is rather complex. Implementation of capacity reporting in UDisks is done on best-effort basis and may be subject to change in the future.

Fixes #1382
Fixes #1194