### PR TITLE
tests: Cleanup PV signature in UdisksLVMTest.test_60_pvs

### DIFF
--- a/src/tests/dbus-tests/test_20_LVM.py
+++ b/src/tests/dbus-tests/test_20_LVM.py
@@ -576,6 +576,9 @@ class UdisksLVMTest(UDisksLVMTestBase):
         _ret, out = self.run_command('pvs --noheadings -o vg_name %s' % self.vdevs[0])
         self.assertEqual(out, '')
 
+        # the device is no longer part of the VG so normal cleanup won't remove the PV signature
+        _ret, _out = self.run_command('pvremove %s' % self.vdevs[0])
+
     def test_devices_file(self):
         '''Test that we correctly handle the LVM devices file'''
 


### PR DESCRIPTION
Normally all devices are wiped when removing the VG but in this case we are testing removing PV from a VG so the PV is no longer in a VG at the end of the test and is not wiped and the PV signature left on the device is sometimes causing issues in later tests.