### PR TITLE
Add CONTRIBUTING guidelines

### DIFF
--- a/CONTRIBUTING
+++ b/CONTRIBUTING
@@ -1,0 +1,72 @@
+GENERAL RULES
+=============
+
+You're welcome to use LLM (Large Language Model) coding assistants for
+contributions as long as:
+
+ - you understand the code
+
+ - you automatically assume you're the author bearing all responsibilities
+
+ - you're able to answer questions during and post review
+
+ - you're sure that the code constructions are not covered by patents or
+   licensed under an incompatible license to UDisks
+
+ - the contribution clearly states the help of an LLM (e.g. use a commit message
+   tag `Assisted-by:`, `Generated-By:` or `Co-Authored-By:`)
+
+
+CODING STYLE
+============
+
+ - Please follow the coding style already used (which is close to the
+   GNU style) - if adding new files please include the following mode
+   line for emacs and other editors:
+
+   -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*-
+
+ - Spaces, not tabs, are used.
+
+ - All external interfaces (network protocols, file formats, etc.)
+   should be documented in man pages or other documentation.
+
+
+SOURCE CONTROL
+==============
+
+Anonymous checkouts:
+
+  $ git clone git@github.com:storaged-project/udisks.git
+
+Follow the usual GitHub 'Creating a pull request from a fork' guidelines:
+https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request-from-a-fork
+
+
+COMMITTING CODE
+===============
+
+ - Commit messages should be of the form (the five lines between the
+   lines starting with ===)
+
+=== begin example commit ===
+Short explanation of the commit
+
+Longer explanation explaining exactly what's changed, whether any
+external or private interfaces changed, what bugs were fixed (with bug
+tracker reference if applicable) and so forth. Be concise but not too brief.
+=== end example commit ===
+
+ - Always add a brief description of the commit to the _first_ line of
+   the commit and terminate by two newlines (it will work without the
+   second newline, but that is not nice for the interfaces).
+
+ - First line (the brief description) must only be one sentence and
+   must start with a capital letter. Don't use a trailing period.
+
+ - The main description (the body) is normal prose and should use normal
+   punctuation and capital letters where appropriate. Normally, for patches
+   sent to a mailing list it's copied from there.
+
+ - When committing code on behalf of others use the --author option, e.g.
+   git commit -a --author "Joe Coder <joe@coder.org>"

--- a/COPYING
+++ b/COPYING
@@ -1,5 +1,5 @@
 Copyright (C) 2007-2011 David Zeuthen <zeuthen@gmail.com>
-Copyright (C) 2007-2011 Red Hat, Inc.
+Copyright (C) 2007-2026 Red Hat, Inc.
 All Rights Reserved.
 
 The source code for the udisks daemon and command-line tools are

--- a/HACKING
+++ b/HACKING
@@ -1,25 +1,3 @@
-CODING STYLE
-============
-
- - Please follow the coding style already used (which is close to the
-   GNU style) - if adding new files please include the following mode
-   line for emacs and other editors:
-
-   -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*-
-
- - Spaces, not tabs, are used.
-
- - All external interfaces (network protocols, file formats, etc.)
-   should be documented in man pages or other documentation.
-
-
-SOURCE CONTROL
-==============
-
-Anonymous checkouts:
-
-  $ git clone git@github.com:storaged-project/udisks.git
-
 MAKING RELEASES
 ===============
 
@@ -70,6 +48,7 @@ For maintenance releases, the rules are simple
  - Do not add, remove or change any translatable strings
  - Do not add new dependencies
 
+
 TRANSLATIONS
 ============
 
@@ -85,31 +64,3 @@ TRANSLATIONS
 - Check that recent commits to the po/ directory done by the GNOME
   Infrastructure Automation Bot (@gnomesysadmins) reflect the translation
   status on the l10n page
-
-COMMITTING CODE
-===============
-
- - Commit messages should be of the form (the five lines between the
-   lines starting with ===)
-
-=== begin example commit ===
-Short explanation of the commit
-
-Longer explanation explaining exactly what's changed, whether any
-external or private interfaces changed, what bugs were fixed (with bug
-tracker reference if applicable) and so forth. Be concise but not too brief.
-=== end example commit ===
-
- - Always add a brief description of the commit to the _first_ line of
-   the commit and terminate by two newlines (it will work without the
-   second newline, but that is not nice for the interfaces).
-
- - First line (the brief description) must only be one sentence and
-   must start with a capital letter. Don't use a trailing period.
-
- - The main description (the body) is normal prose and should use normal
-   punctuation and capital letters where appropriate. Normally, for patches
-   sent to a mailing list it's copied from there.
-
- - When committing code on behalf of others use the --author option, e.g.
-   git commit -a --author "Joe Coder <joe@coder.org>"

--- a/Makefile.am
+++ b/Makefile.am
@@ -22,6 +22,7 @@ export GCC_COLORS
 
 EXTRA_DIST =                                                                   \
 	HACKING                                                                \
+	CONTRIBUTING                                                           \
 	README.md                                                              \
 	$(NULL)
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,10 @@ Please report bugs via the GitHub's issues tracker at
 
  https://github.com/storaged-project/udisks/issues
 
- ### Running out of development source tree
+Please make sure to read CONTRIBUTING before opening a pull request.
+
+
+### Running out of development source tree
  If you would like to run out of the source tree for development without installing,
  please do the following below.
 


### PR DESCRIPTION
The intent was to address the ever-growing use of LLM assistants without being too restrictive.

Splitting HACKING into two files to distinguish between general public and maintainer's responsibilities.

Fixes #1423