### PR TITLE
fix: exclude uhelper=udisks2 for erofs to allow mounting

### DIFF
--- a/src/udiskslinuxmountoptions.c
+++ b/src/udiskslinuxmountoptions.c
@@ -1156,7 +1156,10 @@ calculate_mount_options_for_fs_type (UDisksDaemon  *daemon,
                                                   shared_fs);
 
   /* validate mount options */
-  str = g_string_new ("uhelper=udisks2,nodev,nosuid");
+  if (g_strcmp0 (fs_type, "erofs") == 0)
+    str = g_string_new ("nodev,nosuid");
+  else
+    str = g_string_new ("uhelper=udisks2,nodev,nosuid");
   g_variant_iter_init (&iter, options_to_use);
   while (g_variant_iter_next (&iter, "{&s&s}", &key, &value))
     {


### PR DESCRIPTION
When attempting to mount an EROFS filesystem via udisksctl, the operation fails because udisks2 automatically appends the uhelper=udisks2 mount option. The Linux kernel EROFS driver is strict regarding mount parameters and rejects this unknown option, resulting in a mount failure. This commit adds a check to omit the uhelper parameter for EROFS.