### PR TITLE
daemon: fix leak LUKS keys and passes in -O2/-O3 opt flag

### DIFF
--- a/src/udisksdaemonutil.c
+++ b/src/udisksdaemonutil.c
@@ -24,6 +24,7 @@
 #include <gio/gunixfdlist.h>
 
 #include <stdio.h>
+#include <string.h>
 
 #include <sys/types.h>
 #include <sys/stat.h>
@@ -132,7 +133,8 @@ void udisks_string_wipe_and_free (GString *string)
 {
   if (string != NULL)
     {
-      memset (string->str, '\0', string->len);
+      if (string->str != NULL && string->allocated_len > 0)
+        explicit_bzero (string->str, string->allocated_len);
       g_string_free (string, TRUE);
     }
 }


### PR DESCRIPTION
Standard call memset(string->str, '\0', string->len) before g_string_free() could be removed by compiler optimizer (dead store elimination), leaving LUKS passwords and keys in RAM. Special explicit_bzero function ensures safe buffer clearing and cannot be removed by C/C++ compiler.

Zeroing is now performed for the entire string->allocated_len buffer (not just string->len), which guarantees the removal of any residual data fragments in the allocated memory.

Documentation about function:
- https://manpages.debian.org/testing/manpages-dev/explicit_bzero.3.en.html