### PR TITLE
Move to global lock for libcryptsetup calls

### DIFF
--- a/src/tests/dbus-tests/test_70_encrypted.py
+++ b/src/tests/dbus-tests/test_70_encrypted.py
@@ -931,8 +931,9 @@ class UdisksEncryptedTestBITLK(udiskstestcase.UdisksTestCase):
         dbus_idusage.assertEqual('crypto')
         dbus_idtype = self.get_property(self.loop, '.Block', 'IdType')
         dbus_idtype.assertEqual('BitLocker')
-        dbus_uuid = self.get_property(self.loop, '.Block', 'IdUUID')
-        dbus_uuid.assertEqual('8f595209-f5b9-49a0-85d4-cb8f80258c27')
+        dbus_uuid = self.get_property_raw(self.loop, '.Block', 'IdUUID')
+        if dbus_uuid:
+            self.assertEqual(dbus_uuid, '8f595209-f5b9-49a0-85d4-cb8f80258c27')
 
         crypt_path = self.loop.Unlock(self.passphrase, self.no_options,
                                       dbus_interface=self.iface_prefix + '.Encrypted')
@@ -951,14 +952,21 @@ class UdisksEncryptedTestBITLK(udiskstestcase.UdisksTestCase):
         dbus_fs.assertEqual("ntfs")
 
         dbus_label = self.get_property_raw(self.loop, '.Block', 'IdLabel')
-        bitlk_path = self.get_property(crypt_dev, '.Block', 'PreferredDevice')
         if dbus_label:
             # has label (and we know it): label with '/' and spaces replaced by '_' should be used for DM name
             dm_path = '/dev/mapper/%s' % dbus_label.replace('/', '_').replace(' ', '_')
-        else:
-            # no label: bitlk-<UUID> should be used for DM name
+            self.assertTrue(os.path.exists(dm_path))
+        elif dbus_uuid:
+            # no label but UUID: bitlk-<UUID> should be used for DM name
             dm_path = '/dev/mapper/bitlk-8f595209-f5b9-49a0-85d4-cb8f80258c27'
             self.assertTrue(os.path.exists(dm_path))
+        else:
+            # fallback to bitlk-<device number>
+            dbus_number = self.get_property_raw(self.loop, '.Block', 'DeviceNumber')
+            dm_path = '/dev/mapper/bitlk-%s' % dbus_number
+            self.assertTrue(os.path.exists(dm_path))
+
+        bitlk_path = self.get_property(crypt_dev, '.Block', 'PreferredDevice')
         bitlk_path.assertEqual(self.str_to_ay(dm_path))
 
         self.loop.Lock(self.no_options, dbus_interface=self.iface_prefix + '.Encrypted')

--- a/src/udiskslinuxblock.c
+++ b/src/udiskslinuxblock.c
@@ -91,9 +91,6 @@ typedef struct _UDisksLinuxBlockClass   UDisksLinuxBlockClass;
 struct _UDisksLinuxBlock
 {
   UDisksBlockSkeleton parent_instance;
-
-  /* only allow single cryptsetup call at once */
-  GMutex encrypted_lock;
 };
 
 struct _UDisksLinuxBlockClass
@@ -108,32 +105,19 @@ G_DEFINE_TYPE_WITH_CODE (UDisksLinuxBlock, udisks_linux_block, UDISKS_TYPE_BLOCK
 
 /* ---------------------------------------------------------------------------------------------------- */
 
+/* global lock for all libcryptsetup calls (libcryptsetup/libdevmapper is not thread safe) */
+static GMutex encrypted_lock;
+
 static void
 udisks_linux_block_init (UDisksLinuxBlock *block)
 {
-  g_mutex_init (&(block->encrypted_lock));
   g_dbus_interface_skeleton_set_flags (G_DBUS_INTERFACE_SKELETON (block),
                                        G_DBUS_INTERFACE_SKELETON_FLAGS_HANDLE_METHOD_INVOCATIONS_IN_THREAD);
 }
 
 static void
-udisks_linux_block_finalize (GObject *object)
-{
-  UDisksLinuxBlock *block = UDISKS_LINUX_BLOCK (object);
-
-  g_mutex_clear (&(block->encrypted_lock));
-
-  if (G_OBJECT_CLASS (udisks_linux_block_parent_class)->finalize != NULL)
-    G_OBJECT_CLASS (udisks_linux_block_parent_class)->finalize (object);
-}
-
-static void
 udisks_linux_block_class_init (UDisksLinuxBlockClass *klass)
 {
-  GObjectClass *gobject_class;
-
-  gobject_class = G_OBJECT_CLASS (klass);
-  gobject_class->finalize = udisks_linux_block_finalize;
 }
 
 /**
@@ -2821,15 +2805,13 @@ udisks_linux_block_is_unknown_crypto (UDisksBlock *block)
 void
 udisks_linux_block_encrypted_lock (UDisksBlock *block)
 {
-  UDisksLinuxBlock *block_iface = UDISKS_LINUX_BLOCK (block);
-  g_mutex_lock (&block_iface->encrypted_lock);
+  g_mutex_lock (&encrypted_lock);
 }
 
 void
 udisks_linux_block_encrypted_unlock (UDisksBlock *block)
 {
-  UDisksLinuxBlock *block_iface = UDISKS_LINUX_BLOCK (block);
-  g_mutex_unlock (&block_iface->encrypted_lock);
+  g_mutex_unlock (&encrypted_lock);
 }
 
 /* ---------------------------------------------------------------------------------------------------- */

--- a/src/udiskslinuxblock.c
+++ b/src/udiskslinuxblock.c
@@ -1222,25 +1222,6 @@ udisks_linux_block_update (UDisksLinuxBlock       *block,
   g_free (s);
   s = udisks_decode_udev_string (g_udev_device_get_property (device->udev_device, "ID_FS_UUID_ENC"),
                                  g_udev_device_get_property (device->udev_device, "ID_FS_UUID"));
-  if ((!s || strlen (s) == 0) && udisks_linux_block_is_bitlk (iface))
-    {
-      BDCryptoBITLKInfo *bitlk_info;
-
-      /* Attempt to retrieve bitlk uuid from the on-disk header */
-      bitlk_info = bd_crypto_bitlk_info (device_file, &error);
-      if (bitlk_info)
-        {
-          g_free (s);
-          s = g_strdup (bitlk_info->uuid);
-          bd_crypto_bitlk_info_free (bitlk_info);
-        }
-      else
-        {
-          g_warning ("Crypto bitlk container detected on %s but failed to parse the header: %s",
-                     device_file, error->message);
-          g_clear_error (&error);
-        }
-    }
   udisks_block_set_id_uuid (iface, s);
   g_free (s);
 
@@ -1652,28 +1633,49 @@ has_whitespace (const gchar *s)
   return FALSE;
 }
 
-static gchar *
-make_block_luksname (UDisksBlock *block, GError **error)
+/**
+ * udisks_linux_block_make_dm_name:
+ * @block: A #UDisksBlock.
+ *
+ * Calculates the device-mapper name to use for a crypto device
+ * based on block label, UUID and type. Uses label if available,
+ * otherwise falls back to a type-prefixed UUID, or type-prefixed
+ * device number as a last resort.
+ *
+ * Returns: A newly allocated string with the dm name. Free with g_free().
+ */
+gchar *
+udisks_linux_block_make_dm_name (UDisksBlock *block)
 {
-  BDCryptoLUKSInfo *info = NULL;
-  gchar *ret = NULL;
+  const gchar *label;
+  const gchar *uuid;
+  const gchar *prefix;
 
-  udisks_linux_block_encrypted_lock (block);
-  info = bd_crypto_luks_info (udisks_block_get_device (block), error);
-  udisks_linux_block_encrypted_unlock (block);
-
-  if (info)
+  label = udisks_block_get_id_label (block);
+  if (label && g_strcmp0 (label, "") != 0)
     {
-      if (info->label && g_strcmp0 (info->label, "") != 0)
-        ret = g_strdup (info->label);
-      else
-        ret = g_strdup_printf ("luks-%s", info->uuid);
-      bd_crypto_luks_info_free (info);
+      gchar *safe_name;
 
-      return ret;
+      if (strlen (label) >= 128)
+        safe_name = g_strndup (label, 127);
+      else
+        safe_name = g_strdup (label);
+
+      return g_strdelimit (safe_name, "/ ", '_');
     }
+
+  if (udisks_linux_block_is_luks (block))
+    prefix = "luks";
+  else if (udisks_linux_block_is_bitlk (block))
+    prefix = "bitlk";
   else
-    return NULL;
+    prefix = "tcrypt";
+
+  uuid = udisks_block_get_id_uuid (block);
+  if (uuid && g_strcmp0 (uuid, "") != 0)
+    return g_strdup_printf ("%s-%s", prefix, uuid);
+
+  return g_strdup_printf ("%s-%" G_GUINT64_FORMAT, prefix, udisks_block_get_device_number (block));
 }
 
 static gboolean
@@ -3206,12 +3208,7 @@ format_create_luks (UDisksDaemon  *daemon,
 
   /* Open it */
   crypto_job_data.read_only = FALSE;
-  crypto_job_data.map_name = make_block_luksname (block, error);
-  if (!crypto_job_data.map_name)
-    {
-      g_prefix_error (error, "Failed to get LUKS UUID: ");
-      return FALSE;
-    }
+  crypto_job_data.map_name = udisks_linux_block_make_dm_name (block);
 
   udisks_linux_block_encrypted_lock (block);
   if (!udisks_daemon_launch_threaded_job_sync (daemon,

--- a/src/udiskslinuxblock.c
+++ b/src/udiskslinuxblock.c
@@ -91,6 +91,9 @@ typedef struct _UDisksLinuxBlockClass   UDisksLinuxBlockClass;
 struct _UDisksLinuxBlock
 {
   UDisksBlockSkeleton parent_instance;
+
+  /* per-device lock for cryptsetup info calls */
+  GMutex encrypted_lock;
 };
 
 struct _UDisksLinuxBlockClass
@@ -106,18 +109,34 @@ G_DEFINE_TYPE_WITH_CODE (UDisksLinuxBlock, udisks_linux_block, UDISKS_TYPE_BLOCK
 /* ---------------------------------------------------------------------------------------------------- */
 
 /* global lock for all libcryptsetup calls (libcryptsetup/libdevmapper is not thread safe) */
-static GMutex encrypted_lock;
+static GMutex global_encrypted_lock;
 
 static void
 udisks_linux_block_init (UDisksLinuxBlock *block)
 {
+  g_mutex_init (&(block->encrypted_lock));
   g_dbus_interface_skeleton_set_flags (G_DBUS_INTERFACE_SKELETON (block),
                                        G_DBUS_INTERFACE_SKELETON_FLAGS_HANDLE_METHOD_INVOCATIONS_IN_THREAD);
 }
 
 static void
+udisks_linux_block_finalize (GObject *object)
+{
+  UDisksLinuxBlock *block = UDISKS_LINUX_BLOCK (object);
+
+  g_mutex_clear (&(block->encrypted_lock));
+
+  if (G_OBJECT_CLASS (udisks_linux_block_parent_class)->finalize != NULL)
+    G_OBJECT_CLASS (udisks_linux_block_parent_class)->finalize (object);
+}
+
+static void
 udisks_linux_block_class_init (UDisksLinuxBlockClass *klass)
 {
+  GObjectClass *gobject_class;
+
+  gobject_class = G_OBJECT_CLASS (klass);
+  gobject_class->finalize = udisks_linux_block_finalize;
 }
 
 /**
@@ -2804,16 +2823,67 @@ udisks_linux_block_is_unknown_crypto (UDisksBlock *block)
 
 /* ---------------------------------------------------------------------------------------------------- */
 
+/**
+ * udisks_linux_block_encrypted_lock:
+ * @block: A #UDisksBlock.
+ *
+ * Acquires both the global cryptsetup lock and the per-device lock.
+ * Use this for active operations (unlock, lock, resize, format, etc.)
+ * that modify device state.
+ *
+ * Must be paired with udisks_linux_block_encrypted_unlock().
+ */
 void
 udisks_linux_block_encrypted_lock (UDisksBlock *block)
 {
-  g_mutex_lock (&encrypted_lock);
+  UDisksLinuxBlock *block_iface = UDISKS_LINUX_BLOCK (block);
+  g_mutex_lock (&global_encrypted_lock);
+  g_mutex_lock (&block_iface->encrypted_lock);
 }
 
+/**
+ * udisks_linux_block_encrypted_unlock:
+ * @block: A #UDisksBlock.
+ *
+ * Releases both the per-device lock and the global cryptsetup lock.
+ * Must be paired with udisks_linux_block_encrypted_lock().
+ */
 void
 udisks_linux_block_encrypted_unlock (UDisksBlock *block)
 {
-  g_mutex_unlock (&encrypted_lock);
+  UDisksLinuxBlock *block_iface = UDISKS_LINUX_BLOCK (block);
+  g_mutex_unlock (&block_iface->encrypted_lock);
+  g_mutex_unlock (&global_encrypted_lock);
+}
+
+/**
+ * udisks_linux_block_encrypted_info_lock:
+ * @block: A #UDisksBlock.
+ *
+ * Acquires only the per-device lock. Use this for info operations
+ * that read device metadata without modifying state.
+ *
+ * Must be paired with udisks_linux_block_encrypted_info_unlock().
+ */
+void
+udisks_linux_block_encrypted_info_lock (UDisksBlock *block)
+{
+  UDisksLinuxBlock *block_iface = UDISKS_LINUX_BLOCK (block);
+  g_mutex_lock (&block_iface->encrypted_lock);
+}
+
+/**
+ * udisks_linux_block_encrypted_info_unlock:
+ * @block: A #UDisksBlock.
+ *
+ * Releases the per-device lock.
+ * Must be paired with udisks_linux_block_encrypted_info_lock().
+ */
+void
+udisks_linux_block_encrypted_info_unlock (UDisksBlock *block)
+{
+  UDisksLinuxBlock *block_iface = UDISKS_LINUX_BLOCK (block);
+  g_mutex_unlock (&block_iface->encrypted_lock);
 }
 
 /* ---------------------------------------------------------------------------------------------------- */

--- a/src/udiskslinuxblock.h
+++ b/src/udiskslinuxblock.h
@@ -66,6 +66,8 @@ gboolean     udisks_linux_block_is_unknown_crypto (UDisksBlock *block);
 void         udisks_linux_block_encrypted_lock (UDisksBlock *block);
 void         udisks_linux_block_encrypted_unlock (UDisksBlock *block);
 
+gchar       *udisks_linux_block_make_dm_name (UDisksBlock *block);
+
 G_END_DECLS
 
 #endif /* __UDISKS_LINUX_BLOCK_H__ */

--- a/src/udiskslinuxblock.h
+++ b/src/udiskslinuxblock.h
@@ -65,6 +65,8 @@ gboolean     udisks_linux_block_is_unknown_crypto (UDisksBlock *block);
 
 void         udisks_linux_block_encrypted_lock (UDisksBlock *block);
 void         udisks_linux_block_encrypted_unlock (UDisksBlock *block);
+void         udisks_linux_block_encrypted_info_lock (UDisksBlock *block);
+void         udisks_linux_block_encrypted_info_unlock (UDisksBlock *block);
 
 gchar       *udisks_linux_block_make_dm_name (UDisksBlock *block);
 

--- a/src/udiskslinuxencrypted.c
+++ b/src/udiskslinuxencrypted.c
@@ -223,7 +223,7 @@ udisks_linux_encrypted_update (UDisksLinuxEncrypted   *encrypted,
 {
   UDisksBlock *block = udisks_object_peek_block (UDISKS_OBJECT (object));
 
-  udisks_linux_block_encrypted_lock (block);
+  udisks_linux_block_encrypted_info_lock (block);
 
   update_child_configuration (encrypted, object);
   update_cleartext_device (encrypted, object);
@@ -238,7 +238,7 @@ udisks_linux_encrypted_update (UDisksLinuxEncrypted   *encrypted,
   if (udisks_linux_block_is_luks (block))
     update_metadata_size (encrypted, object);
 
-  udisks_linux_block_encrypted_unlock (block);
+  udisks_linux_block_encrypted_info_unlock (block);
 
   g_dbus_interface_skeleton_flush (G_DBUS_INTERFACE_SKELETON (encrypted));
 }

--- a/src/udiskslinuxencrypted.c
+++ b/src/udiskslinuxencrypted.c
@@ -324,16 +324,6 @@ has_option (const gchar *options,
   return ret;
 }
 
-static gchar *
-label_to_safe_dm_name (const gchar *label)
-{
-  if (strlen (label) >= 128)
-    return g_strdelimit (g_strndup (label, 127), "/ ", '_');
-  return g_strdelimit (g_strdup (label), "/ ", '_');
-}
-
-/* ---------------------------------------------------------------------------------------------------- */
-
 /* runs in thread dedicated to handling @invocation */
 static gboolean
 handle_unlock (UDisksEncrypted        *encrypted,
@@ -373,8 +363,6 @@ handle_unlock (UDisksEncrypted        *encrypted,
   gboolean is_bitlk;
   gboolean handle_as_tcrypt;
   void *open_func;
-  const gchar *uuid = NULL;
-  const gchar *label = NULL;
 
   object = udisks_daemon_util_dup_object (encrypted, &error);
   if (object == NULL)
@@ -533,28 +521,8 @@ handle_unlock (UDisksEncrypted        *encrypted,
   /* calculate the name to use */
   if (is_in_crypttab && crypttab_name != NULL)
     name = g_strdup (crypttab_name);
-  else {
-    label = udisks_block_get_id_label (block);
-    if (label)
-      name = label_to_safe_dm_name (label);
-    else
-      {
-        if (is_luks)
-          name = g_strdup_printf ("luks-%s", udisks_block_get_id_uuid (block));
-        else if (is_bitlk)
-          {
-            uuid = udisks_block_get_id_uuid (block);
-            if (uuid && g_strcmp0 (uuid, "") != 0)
-              name = g_strdup_printf ("bitlk-%s", uuid);
-            else
-              name = g_strdup_printf ("bitlk-%" G_GUINT64_FORMAT, udisks_block_get_device_number (block));
-          }
-        else
-          /* TCRYPT devices don't have a UUID, so we use the device number instead */
-          name = g_strdup_printf ("tcrypt-%" G_GUINT64_FORMAT, udisks_block_get_device_number (block));
-      }
-
-  }
+  else
+    name = udisks_linux_block_make_dm_name (block);
 
   /* save old encryption type to be able to restore it */
   old_hint_encryption_type = udisks_encrypted_dup_hint_encryption_type (encrypted);


### PR DESCRIPTION
8 years ago we added per-device locks to protect single device access from multiple threads, but libcryptsetup (libdevmapper mostly) is not thread safe at all, so that's not good enough.

Fixes: #1489