### PR TITLE
misc: Remove python3-monotonic from test requirements

### DIFF
--- a/misc/udisks-tasks.yml
+++ b/misc/udisks-tasks.yml
@@ -48,7 +48,6 @@
       - nilfs-utils
       - udftools
       - python3-systemd
-      - python3-monotonic
       - python3-packaging
       - cryptsetup
       - vdo


### PR DESCRIPTION
Monotonic is part of the standard library since Python 3.3.