### PR TITLE
Make spec file Release condition more robust

### DIFF
--- a/packaging/udisks2.spec
+++ b/packaging/udisks2.spec
@@ -23,7 +23,7 @@
 Name:    udisks2
 Summary: Disk Manager
 Version: 2.12.0
-%if %{is_git} == 0
+%if 0%{?is_git} == 0
 Release: 1%{?dist}
 %else
 Release: 0.%{build_date}git%{git_hash}%{?dist}


### PR DESCRIPTION
We've hardened security in Packit Service and shell expansions in spec files are now rejected as they can be used to execute arbitrary code. This change makes the condition in the spec file that would otherwise cause a [parsing error](https://download.copr.fedorainfracloud.org/results/packit/storaged-project-udisks-1485/srpm-builds/10211216/builder-live.log.gz) return true also in case `is_git` is undefined or empty.