### PR TITLE
linux-drive: handle empty vendor/model/serial when building object pa…

### DIFF
--- a/src/udiskslinuxdriveobject.c
+++ b/src/udiskslinuxdriveobject.c
@@ -258,8 +258,11 @@ udisks_linux_drive_object_constructed (GObject *_object)
   strip_and_replace_with_uscore (model);
   strip_and_replace_with_uscore (serial);
   str = g_string_new ("/org/freedesktop/UDisks2/drives/");
-  if (vendor == NULL && model == NULL && serial == NULL)
+  if ((vendor == NULL || strlen(vendor) == 0) &&
+      (model == NULL || strlen(model) == 0) &&
+      (serial == NULL || strlen(serial) == 0))
     {
+      g_warning("Drive has no vendor/model/serial.");
       g_string_append (str, "drive");
     }
   else

--- a/src/udiskslinuxdriveobject.c
+++ b/src/udiskslinuxdriveobject.c
@@ -258,8 +258,11 @@ udisks_linux_drive_object_constructed (GObject *_object)
   strip_and_replace_with_uscore (model);
   strip_and_replace_with_uscore (serial);
   str = g_string_new ("/org/freedesktop/UDisks2/drives/");
-  if (vendor == NULL && model == NULL && serial == NULL)
+  if ((vendor == NULL || strlen (vendor) == 0) &&
+      (model == NULL || strlen (model) == 0) &&
+      (serial == NULL || strlen (serial) == 0))
     {
+      g_warning ("Drive has no vendor/model/serial.");
       g_string_append (str, "drive");
     }
   else


### PR DESCRIPTION
linux-drive: handle empty vendor/model/serial when building object path, Some NVMe devices expose empty Vendor/Model/Serial strings instead of NULL
fix:https://github.com/storaged-project/udisks/issues/1507