### PR TITLE
Change KillSignal from SIGINT to SIGTERM in udisks2.service.in

### DIFF
--- a/data/udisks2.service.in
+++ b/data/udisks2.service.in
@@ -6,7 +6,7 @@ Documentation=man:udisks(8)
 Type=dbus
 BusName=org.freedesktop.UDisks2
 ExecStart=@udisksdprivdir@/udisksd
-KillSignal=SIGINT
+KillSignal=SIGTERM
 
 [Install]
 WantedBy=graphical.target


### PR DESCRIPTION
## Summary

When the udisks2 service was stopped using systemctl stop, the process generated a core dump.

After analyzing the core dump, I confirmed that exit_handler had completed normally. However, an abort was triggered afterward, causing the process to terminate abnormally.

To address this, the service file was updated to change the stop signal from SIGINT to SIGTERM. After applying this change and reproducing the stop operation, the service no longer terminated abnormally.